### PR TITLE
Potential fix for code scanning alert no. 151: Information exposure through an exception

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -10213,7 +10213,13 @@ def blueprint_update(request, id):
         
     except Exception as e:
         logger.error(f"Error saving blueprint: {e}", exc_info=True)
-        return JsonResponse({'success': False, 'error': str(e)}, status=500)
+        return JsonResponse(
+            {
+                'success': False,
+                'error': 'An unexpected error occurred while saving the blueprint.'
+            },
+            status=500
+        )
 
 
 @login_required


### PR DESCRIPTION
Potential fix for [https://github.com/gdsanger/Agira/security/code-scanning/151](https://github.com/gdsanger/Agira/security/code-scanning/151)

In general, the fix is to **avoid returning raw exception messages to the client**. Instead, log the detailed exception on the server (as is already done with `logger.error(..., exc_info=True)`) and send back a generic, non-sensitive error message. Where possible, reserve specific, user-friendly messages for expected/handled error types (like `ValidationError`) and keep truly unexpected errors generic.

For this specific code:

- Keep the existing logging in the `except Exception as e` block at line 10214 so that developers still see the full stack trace and message in server logs.
- Change the JSON response so that it does **not** include `str(e)`. Instead, use a generic message such as `"An unexpected error occurred while saving the blueprint."` or a similarly neutral text that does not reveal internals.
- We do not need new imports or additional methods: we can re-use the existing `logger` and `JsonResponse`.
- Only the `JsonResponse` construction on line 10216 needs to be changed accordingly.
- The analogous error handler in `blueprint_delete` (lines 10246–10248) already returns a generic message, so we will make `blueprint_update` consistent with that.

Concretely: in `core/views.py`, inside `blueprint_update`, replace

```python
return JsonResponse({'success': False, 'error': str(e)}, status=500)
```

with something like

```python
return JsonResponse(
    {
        'success': False,
        'error': 'An unexpected error occurred while saving the blueprint.'
    },
    status=500
)
```

This preserves behavior (error still indicated, status still 500) but removes exposure of exception text.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
