### PR TITLE
Include attachments in extended RAG layer-B selection

### DIFF
--- a/core/services/rag/extended_service.py
+++ b/core/services/rag/extended_service.py
@@ -525,7 +525,7 @@ class ExtendedRAGPipelineService:
         Separate results into A/B/C layers.
         
         Layer A: Thread/Task-related (2-3 snippets) - comments, related items
-        Layer B: Item context (2-3 snippets) - same item or closely related
+        Layer B: Item context (2-3 snippets) - items and attachments
         Layer C: Global background (1-2 snippets) - general context
         
         Args:
@@ -565,8 +565,8 @@ class ExtendedRAGPipelineService:
             # Layer A: Comments and closely related items (high relevance)
             if obj_type == 'comment' and len(layer_a) < 3:
                 layer_a.append(item)
-            # Layer B: Same item or item-level context
-            elif (obj_type == 'item' or (item_id and obj_id == item_id)) and len(layer_b) < 3:
+            # Layer B: Item-level context (items + attachments)
+            elif (obj_type in {'item', 'attachment'} or (item_id and obj_id == item_id)) and len(layer_b) < 3:
                 layer_b.append(item)
             # Layer C: Global background
             elif len(layer_c) < 2:

--- a/core/services/rag/test_extended_rag.py
+++ b/core/services/rag/test_extended_rag.py
@@ -282,6 +282,7 @@ class LayerSeparationTestCase(TestCase):
         results = [
             {'object_id': '1', 'object_type': 'comment', 'content': 'Comment 1', 'title': 'C1', 'score': 0.9},
             {'object_id': '2', 'object_type': 'item', 'content': 'Item 1', 'title': 'I1', 'score': 0.8},
+            {'object_id': '5', 'object_type': 'attachment', 'content': 'Attachment 1', 'title': 'A1', 'score': 0.75},
             {'object_id': '3', 'object_type': 'project', 'content': 'Project 1', 'title': 'P1', 'score': 0.7},
             {'object_id': '4', 'object_type': 'comment', 'content': 'Comment 2', 'title': 'C2', 'score': 0.6},
         ]
@@ -293,10 +294,12 @@ class LayerSeparationTestCase(TestCase):
         for item in layer_a:
             self.assertEqual(item.object_type, 'comment')
         
-        # Layer B should have items (up to 3)
+        # Layer B should have item-level context (items + attachments) (up to 3)
         self.assertLessEqual(len(layer_b), 3)
         for item in layer_b:
-            self.assertEqual(item.object_type, 'item')
+            self.assertIn(item.object_type, {'item', 'attachment'})
+
+        self.assertTrue(any(item.object_type == 'attachment' for item in layer_b))
         
         # Layer C should have global context (up to 2)
         self.assertLessEqual(len(layer_c), 2)


### PR DESCRIPTION
### Motivation

- Attachments often contain documentation and should be treated as item-level context so they are surfaced with items rather than falling into global background.

### Description

- Update layer-separation logic in `core/services/rag/extended_service.py` to treat `attachment` results as item-level context (Layer B) by checking `obj_type in {'item', 'attachment'}` when assigning to Layer B.
- Extend tests in `core/services/rag/test_extended_rag.py` to include an `attachment` sample and assert that Layer B accepts both `item` and `attachment` and includes at least one attachment.

### Testing

- Ran `python -m compileall core/services/rag/extended_service.py core/services/rag/test_extended_rag.py`, which completed successfully.
- Attempted `python -m pytest core/services/rag/test_extended_rag.py -q`, but collection failed because Django settings are not configured in this environment (test run aborted).
- Attempted `python manage.py test core.services.rag.test_extended_rag.LayerSeparationTestCase`, but the run failed due to inability to connect to the local PostgreSQL instance (connection refused), so full Django test execution could not be completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f30d12694832784ed0bc31e1cf767)