### PR TITLE
Potential fix for code scanning alert no. 3: Incomplete URL substring sanitization

### DIFF
--- a/core/test_azuread_authentication.py
+++ b/core/test_azuread_authentication.py
@@ -9,6 +9,7 @@ from core.models import User
 from core.backends.azuread import AzureADAuth, AzureADAuthError
 import jwt
 import time
+from urllib.parse import urlparse
 
 
 @override_settings(
@@ -73,7 +74,9 @@ class AzureADAuthenticationTestCase(TestCase):
         
         # Should redirect to Azure AD
         self.assertEqual(response.status_code, 302)
-        self.assertTrue(response.url.startswith('https://login.microsoftonline.com'))
+        parsed_url = urlparse(response.url)
+        self.assertEqual(parsed_url.scheme, 'https')
+        self.assertEqual(parsed_url.netloc, 'login.microsoftonline.com')
         
         # Flow should be stored in session
         self.assertIn('azure_ad_flow', self.client.session)


### PR DESCRIPTION
Potential fix for [https://github.com/gdsanger/Agira/security/code-scanning/3](https://github.com/gdsanger/Agira/security/code-scanning/3)

In general, instead of checking a URL using string operations like `startswith` or `in`, parse the URL and validate its components (scheme, hostname, path, etc.) using a URL parser. For host validation, extract the hostname and compare it directly or with a controlled suffix check (e.g., `host == "login.microsoftonline.com"`), rather than matching substrings in the full URL.

For this specific test, we should stop using `response.url.startswith('https://login.microsoftonline.com')` and instead parse `response.url` with `urllib.parse.urlparse`, then assert that the `scheme` is `https` and the `netloc` (host) is `login.microsoftonline.com`. This preserves the intent of the test—confirming a redirect to Azure AD—without relying on brittle substring logic. To implement this, we need to (a) import `urlparse` from `urllib.parse` at the top of the file, and (b) change the assertion in `test_azuread_login_redirects_to_azure` to parse and inspect the URL’s components.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
