### PR TITLE
Potential fix for code scanning alert no. 157: Information exposure through an exception

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -10496,7 +10496,13 @@ def item_create_blueprint_submit(request, item_id):
         
     except Exception as e:
         logger.error(f"Error creating blueprint from issue: {e}", exc_info=True)
-        return JsonResponse({'success': False, 'error': str(e)}, status=500)
+        return JsonResponse(
+            {
+                'success': False,
+                'error': 'An unexpected error occurred while creating the blueprint.'
+            },
+            status=500
+        )
 
 
 @login_required


### PR DESCRIPTION
Potential fix for [https://github.com/gdsanger/Agira/security/code-scanning/157](https://github.com/gdsanger/Agira/security/code-scanning/157)

In general, to fix this kind of issue, you should avoid returning raw exception messages or stack traces to the client. Instead, log the detailed error server‑side and send back a generic, user‑friendly message, optionally with a stable error code so you can correlate client reports with server logs.

For this specific function `item_create_blueprint_submit` in `core/views.py`, the best minimal fix is to keep the existing logging call (which already logs the full exception and stack trace with `exc_info=True`) and change the JSON response to use a generic error message that does not include `str(e)`. That preserves existing behavior (client still receives a clear indication of failure and 500 status; server still has full diagnostic information) while eliminating the exposure of internal exception details. No new imports or helper methods are required; we only need to modify the `JsonResponse` in the `except` block at line 10499.

Concretely:
- Leave `logger.error(f"Error creating blueprint from issue: {e}", exc_info=True)` as is, so developers still have detailed logs.
- Replace `return JsonResponse({'success': False, 'error': str(e)}, status=500)` with something like `return JsonResponse({'success': False, 'error': 'An unexpected error occurred while creating the blueprint.'}, status=500)` (or similar generic wording).
- No other parts of the file need to change for this fix.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
