### PR TITLE
Potential fix for code scanning alert no. 152: Information exposure through an exception

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -10245,7 +10245,13 @@ def blueprint_delete(request, id):
         
     except Exception as e:
         logger.error(f"Error deleting blueprint: {e}", exc_info=True)
-        return JsonResponse({'success': False, 'error': str(e)}, status=500)
+        return JsonResponse(
+            {
+                'success': False,
+                'error': 'An error occurred while deleting the blueprint.'
+            },
+            status=500
+        )
 
 
 @login_required


### PR DESCRIPTION
Potential fix for [https://github.com/gdsanger/Agira/security/code-scanning/152](https://github.com/gdsanger/Agira/security/code-scanning/152)

In general, to fix information exposure via exceptions, you should log the detailed exception (including stack trace) on the server side and return only a generic, user-friendly error message to the client. Avoid including `str(e)` or stack traces in HTTP responses, unless you have explicitly sanitized and classified the error as safe.

For this specific case in `core/views.py` (function `blueprint_delete`), we should keep the existing logging (which already logs the exception with `exc_info=True`) and change the error `JsonResponse` so it does not include `str(e)`. Instead, we can send a generic message like `"An error occurred while deleting the blueprint."` or similar, preserving the existing 500 status code and JSON structure as much as possible. This preserves functionality (the client still learns that the operation failed and gets an error message) without leaking internal details. No new imports are needed because we already have `logger` configured and `JsonResponse` imported.

Concretely:
- In `blueprint_delete`, replace `return JsonResponse({'success': False, 'error': str(e)}, status=500)` with a response that uses a generic error message and does not interpolate `e`. For example:
  ```python
  return JsonResponse(
      {'success': False, 'error': 'An error occurred while deleting the blueprint.'},
      status=500
  )
  ```
- Leave all other code, including logging, unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
