### PR TITLE
Potential fix for code scanning alert no. 159: Information exposure through an exception

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -10665,4 +10665,10 @@ def item_apply_blueprint_submit(request, item_id):
         
     except Exception as e:
         logger.error(f"Error applying blueprint to issue: {e}", exc_info=True)
-        return JsonResponse({'success': False, 'error': str(e)}, status=500)
+        return JsonResponse(
+            {
+                'success': False,
+                'error': 'An internal error occurred while applying the blueprint.'
+            },
+            status=500
+        )


### PR DESCRIPTION
Potential fix for [https://github.com/gdsanger/Agira/security/code-scanning/159](https://github.com/gdsanger/Agira/security/code-scanning/159)

To fix the issue, we should stop returning the raw exception message (`str(e)`) to the client and instead return a generic, user-safe error message while still logging full details on the server. This aligns with the recommended pattern of logging the stack trace server-side and exposing only minimal information to the user.

Concretely, in `core/views.py` within the `item_apply_blueprint_submit` view, only the `JsonResponse` inside the `except Exception as e:` block needs changing. We should keep the existing `logger.error(..., exc_info=True)` call so developers still have stack traces in the logs. Then we replace `str(e)` in the JSON body with a generic message like `"An internal error occurred while applying the blueprint."` or similar, which does not reveal implementation details.

No new methods or imports are required, because logging is already configured and `JsonResponse` is already imported. The only change is to the JSON payload in that `except` block at lines 10666–10668.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
