### PR TITLE
Fix MCP connector over HTTPS: allowed hosts + restore env-fallback fix

### DIFF
--- a/agira_mcp/server.py
+++ b/agira_mcp/server.py
@@ -34,6 +34,7 @@ import contextvars
 import os
 
 from mcp.server.fastmcp import FastMCP
+from mcp.server.transport_security import TransportSecuritySettings
 
 from .client import AgiraClient, AgiraError
 
@@ -56,7 +57,38 @@ def _user_token() -> str | None:
     return _current_user_token.get() or os.environ.get("AGIRA_USER_TOKEN") or None
 
 
-mcp = FastMCP("agira")
+# Default SDK hosts/origins (localhost only) — kept so stdio and local HTTP
+# keep working. The MCP SDK enables DNS-rebinding protection and answers 421
+# for any Host header not on this allowlist.
+_DEFAULT_HOSTS = ["127.0.0.1:*", "localhost:*", "[::1]:*"]
+_DEFAULT_ORIGINS = ["http://127.0.0.1:*", "http://localhost:*", "http://[::1]:*"]
+
+
+def _transport_security() -> TransportSecuritySettings | None:
+    """Build transport-security settings from env.
+
+    When the server runs behind a reverse proxy, nginx forwards the public
+    Host header (e.g. ``agiramcp.example.com``), which is not on the SDK's
+    localhost-only allowlist and would be rejected with 421. Set
+    ``AGIRA_MCP_ALLOWED_HOSTS`` (comma-separated, no scheme) to the public
+    host(s) to allow them. Returns None to keep the SDK defaults (local only).
+    """
+    hosts = [h.strip() for h in os.environ.get("AGIRA_MCP_ALLOWED_HOSTS", "").split(",") if h.strip()]
+    if not hosts:
+        return None
+    origins = [o.strip() for o in os.environ.get("AGIRA_MCP_ALLOWED_ORIGINS", "").split(",") if o.strip()]
+    # Default origins to https://<host> for each configured host if none given.
+    if not origins:
+        origins = [f"https://{h}" for h in hosts]
+    return TransportSecuritySettings(
+        enable_dns_rebinding_protection=True,
+        allowed_hosts=_DEFAULT_HOSTS + hosts,
+        allowed_origins=_DEFAULT_ORIGINS + origins,
+    )
+
+
+_security = _transport_security()
+mcp = FastMCP("agira", **({"transport_security": _security} if _security else {}))
 
 
 # --------------------------------------------------------------------------

--- a/agira_mcp/server.py
+++ b/agira_mcp/server.py
@@ -39,8 +39,12 @@ from mcp.server.transport_security import TransportSecuritySettings
 from .client import AgiraClient, AgiraError
 
 # Per-request user token (set by the ASGI middleware for HTTP transport).
-_current_user_token: contextvars.ContextVar[str | None] = contextvars.ContextVar(
-    "current_user_token", default=None
+# The default is a sentinel (not None) so we can tell "no HTTP request context"
+# (stdio transport) apart from "HTTP request without a token". Only the former
+# may fall back to the AGIRA_USER_TOKEN env var.
+_UNSET = object()
+_current_user_token: contextvars.ContextVar = contextvars.ContextVar(
+    "current_user_token", default=_UNSET
 )
 
 
@@ -53,8 +57,17 @@ def _client() -> AgiraClient:
 
 
 def _user_token() -> str | None:
-    """Resolve the acting user's token: per-request (HTTP) or env (stdio)."""
-    return _current_user_token.get() or os.environ.get("AGIRA_USER_TOKEN") or None
+    """Resolve the acting user's token.
+
+    Under HTTP transport the middleware always sets the context var (to the
+    request's token, or None when absent), so we use exactly what the request
+    carried and never fall back to the env var. Under stdio transport the
+    context var is never set, so we fall back to AGIRA_USER_TOKEN.
+    """
+    value = _current_user_token.get()
+    if value is _UNSET:
+        return os.environ.get("AGIRA_USER_TOKEN") or None
+    return value or None
 
 
 # Default SDK hosts/origins (localhost only) — kept so stdio and local HTTP


### PR DESCRIPTION
## Problem

Beim Ausrollen des MCP-Connectors hinter nginx/TLS lieferte `https://agiramcp.isarlabs.de/mcp` ein **421 Misdirected Request** — schon beim lokalen Direkttest am Upstream (`--resolve …:127.0.0.1`). Ursache ist **nicht** nginx, sondern der **DNS-Rebinding-Schutz des MCP-SDK**: es validiert den `Host`-Header gegen eine localhost-only Allowlist (`127.0.0.1:*`, `localhost:*`, `[::1]:*`) und antwortet sonst mit 421. Hinter einem Reverse-Proxy ist der weitergereichte Host (`agiramcp.isarlabs.de`) nicht erlaubt → unerreichbar über HTTPS. Analog wird der `Origin`-Header geprüft (→ 403).

## Fix 1 — konfigurierbare Transport-Security-Hosts

Neue Env-Variablen, die die Allowlist erweitern (localhost-Defaults bleiben erhalten):
- `AGIRA_MCP_ALLOWED_HOSTS` (kommagetrennt, ohne Schema) → erlaubte Hosts
- `AGIRA_MCP_ALLOWED_ORIGINS` (optional) → erlaubte Origins; ohne Angabe automatisch `https://<host>`

Ohne diese Variablen bleibt der sichere localhost-only Default (stdio / lokales HTTP unverändert).

## Fix 2 — Bugbot-Sentinel-Fix nachgezogen

Der Fix aus der Bugbot-Review von #664 (`acdedf2`, Env-Token-Fallback darf im HTTP-Transport nicht greifen) war beim Merge von #664 **nicht** in `main` gelandet — `main` wurde auf dem Stand `54daa68` gemergt. Dieser PR zieht ihn mit ein, damit Prod auch diesen Fix bekommt.

## Verifikation

- `host=agiramcp.isarlabs.de` → erlaubt, `origin=https://agiramcp.isarlabs.de` → erlaubt, fremder Host → weiterhin 421 abgewiesen
- HTTP ohne Token → `responsible=None` (kein Env-Fallback); stdio → Env-Token
- Alle 7 Tools registrieren, HTTP-App baut (mcp 1.28.0)

## Deployment

Auf dem Server in der Env-Datei des Dienstes ergänzen und neu starten:
```
AGIRA_MCP_ALLOWED_HOSTS=agiramcp.isarlabs.de
```
```
sudo systemctl restart agira-mcp.service
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches auth-related token resolution for HTTP vs stdio and expands Host/Origin allowlists when configured—misconfiguration could weaken DNS-rebinding protection or change who acts on write tools.
> 
> **Overview**
> Fixes MCP HTTP behind TLS/reverse proxies by wiring **MCP SDK transport security** so public `Host`/`Origin` values can be allowlisted via **`AGIRA_MCP_ALLOWED_HOSTS`** (and optional **`AGIRA_MCP_ALLOWED_ORIGINS`**, defaulting to `https://<host>`), while keeping localhost defaults when those env vars are unset.
> 
> Also restores the **per-request user token** behavior: a sentinel default on `_current_user_token` so **HTTP** uses only the request token (no **`AGIRA_USER_TOKEN`** fallback when the header/query is missing), while **stdio** still falls back to the env var.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b336006b46528a42fbd2ff44232b5cee6b472a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->