### PR TITLE
Potential fix for code scanning alert no. 146: Information exposure through an exception

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -9629,8 +9629,12 @@ def email_send_reply(request):
     except json.JSONDecodeError:
         return JsonResponse({'success': False, 'error': 'Invalid JSON data'}, status=400)
     except Exception as e:
-        logger.error(f"Error sending email: {e}")
-        return JsonResponse({'success': False, 'error': str(e)}, status=500)
+        # Log full exception details server-side, but return a generic message to the client
+        logger.exception("Unexpected error while sending email")
+        return JsonResponse(
+            {'success': False, 'error': 'An internal error occurred while sending the email.'},
+            status=500,
+        )
 
 
 # ==================== Global Settings Views ====================


### PR DESCRIPTION
Potential fix for [https://github.com/gdsanger/Agira/security/code-scanning/146](https://github.com/gdsanger/Agira/security/code-scanning/146)

In general, to fix information exposure through exceptions, you should log the full exception server‑side (including stack trace if needed), and return a generic, user‑friendly error message to the client that does not reveal implementation or configuration details. Avoid returning raw `str(e)` or formatted tracebacks in HTTP responses.

For this specific case in `core/views.py`, in the `email_send_reply` view, we should change the broad `except Exception as e:` block so that it:

1. Logs the exception with stack trace using `logger.exception` (or `logger.error(..., exc_info=True)`), so developers still get full diagnostic information.
2. Returns a generic JSON error response such as `{'success': False, 'error': 'Failed to send email'}` without including `str(e)`.

This maintains existing functionality (the endpoint still returns a JSON error and HTTP 500 on unexpected exceptions), but it removes the leakage of exception details. We already have a `logger` configured at the top of the file, so no new imports are needed. Concretely, modify lines 9631–9633 to log with stack trace and return a generic message instead of `str(e)`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
