### PR TITLE
Fix item creation: persist ToastUI editor description for new items

### DIFF
--- a/templates/item_form.html
+++ b/templates/item_form.html
@@ -624,6 +624,14 @@ function syncEditorContent() {
     {% endif %}
 }
 
+// Keep hidden form fields in sync while typing so HTMX always picks up latest editor values
+descriptionEditor.on('change', syncEditorContent);
+userInputEditor.on('change', syncEditorContent);
+solutionEditor.on('change', syncEditorContent);
+
+// Ensure hidden fields are initialized with the editors' initial state
+syncEditorContent();
+
 // Sync editor content to hidden fields on form submit (for non-HTMX submissions)
 document.getElementById('itemForm').addEventListener('submit', function(event) {
     syncEditorContent();


### PR DESCRIPTION
### Motivation
- New items created via the ToastUI editors could lose the `description` because HTMX sometimes collects form parameters before the hidden inputs were updated from the editors, so the description was not persisted on `/items/new/`.

### Description
- Continuously synchronize the ToastUI editors (`description`, `user_input`, `solution_description`) into their hidden form fields on every editor `change` event and initialize the hidden fields on page load so HTMX requests always include the current editor values (`templates/item_form.html`).

### Testing
- Ran `python manage.py test core.test_item_detail.ItemCRUDTest.test_item_create_post`, which could not complete in this environment because PostgreSQL on `localhost:5432` is not reachable (test environment failure).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f2bd2b3908327a700038eae432b2f)