### PR TITLE
Fix DetailView status apply 400 by hardening status change payload handling

### DIFF
--- a/templates/item_detail.html
+++ b/templates/item_detail.html
@@ -1376,13 +1376,16 @@
         // Get CSRF token
         const csrfToken = document.querySelector('[name=csrfmiddlewaretoken]').value;
         
+        const formData = new FormData();
+        formData.append('status', newStatus);
+
         fetch('{% url 'item-change-status' item.id %}', {
             method: 'POST',
             headers: {
-                'Content-Type': 'application/x-www-form-urlencoded',
-                'X-CSRFToken': csrfToken
+                'X-CSRFToken': csrfToken,
+                'X-Requested-With': 'XMLHttpRequest'
             },
-            body: 'status=' + encodeURIComponent(newStatus)
+            body: formData
         })
         .then(response => {
             // Check if response is ok


### PR DESCRIPTION
### Motivation

- The DetailView "Apply" status flow could return HTTP 400 because the backend expected a `status` field in a specific form encoding while some callers sent different payload shapes, causing a backend/frontend mismatch.

### Description

- Make `item_change_status` explicitly POST-only and authenticated by applying `@require_POST` and `@login_required` to the view.
- Harden status extraction in `core/views.py` to accept `status` or `new_status` from `request.POST` and fall back to parsing a JSON body (`status`/`new_status`) when present.
- Update the DetailView frontend in `templates/item_detail.html` to send the status as `FormData` and include the `X-Requested-With` header, aligning it with the Kanban flow and avoiding content-type parsing edge cases.
- Clean up duplicate decorator occurrences and ensure the endpoint remains HTMX-friendly by returning JSON for mail-preview flows and HTML for normal badge swaps.

### Testing

- Ran `python manage.py check` which succeeded with no system-check issues.
- Ran `python -m compileall core/views.py templates/item_detail.html` which completed successfully.
- Attempted the relevant unit test `core.test_item_detail.ItemDetailViewTest.test_item_change_status`, but it failed to run in this environment due to PostgreSQL being unreachable (`connection refused` on localhost:5432), so the full test-suite could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f3486ccf083279a5f79ca9bcd2401)