### PR TITLE
Potential fix for code scanning alert no. 156: Information exposure through an exception

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -10401,7 +10401,13 @@ def blueprint_create_issue(request, id):
         
     except Exception as e:
         logger.error(f"Error creating issue from blueprint: {e}", exc_info=True)
-        return JsonResponse({'success': False, 'error': str(e)}, status=500)
+        return JsonResponse(
+            {
+                'success': False,
+                'error': 'An internal error occurred while creating the issue from the blueprint.'
+            },
+            status=500
+        )
 
 
 @login_required


### PR DESCRIPTION
Potential fix for [https://github.com/gdsanger/Agira/security/code-scanning/156](https://github.com/gdsanger/Agira/security/code-scanning/156)

In general, to fix this category of issue, we should avoid sending raw exception messages or stack traces back to the client. Instead, log the detailed error on the server and return a generic, user-friendly message. If you want to distinguish between expected user errors and unexpected internal errors, handle known, safe exception types separately and only for those return specific messages; for all other exceptions, use a generic message.

For this specific code in `core/views.py`, the best minimal change is:
- Keep the existing logging call with `exc_info=True` (so developers still get the full stack trace in logs).
- Replace the use of `str(e)` in the JSON response with a generic message that reveals no internal details.

Concretely, edit the `except Exception as e:` block in `blueprint_create_issue` so that:

- The `logger.error(...)` line remains unchanged.
- The `JsonResponse` no longer includes `str(e)`, but instead something like `"An internal error occurred while creating the issue from the blueprint."` (or similarly generic wording).

No new imports or helper methods are needed; this is a simple change within the existing function.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
