### PR TITLE
Potential fix for code scanning alert no. 153: Information exposure through an exception

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -10279,7 +10279,13 @@ def blueprint_export(request, id):
         
     except BlueprintSerializationError as e:
         logger.error(f"Error exporting blueprint: {e}", exc_info=True)
-        return JsonResponse({'success': False, 'error': str(e)}, status=400)
+        return JsonResponse(
+            {
+                'success': False,
+                'error': 'Failed to export blueprint due to a validation or formatting error.'
+            },
+            status=400
+        )
     except Exception as e:
         logger.error(f"Unexpected error exporting blueprint: {e}", exc_info=True)
         return JsonResponse({'success': False, 'error': 'An unexpected error occurred'}, status=500)


### PR DESCRIPTION
Potential fix for [https://github.com/gdsanger/Agira/security/code-scanning/153](https://github.com/gdsanger/Agira/security/code-scanning/153)

Generally, to fix information exposure via exceptions, you should avoid sending raw exception objects or their string representations (`str(e)` or `repr(e)`) back to the client. Instead, log the full exception (including stack trace) on the server and return a sanitized, generic message to the user—optionally with a stable error code if the client needs to distinguish cases.

For this specific case in `core/views.py`, in the `blueprint_export` view:

- Keep the logging line `logger.error(f"Error exporting blueprint: {e}", exc_info=True)` as-is so developers retain full diagnostic information.
- Change the `JsonResponse` returned in the `except BlueprintSerializationError as e:` block so it no longer includes `str(e)` and instead returns a generic but still user-meaningful message such as `"Failed to export blueprint. Please check that the blueprint is valid."` or similar.
- The rest of the function, including the 400 status code, remains unchanged to preserve existing behaviour as much as possible (client still sees an error with HTTP 400, but without sensitive internal details).

No new imports or helpers are required; we only need to modify the JSON payload in that one `JsonResponse` call.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
