### PR TITLE
Remove inline `hx-vals` JS eval to fix HTMX syntax error on item save

### DIFF
--- a/templates/item_form.html
+++ b/templates/item_form.html
@@ -134,7 +134,6 @@
     <div class="detail-main">
         <form id="itemForm" 
               hx-post="{% if item %}{% url 'item-update' item.id %}{% else %}{% url 'item-create' %}{% endif %}"
-              hx-vals='js:getEditorPayload()'
               hx-swap="none"
               hx-on::after-request="handleFormResponse(event)">
             {% csrf_token %}
@@ -640,16 +639,6 @@ function syncEditorContentToHtmxRequest(event) {
         event.detail.parameters.solution_description = solutionEditor.getMarkdown();
     }
 }
-
-
-function getEditorPayload() {
-    return {
-        description: descriptionEditor.getMarkdown(),
-        user_input: userInputEditor.getMarkdown(),
-        solution_description: solutionEditor.getMarkdown(),
-    };
-}
-
 
 
 document.getElementById('itemForm').addEventListener('htmx:beforeRequest', syncEditorContentToHtmxRequest);


### PR DESCRIPTION
### Motivation
- Submitting the item edit/create form triggered an HTMX runtime JS evaluation that caused `Uncaught SyntaxError: Unexpected token '}'`; the inline `hx-vals='js:getEditorPayload()'` expression is the likely culprit and must be removed while preserving editor payload sync.

### Description
- Removed the inline `hx-vals='js:getEditorPayload()'` attribute from the item form in `templates/item_form.html` to avoid HTMX evaluating an inline JS expression at submit. 
- Deleted the now-unused `getEditorPayload()` helper from `templates/item_form.html`. 
- Retained the existing synchronization via `htmx:beforeRequest` / `htmx:configRequest` (`syncEditorContentToHtmxRequest`) so editor markdown fields remain included in requests.

### Testing
- Ran `python manage.py test core.test_item_detail.ItemCRUDTest.test_item_update_post`, which could not complete in this environment because PostgreSQL on `localhost:5432` is not available and the test runner raised a DB connection error. 
- Attempted `python manage.py test core.test_item_detail.ItemViewsTestCase.test_item_update_post`, which failed immediately because the `ItemViewsTestCase` test class does not exist in this codebase.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f984cef7c83278f3b53119f739598)