### PR TITLE
Potential fix for code scanning alert no. 155: Information exposure through an exception

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -10355,7 +10355,13 @@ def blueprint_import(request):
         return JsonResponse({'success': False, 'error': str(e)}, status=400)
     except Exception as e:
         logger.error(f"Unexpected error importing blueprint: {e}", exc_info=True)
-        return JsonResponse({'success': False, 'error': f'An unexpected error occurred: {str(e)}'}, status=500)
+        return JsonResponse(
+            {
+                'success': False,
+                'error': 'An unexpected error occurred while importing the blueprint. Please try again later.'
+            },
+            status=500
+        )
 
 
 @login_required


### PR DESCRIPTION
Potential fix for [https://github.com/gdsanger/Agira/security/code-scanning/155](https://github.com/gdsanger/Agira/security/code-scanning/155)

In general, to fix this type of problem you should avoid including raw exception messages or stack traces in responses sent to clients. Instead, log full details (including stack trace) on the server and respond with a generic, user-friendly message that does not reveal internal information.

For this specific function `blueprint_import` in `core/views.py`, the best fix with minimal behavior change is:
- Keep the existing logging in the broad `except Exception as e:` block, so developers still see the full error and stack trace.
- Change the JSON response in that block so it does not interpolate `str(e)` into the error message. Return a generic error such as `"An unexpected error occurred while importing the blueprint."` without including the exception text.
- Do not alter the behavior of the specific `BlueprintDeserializationError` handler, which is already returning a controlled validation message and not a stack trace.

Concretely:
- In `core/views.py`, around lines 10356–10358, modify the `JsonResponse` returned in the generic exception handler to remove `str(e)` from the message and use a fixed string instead. No new imports or helper methods are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
