### PR TITLE
Potential fix for code scanning alert no. 149: Information exposure through an exception

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -9959,7 +9959,13 @@ def change_policy_update(request, id):
         
     except Exception as e:
         logger.error(f"Error updating change policy: {e}", exc_info=True)
-        return JsonResponse({'success': False, 'error': str(e)}, status=500)
+        return JsonResponse(
+            {
+                'success': False,
+                'error': 'An unexpected error occurred while updating the change policy.'
+            },
+            status=500
+        )
 
 
 @login_required


### PR DESCRIPTION
Potential fix for [https://github.com/gdsanger/Agira/security/code-scanning/149](https://github.com/gdsanger/Agira/security/code-scanning/149)

In general, the fix is to avoid returning raw exception information to the client. Instead, log the detailed exception (including stack trace) on the server, and send a generic, non-sensitive error message in the HTTP response. This way, developers keep full diagnostics in logs, while clients get a safe and predictable error payload.

For this specific code, we should modify the `except Exception as e:` block in `change_policy_update` so that it no longer includes `str(e)` in the JSON. The call to `logger.error(..., exc_info=True)` is good and should remain. The `JsonResponse` should instead return a fixed, generic message like `"An unexpected error occurred while updating the change policy."` or similar. This does not change control flow or the response structure (`{'success': False, 'error': ...}`), so clients can continue to rely on the same keys, just with a safer message value.

Concretely:
- In `core/views.py`, locate the `change_policy_update` view’s `except Exception as e:` block (lines 9960–9962).
- Keep the `logger.error` call as-is.
- Replace `JsonResponse({'success': False, 'error': str(e)}, status=500)` with a `JsonResponse` that uses a generic error message string instead of `str(e)`.
- No new imports or helper methods are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
