### PR TITLE
Potential fix for code scanning alert no. 148: Information exposure through an exception

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -9777,7 +9777,8 @@ def system_setting_update(request):
         error_msg = ', '.join([f"{k}: {', '.join(v)}" for k, v in e.message_dict.items()])
         return HttpResponse(f"Validation error: {error_msg}", status=400)
     except Exception as e:
-        return HttpResponse(f"Error updating settings: {str(e)}", status=400)
+        logger.exception("Error updating system settings")
+        return HttpResponse("An error occurred while updating system settings.", status=400)
 
 
 # Change Policy Views


### PR DESCRIPTION
Potential fix for [https://github.com/gdsanger/Agira/security/code-scanning/148](https://github.com/gdsanger/Agira/security/code-scanning/148)

In general, the fix is to avoid sending raw exception messages back to the user. Instead, log the full error (optionally including the stack trace) on the server, and return a generic, user-friendly error message in the HTTP response.

For this specific code, we should modify the broad `except Exception as e:` block in `system_setting_update` (lines 9779–9780). The best minimal fix without changing functionality is:

- Log the exception using the existing `logger` (possibly with `logger.exception` so the stack trace is captured).
- Replace `f"Error updating settings: {str(e)}"` with a generic message like `"An error occurred while updating system settings."` that does not include `str(e)`.

No imports need to be added since `logging` and `logger` are already defined at the top of `core/views.py`. We leave the `ValidationError` handling unchanged, as that already formats messages about user input and does not include stack traces, and its behaviour appears intentional.

Concretely:

- In `core/views.py`, in `system_setting_update`, change the general exception handler to:
  - Call `logger.exception("Error updating system settings")`.
  - Return `HttpResponse("An error occurred while updating system settings.", status=400)`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
