### PR TITLE
Potential fix for code scanning alert no. 147: Information exposure through an exception

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -9690,7 +9690,8 @@ def global_settings_update(request):
         error_msg = ', '.join([f"{k}: {', '.join(v)}" for k, v in e.message_dict.items()])
         return HttpResponse(f"Validation error: {error_msg}", status=400)
     except Exception as e:
-        return HttpResponse(f"Error updating settings: {str(e)}", status=400)
+        logger.exception("Unexpected error while updating global settings.")
+        return HttpResponse("An error occurred while updating settings.", status=400)
 
 
 def public_logo(request):


### PR DESCRIPTION
Potential fix for [https://github.com/gdsanger/Agira/security/code-scanning/147](https://github.com/gdsanger/Agira/security/code-scanning/147)

In general, to fix information exposure through exceptions, the application should avoid returning raw exception messages or stack traces to the client. Instead, the server should log the detailed error (including stack trace) and send a generic, user-friendly error message in the HTTP response. For validation errors where the message is intentionally user-facing, it may still be acceptable to show specific information, but unexpected exceptions should not reveal internal details.

For this specific view in `core/views.py`, the best fix without changing the intended functionality is:

- Keep the `ValidationError` handling as-is, since those messages are part of normal, expected user feedback.
- In the broad `except Exception as e:` block, replace the direct inclusion of `str(e)` in the response with:
  - A server-side log entry that records the error (using the already-configured `logger`), ideally with `logger.exception` to capture the stack trace.
  - A generic error message returned to the user, such as `"An error occurred while updating settings."`, without including exception details.

Concretely, modify lines 9692–9693 so that instead of:

```python
    except Exception as e:
        return HttpResponse(f"Error updating settings: {str(e)}", status=400)
```

the code logs the exception and returns a generic message:

```python
    except Exception as e:
        logger.exception("Unexpected error while updating global settings.")
        return HttpResponse("An error occurred while updating settings.", status=400)
```

No new imports are necessary because `logger` is already defined at the top of `core/views.py`. This preserves the behavior of signaling an error via HTTP 400 while eliminating the direct exposure of exception details.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
