### PR TITLE
fix: MCP get_item_context liefert 0 Ergebnisse — Umstieg auf Extended RAG Pipeline

### DIFF
--- a/core/views_api.py
+++ b/core/views_api.py
@@ -12,7 +12,7 @@ from django.views.decorators.csrf import csrf_exempt
 from django.core.exceptions import ValidationError
 
 from core.models import Project, Item, ItemType, ItemStatus, User, UserRole
-from core.services.rag import build_context
+from core.services.rag import build_extended_context
 
 logger = logging.getLogger(__name__)
 
@@ -90,37 +90,18 @@ def serialize_item(item):
     }
 
 
-# Helper function to serialize RAGContext to dict
+# Helper function to serialize ExtendedRAGContext to dict
 def serialize_rag_context(context):
     """
-    Serialize a RAGContext instance to a dictionary.
-    
-    Args:
-        context: RAGContext instance
-        
-    Returns:
-        Dictionary with RAG context data
+    Serialize an ExtendedRAGContext instance to a dictionary.
+
+    Returns a backward-compatible structure with an `items` key (= all retrieved
+    items) plus the richer layer_a/b/c and optimized_query fields.
     """
-    return {
-        'query': context.query,
-        'alpha': context.alpha,
-        'summary': context.summary,
-        'items': [
-            {
-                'object_type': obj.object_type,
-                'object_id': obj.object_id,
-                'title': obj.title,
-                'content': obj.content,
-                'source': obj.source,
-                'relevance_score': obj.relevance_score,
-                'link': obj.link,
-                'updated_at': obj.updated_at,
-            }
-            for obj in context.items
-        ],
-        'stats': context.stats,
-        'debug': context.debug,
-    }
+    result = context.to_dict()
+    # Backward-compat alias so MCP clients reading `items` still work
+    result['items'] = result['all_items']
+    return result
 
 
 # Projects Endpoints
@@ -551,19 +532,22 @@ def api_item_context(request, item_id):
     try:
         # Verify item exists
         item = Item.objects.get(id=item_id)
-        
-        # Build query from item title and description
-        query = f"{item.title} {item.description}".strip()
-        
-        # Build RAG context using existing service
-        context = build_context(
+
+        # Use description as primary query, fall back to title (matches UI RAG button)
+        query = (item.description or item.title or "").strip()
+        if not query:
+            return JsonResponse({'error': 'Item has no description or title to search with'}, status=400)
+
+        # Build extended RAG context via the same pipeline as the UI RAG Retrieval button:
+        # question-optimization-agent + parallel hybrid search + A/B/C-fusion.
+        # item_id is intentionally omitted — it is DEPRECATED in build_extended_context
+        # (Issue #395) and previously caused 0 results by filtering on parent_object_id.
+        context = build_extended_context(
             query=query,
             project_id=str(item.project_id),
-            item_id=str(item.id),
-            current_item_id=str(item.id),  # Exclude current item from results (Issue #392)
-            limit=20,
+            current_item_id=str(item.id),
         )
-        
+
         # Return the RAG result 1:1 as JSON
         return JsonResponse(serialize_rag_context(context))
         


### PR DESCRIPTION
## Summary

- `AgiraMCP__get_item_context` lieferte konsequent 0 Ergebnisse, während der UI-„RAG Retrieval"-Button für dieselben Items korrekte Treffer zeigte
- Root cause: Der Endpoint rief `build_context` (Basis-Service) mit `item_id=str(item.id)` auf — dieser Parameter filtert auf `parent_object_id` (nur Kinder des Items). Zusammen mit dem `current_item_id`-Exclude-Filter war das Ergebnis immer leer
- Fix: Umstieg auf `build_extended_context` (gleicher Code-Pfad wie UI-Button) ohne `item_id`-Filter; Question-Optimization-Agent + A/B/C-Fusion aktiv

## Changes

**`core/views_api.py`**
- Import: `build_context` → `build_extended_context`
- Query: `title + description` → nur `description` (Fallback auf `title`), entspricht UI-Verhalten
- Service-Aufruf: Basis-Service → Extended Service; `item_id`-Parameter entfernt (war in `build_extended_context` bereits als DEPRECATED/Issue #395 markiert und ignoriert)
- Serializer: nutzt `ExtendedRAGContext.to_dict()` mit `items`-Alias auf `all_items` für Backward-Compat

## Test plan

- [ ] `AgiraMCP__get_item_context` für Item #721 (project_id=3) muss ≥1 Treffer liefern (UI liefert 6)
- [ ] `AgiraMCP__get_item_context` für Item #392 (project_id=1) muss ≥1 Treffer liefern
- [ ] Antwortstruktur enthält `items` (Backward-Compat), `layer_a`, `layer_b`, `layer_c`, `optimized_query`, `summary`, `stats`
- [ ] UI RAG Retrieval Button funktioniert weiterhin unverändert (nicht betroffen)

## Related

- Root cause identisch mit dem ursprünglichen RAG-Filter-Bug (Issue #392/#395)
- Extended RAG Pipeline Feature (Issue #407)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes retrieval behavior and JSON shape for an authenticated API used by MCP/CustomGPT; low security impact but affects live agent context quality and client parsing.
> 
> **Overview**
> **Fixes MCP `get_item_context` returning empty results** by routing the CustomGPT/MCP item-context endpoint through the same **extended RAG pipeline** as the UI “RAG Retrieval” button, instead of the basic `build_context` path.
> 
> The search query now prefers **description** (with **title** fallback) and returns **400** when both are empty. The deprecated **`item_id`** filter is no longer passed— it had restricted results to children via `parent_object_id` and, together with excluding the current item, often yielded **zero hits**.
> 
> Responses are serialized from **`ExtendedRAGContext.to_dict()`**, exposing layers **`layer_a` / `layer_b` / `layer_c`**, **`optimized_query`**, and related fields, while keeping an **`items`** alias on **`all_items`** for existing MCP clients.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1dbe4c74132f8e92afc7c9efd3867da22df065b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->