### PR TITLE
Potential fix for code scanning alert no. 154: Information exposure through an exception

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -10352,10 +10352,16 @@ def blueprint_import(request):
         
     except BlueprintDeserializationError as e:
         logger.warning(f"Blueprint import validation error: {e}")
-        return JsonResponse({'success': False, 'error': str(e)}, status=400)
+        return JsonResponse({
+            'success': False,
+            'error': 'The provided blueprint JSON is invalid. Please verify the format and required fields.'
+        }, status=400)
     except Exception as e:
         logger.error(f"Unexpected error importing blueprint: {e}", exc_info=True)
-        return JsonResponse({'success': False, 'error': f'An unexpected error occurred: {str(e)}'}, status=500)
+        return JsonResponse({
+            'success': False,
+            'error': 'An unexpected error occurred while importing the blueprint. Please try again later.'
+        }, status=500)
 
 
 @login_required


### PR DESCRIPTION
Potential fix for [https://github.com/gdsanger/Agira/security/code-scanning/154](https://github.com/gdsanger/Agira/security/code-scanning/154)

In general, to fix information exposure through exceptions, log the full exception (with stack trace) server-side and return only a generic, user-friendly error message to the client. For validation-like errors where some feedback is necessary, return a controlled, high-level message that does not embed the raw exception string.

Specifically for `blueprint_import` in `core/views.py`:

- Keep logging as-is (or include more context if desired).
- Change the JSON response in the `except BlueprintDeserializationError as e:` block to use a generic message not derived from `str(e)`. Optionally, you can add a safe, high-level hint such as “Please check that the JSON matches the required blueprint format,” but it should not echo the raw exception.
- Similarly, in the generic `except Exception as e:` block, stop including `str(e)` in the response. Return a fully generic error message such as “An unexpected error occurred while importing the blueprint. Please contact support if the problem persists.”

These changes are confined to the `blueprint_import` view (lines 10353–10358). No new methods or imports are required, since logging is already configured and used.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
