### PR TITLE
Potential fix for code scanning alert no. 2: DOM text reinterpreted as HTML

### DIFF
--- a/static/js/sidebar-recents.js
+++ b/static/js/sidebar-recents.js
@@ -21,6 +21,23 @@
     let pinned = [];
 
     /**
+     * Safely escape text for insertion into HTML.
+     * This prevents HTML meta-characters from being interpreted as markup.
+     */
+    function escapeHtml(str) {
+        if (str === null || str === undefined) {
+            return '';
+        }
+        return String(str)
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#39;')
+            .replace(/\//g, '&#x2F;');
+    }
+
+    /**
      * Initialize the module
      */
     function init() {
@@ -254,7 +271,7 @@
                 <div class="recents-entry-content">
                     <div class="recents-entry-header">
                         <i class="bi ${typeIcon} me-1"></i>
-                        <span class="recents-entry-title">${entry.title}</span>
+                        <span class="recents-entry-title">${escapeHtml(entry.title)}</span>
                     </div>
                     <div class="recents-entry-meta">
                         <span class="recents-entry-type">${typeLabel}</span>


### PR DESCRIPTION
Potential fix for [https://github.com/gdsanger/Agira/security/code-scanning/2](https://github.com/gdsanger/Agira/security/code-scanning/2)

In general, the problem is that the code builds HTML strings via template literals and string concatenation, then assigns them to `innerHTML`. Any unescaped, attacker-controlled text interpolated into these strings can become executable HTML/JS. To fix this without changing visible functionality, we should ensure that any dynamic text fields (such as `entry.title`, and analogous text labels) are HTML-escaped before being inserted into the template. This can be done by adding a small helper function that converts `<`, `>`, `&`, `"`, `'`, and `/` into their HTML entities, and then using this helper whenever these values are interpolated. We should keep using `innerHTML` because the templates also contain safe markup/HTMX attributes, but we must ensure only escaped text reaches it.

Concretely in `static/js/sidebar-recents.js`:

1. Add a small `escapeHtml` helper near the top of the module (after configuration/state or before rendering helpers). It will take a string and return the escaped version by replacing HTML meta-characters.
2. In `renderEntry`, wrap `entry.title` in this helper before interpolation: `escapeHtml(entry.title)`. If there are other clearly user-facing text fields that may come from untrusted sources (like `typeLabel` or a plain-status text), we should also escape them if they are currently inserted as raw text. From the snippet, `typeLabel` is likely internal/derived, but it's safe to leave as-is if it only ever contains controlled values.
3. Keep `statusHtml`, `pinButton`, `removeButton` as they are if they are known-safe markup generated by this script, not user input. They may purposely contain HTML (icons, buttons).
4. No changes are needed in the event-handling section where `.textContent` is read; that usage is safe. The key is to prevent any persisted/rehydrated data from being injected unescaped back into `innerHTML`.

This approach keeps the same functionality and layout while ensuring that any dangerous characters in untrusted text are rendered visibly rather than interpreted as markup.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
