### PR TITLE
Potential fix for code scanning alert no. 145: Information exposure through an exception

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -9509,7 +9509,10 @@ def email_prepare_reply(request, comment_id):
         })
     except Exception as e:
         logger.error(f"Error preparing reply: {e}")
-        return JsonResponse({'success': False, 'error': str(e)}, status=500)
+        return JsonResponse(
+            {'success': False, 'error': 'An internal error occurred while preparing the reply.'},
+            status=500,
+        )
 
 
 @login_required
@@ -9533,7 +9536,10 @@ def email_prepare_reply_all(request, comment_id):
         })
     except Exception as e:
         logger.error(f"Error preparing reply all: {e}")
-        return JsonResponse({'success': False, 'error': str(e)}, status=500)
+        return JsonResponse(
+            {'success': False, 'error': 'An internal error occurred while preparing the reply-all.'},
+            status=500,
+        )
 
 
 @login_required
@@ -9557,7 +9563,10 @@ def email_prepare_forward(request, comment_id):
         })
     except Exception as e:
         logger.error(f"Error preparing forward: {e}")
-        return JsonResponse({'success': False, 'error': str(e)}, status=500)
+        return JsonResponse(
+            {'success': False, 'error': 'An internal error occurred while preparing the forward.'},
+            status=500,
+        )
 
 
 @login_required


### PR DESCRIPTION
Potential fix for [https://github.com/gdsanger/Agira/security/code-scanning/145](https://github.com/gdsanger/Agira/security/code-scanning/145)

In general, the fix is to avoid returning raw exception information to the client. Instead, log the full exception server-side (ideally with stack trace) and send a generic, non-sensitive error message in the HTTP response. This preserves observability for developers while preventing leakage of internal details.

For this specific code, we should keep the `logger.error(...)` calls but stop including `str(e)` in responses. We can replace `str(e)` with a generic string such as `"An internal error occurred while preparing the reply."` that does not reveal implementation details. To maintain consistent UX and not change functional behavior beyond information exposure, we will:
- Leave the control flow and HTTP status codes unchanged (still `status=500`).
- Adjust only the `error` field in the JSON responses in:
  - `email_prepare_reply` (around line 9510–9512)
  - `email_prepare_reply_all` (around line 9534–9536)
  - `email_prepare_forward` (around line 9558–9560)

The existing `logger` import and initialization already exist at the top (`logger = logging.getLogger(__name__)`), so we do not need additional imports or helpers. Optionally, in a fuller refactor one might centralize error handling, but that’s beyond the current snippet; we will make minimal, targeted changes.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
