### PR TITLE
feat: Claude Queue visibility (live list + detail)

### DIFF
--- a/core/test_claude_queue_views.py
+++ b/core/test_claude_queue_views.py
@@ -1,0 +1,206 @@
+"""
+Tests for the Claude Queue visibility views (list, detail, and HTMX polling
+partials).
+"""
+from decimal import Decimal
+
+from django.test import TestCase, Client
+from django.urls import reverse
+from django.db.models import Max
+
+from core.models import (
+    Item, Project, ItemStatus, ItemType, User,
+    ClaudeQueueJob, ClaudeQueueJobStatus,
+)
+
+
+class ClaudeQueueViewsTestCase(TestCase):
+    """Test case for the Claude Queue list/detail/partial views."""
+
+    def setUp(self):
+        self.client = Client()
+
+        self.user = User.objects.create_user(
+            username='testuser',
+            password='testpass123',
+            email='test@example.com',
+        )
+        self.user.name = 'Test User'
+        self.user.active = True
+        self.user.save()
+
+        self.project = Project.objects.create(
+            name='Test Project',
+            description='Test project description',
+        )
+        self.other_project = Project.objects.create(
+            name='Other Project',
+            description='Another project',
+        )
+        self.item_type = ItemType.objects.create(
+            key='bug', name='Bug', description='Bug type',
+        )
+        self.item = Item.objects.create(
+            title='Fix the auth bug',
+            description='desc',
+            project=self.project,
+            type=self.item_type,
+            status=ItemStatus.WORKING,
+        )
+        self.other_item = Item.objects.create(
+            title='Other item',
+            description='desc',
+            project=self.other_project,
+            type=self.item_type,
+            status=ItemStatus.WORKING,
+        )
+
+    # ---- helpers -------------------------------------------------------
+
+    def _running_job(self):
+        return ClaudeQueueJob.objects.create(
+            item=self.item,
+            project=self.project,
+            status=ClaudeQueueJobStatus.RUNNING,
+            progress_text='reads auth.py',
+        )
+
+    def _done_job(self):
+        return ClaudeQueueJob.objects.create(
+            item=self.item,
+            project=self.project,
+            status=ClaudeQueueJobStatus.DONE,
+            num_turns=12,
+            total_cost_usd=Decimal('0.4231'),
+            pr_number=42,
+            pr_url='https://github.com/acme/repo/pull/42',
+        )
+
+    def _failed_job(self):
+        return ClaudeQueueJob.objects.create(
+            item=self.item,
+            project=self.project,
+            status=ClaudeQueueJobStatus.FAILED,
+            error_text='boom: something went wrong',
+        )
+
+    # ---- auth ----------------------------------------------------------
+
+    def test_list_requires_authentication(self):
+        response = self.client.get(reverse('claude-queue-jobs'))
+        self.assertEqual(response.status_code, 302)
+        self.assertIn('/login/', response.url)
+
+    def test_detail_requires_authentication(self):
+        job = self._running_job()
+        response = self.client.get(reverse('claude-queue-job-detail', args=[job.id]))
+        self.assertEqual(response.status_code, 302)
+        self.assertIn('/login/', response.url)
+
+    # ---- list view -----------------------------------------------------
+
+    def test_list_shows_jobs(self):
+        self.client.login(username='testuser', password='testpass123')
+        self._running_job()
+        response = self.client.get(reverse('claude-queue-jobs'))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'Fix the auth bug')
+        self.assertContains(response, 'reads auth.py')
+
+    def test_list_filter_by_project(self):
+        self.client.login(username='testuser', password='testpass123')
+        self._running_job()
+        ClaudeQueueJob.objects.create(
+            item=self.other_item, project=self.other_project,
+            status=ClaudeQueueJobStatus.RUNNING,
+        )
+        response = self.client.get(
+            reverse('claude-queue-jobs'), {'project': self.project.id}
+        )
+        self.assertContains(response, 'Fix the auth bug')
+        self.assertNotContains(response, 'Other item')
+
+    def test_list_filter_by_status(self):
+        self.client.login(username='testuser', password='testpass123')
+        self._running_job()
+        self._done_job()
+        response = self.client.get(
+            reverse('claude-queue-jobs'), {'status': ClaudeQueueJobStatus.DONE}
+        )
+        # The done job carries a PR link; the running one shows progress text.
+        self.assertContains(response, 'PR #42')
+        self.assertNotContains(response, 'reads auth.py')
+
+    def test_list_invalid_project_filter_is_ignored(self):
+        self.client.login(username='testuser', password='testpass123')
+        self._running_job()
+        response = self.client.get(
+            reverse('claude-queue-jobs'), {'project': 'not-a-number'}
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'Fix the auth bug')
+
+    # ---- row partial (list polling) -----------------------------------
+
+    def test_row_active_job_has_polling_attributes(self):
+        self.client.login(username='testuser', password='testpass123')
+        job = self._running_job()
+        response = self.client.get(reverse('claude-queue-job-row', args=[job.id]))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'hx-get')
+        self.assertContains(response, 'reads auth.py')
+
+    def test_row_terminal_job_has_no_polling(self):
+        self.client.login(username='testuser', password='testpass123')
+        job = self._done_job()
+        response = self.client.get(reverse('claude-queue-job-row', args=[job.id]))
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, 'hx-get')
+        self.assertContains(response, 'PR #42')
+
+    def test_row_204_for_nonexistent_job(self):
+        self.client.login(username='testuser', password='testpass123')
+        max_id = ClaudeQueueJob.objects.aggregate(Max('id'))['id__max'] or 0
+        response = self.client.get(reverse('claude-queue-job-row', args=[max_id + 1]))
+        self.assertEqual(response.status_code, 204)
+        self.assertEqual(response.content, b'')
+
+    # ---- detail + live partial ----------------------------------------
+
+    def test_detail_running_shows_current_step(self):
+        self.client.login(username='testuser', password='testpass123')
+        job = self._running_job()
+        response = self.client.get(reverse('claude-queue-job-detail', args=[job.id]))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'reads auth.py')
+        self.assertContains(response, 'hx-get')  # live block polls while running
+
+    def test_detail_done_shows_pr_and_cost(self):
+        self.client.login(username='testuser', password='testpass123')
+        job = self._done_job()
+        response = self.client.get(reverse('claude-queue-job-detail', args=[job.id]))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'PR #42')
+        self.assertContains(response, '4231')  # cost digits (locale-independent)
+        self.assertContains(response, '12')  # num_turns
+        self.assertNotContains(response, 'hx-get')  # polling stops when done
+
+    def test_detail_failed_shows_error(self):
+        self.client.login(username='testuser', password='testpass123')
+        job = self._failed_job()
+        response = self.client.get(reverse('claude-queue-job-detail', args=[job.id]))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'boom: something went wrong')
+        self.assertContains(response, 'failed')
+
+    def test_detail_404_for_nonexistent_job(self):
+        self.client.login(username='testuser', password='testpass123')
+        max_id = ClaudeQueueJob.objects.aggregate(Max('id'))['id__max'] or 0
+        response = self.client.get(reverse('claude-queue-job-detail', args=[max_id + 1]))
+        self.assertEqual(response.status_code, 404)
+
+    def test_live_204_for_nonexistent_job(self):
+        self.client.login(username='testuser', password='testpass123')
+        max_id = ClaudeQueueJob.objects.aggregate(Max('id'))['id__max'] or 0
+        response = self.client.get(reverse('claude-queue-job-live', args=[max_id + 1]))
+        self.assertEqual(response.status_code, 204)

--- a/core/urls.py
+++ b/core/urls.py
@@ -121,6 +121,12 @@ urlpatterns = [
     
     # Change Management URLs
     path('changes/', views.changes, name='changes'),
+
+    # Claude Queue visibility
+    path('claude-queue/', views.claude_queue_jobs, name='claude-queue-jobs'),
+    path('claude-queue/<int:job_id>/', views.claude_queue_job_detail, name='claude-queue-job-detail'),
+    path('claude-queue/<int:job_id>/row/', views.claude_queue_job_row, name='claude-queue-job-row'),
+    path('claude-queue/<int:job_id>/live/', views.claude_queue_job_live, name='claude-queue-job-live'),
     path('changes/new/', views.change_create, name='change-create'),
     path('changes/<int:id>/', views.change_detail, name='change-detail'),
     path('changes/<int:id>/edit/', views.change_edit, name='change-edit'),

--- a/core/views.py
+++ b/core/views.py
@@ -30,7 +30,8 @@ from .models import (
     AIProvider, AIModel, AIProviderType, AIJobsHistory, UserOrganisation, UserRole,
     ExternalIssueMapping, ExternalIssueKind, Change, ChangeStatus, ChangeApproval, ApprovalStatus, RiskLevel, ReleaseType,
     MailTemplate, MailActionMapping, IssueOpenQuestion, IssueStandardAnswer, OpenQuestionStatus, OpenQuestionSource,
-    GlobalSettings, SystemSetting, ChangePolicy, ChangePolicyRole)
+    GlobalSettings, SystemSetting, ChangePolicy, ChangePolicyRole,
+    ClaudeQueueJob, ClaudeQueueJobStatus)
 
 
 from .services.workflow import ItemWorkflowGuard
@@ -722,6 +723,103 @@ def changes(request):
         'selected_risk': risk_filter,
     }
     return render(request, 'changes.html', context)
+
+
+# ---------------------------------------------------------------------------
+# Claude Queue visibility
+#
+# Live insight into what Claude Code is working on, so a batch run is no longer
+# a black box. The list and detail views render normally; the status row (list)
+# and live block (detail) refresh themselves via HTMX polling. Terminal jobs are
+# rendered without polling attributes, so polling stops on its own once a job
+# reaches done/failed/cancelled.
+# ---------------------------------------------------------------------------
+
+# Statuses that are still in flight and therefore keep polling.
+_CLAUDE_QUEUE_ACTIVE_STATUSES = (
+    ClaudeQueueJobStatus.QUEUED,
+    ClaudeQueueJobStatus.RUNNING,
+)
+
+
+@login_required
+def claude_queue_jobs(request):
+    """List view of all Claude queue jobs with project/status filters."""
+    jobs = ClaudeQueueJob.objects.select_related(
+        'item', 'project'
+    ).order_by('-created_at')
+
+    project_filter = request.GET.get('project', '')
+    if project_filter:
+        try:
+            jobs = jobs.filter(project_id=int(project_filter))
+        except (ValueError, TypeError):
+            project_filter = ''
+
+    status_filter = request.GET.get('status', '')
+    if status_filter:
+        jobs = jobs.filter(status=status_filter)
+
+    context = {
+        'jobs': jobs,
+        'projects': Project.objects.all().order_by('name'),
+        'statuses': ClaudeQueueJobStatus.choices,
+        'selected_project': project_filter,
+        'selected_status': status_filter,
+    }
+    return render(request, 'claude_queue_jobs.html', context)
+
+
+@login_required
+def claude_queue_job_row(request, job_id):
+    """HTMX endpoint: the single table row for a job, used for list polling.
+
+    Returns the row partial. The partial only carries polling attributes while
+    the job is still active, so an active row keeps refreshing and a finished
+    row swaps in a static version that stops the poll.
+    """
+    try:
+        job = ClaudeQueueJob.objects.select_related('item', 'project').get(id=job_id)
+    except ClaudeQueueJob.DoesNotExist:
+        # HTMX-friendly: no error page, and 204 leaves the existing row in place.
+        return HttpResponse(status=204)
+
+    return render(request, 'partials/claude_queue_job_row.html', {
+        'job': job,
+        'active_statuses': _CLAUDE_QUEUE_ACTIVE_STATUSES,
+    })
+
+
+@login_required
+def claude_queue_job_detail(request, job_id):
+    """Detail view for a single Claude queue job."""
+    job = get_object_or_404(
+        ClaudeQueueJob.objects.select_related('item', 'project'),
+        id=job_id,
+    )
+    return render(request, 'claude_queue_job_detail.html', {
+        'job': job,
+        'active_statuses': _CLAUDE_QUEUE_ACTIVE_STATUSES,
+    })
+
+
+@login_required
+def claude_queue_job_live(request, job_id):
+    """HTMX endpoint: the live status block on the detail page.
+
+    Shows the current step (progress_text) while running, and the result
+    (turns/cost + PR link) or error once finished. Polling attributes are only
+    emitted while the job is active, so the poll stops when the job settles.
+    """
+    try:
+        job = ClaudeQueueJob.objects.select_related('item', 'project').get(id=job_id)
+    except ClaudeQueueJob.DoesNotExist:
+        return HttpResponse(status=204)
+
+    return render(request, 'partials/claude_queue_job_live.html', {
+        'job': job,
+        'active_statuses': _CLAUDE_QUEUE_ACTIVE_STATUSES,
+    })
 
 @login_required
 def item_lookup(request, item_id):

--- a/templates/base.html
+++ b/templates/base.html
@@ -180,6 +180,10 @@
                     <i class="bi bi-arrow-repeat sidebar-icon"></i>
                     <span class="sidebar-text">Changes</span>
                 </a>
+                <a href="{% url 'claude-queue-jobs' %}" class="sidebar-link {% if 'claude-queue' in request.resolver_match.url_name %}active{% endif %}">
+                    <i class="bi bi-robot sidebar-icon"></i>
+                    <span class="sidebar-text">Claude Queue</span>
+                </a>
                 <a href="{% url 'organisations' %}" class="sidebar-link {% if request.resolver_match.url_name == 'organisations' %}active{% endif %}">
                     <i class="bi bi-building sidebar-icon"></i>
                     <span class="sidebar-text">Organisations</span>

--- a/templates/claude_queue_job_detail.html
+++ b/templates/claude_queue_job_detail.html
@@ -1,0 +1,57 @@
+{% extends "base.html" %}
+
+{% block title %}Claude Queue Job #{{ job.id }} - Agira{% endblock %}
+
+{% block content %}
+<div class="page-header">
+    <div class="d-flex justify-content-between align-items-start">
+        <div>
+            <nav aria-label="breadcrumb">
+                <ol class="breadcrumb mb-1">
+                    <li class="breadcrumb-item"><a href="{% url 'claude-queue-jobs' %}">Claude Queue</a></li>
+                    <li class="breadcrumb-item active" aria-current="page">Job #{{ job.id }}</li>
+                </ol>
+            </nav>
+            <h1 class="mb-0">{{ job.item.title }}</h1>
+            <p class="text-muted mb-0">
+                <a href="{% url 'item-detail' job.item.id %}">Item #{{ job.item.id }}</a>
+                &middot; {{ job.project.name }}
+                &middot; Model: {{ job.get_model_display }}
+            </p>
+        </div>
+    </div>
+</div>
+
+<div class="row g-4">
+    <div class="col-lg-8">
+        <div class="card">
+            <div class="card-body">
+                {% include 'partials/claude_queue_job_live.html' %}
+            </div>
+        </div>
+    </div>
+    <div class="col-lg-4">
+        <div class="card">
+            <div class="card-header">Details</div>
+            <div class="card-body">
+                <dl class="row mb-0">
+                    <dt class="col-5 text-muted">Branch</dt>
+                    <dd class="col-7">{{ job.branch_name|default:"—" }}</dd>
+
+                    <dt class="col-5 text-muted">Session</dt>
+                    <dd class="col-7 text-break"><small>{{ job.session_id|default:"—" }}</small></dd>
+
+                    <dt class="col-5 text-muted">Created</dt>
+                    <dd class="col-7">{{ job.created_at|date:"Y-m-d H:i" }}</dd>
+
+                    <dt class="col-5 text-muted">Started</dt>
+                    <dd class="col-7">{{ job.started_at|date:"Y-m-d H:i"|default:"—" }}</dd>
+
+                    <dt class="col-5 text-muted">Finished</dt>
+                    <dd class="col-7">{{ job.finished_at|date:"Y-m-d H:i"|default:"—" }}</dd>
+                </dl>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/templates/claude_queue_jobs.html
+++ b/templates/claude_queue_jobs.html
@@ -1,0 +1,77 @@
+{% extends "base.html" %}
+
+{% block title %}Claude Queue - Agira{% endblock %}
+
+{% block content %}
+<div class="page-header">
+    <div class="d-flex justify-content-between align-items-center">
+        <div>
+            <h1>Claude Queue</h1>
+            <p class="text-muted">Live view of what Claude Code is working on</p>
+        </div>
+    </div>
+</div>
+
+<!-- Filter Bar -->
+<div class="mb-4">
+    <form method="get" action="{% url 'claude-queue-jobs' %}" class="row g-3">
+        <div class="col-md-3">
+            <select name="project" class="form-select">
+                <option value="">All Projects</option>
+                {% for project in projects %}
+                <option value="{{ project.id }}" {% if selected_project == project.id|stringformat:"s" %}selected{% endif %}>
+                    {{ project.name }}
+                </option>
+                {% endfor %}
+            </select>
+        </div>
+        <div class="col-md-2">
+            <select name="status" class="form-select">
+                <option value="">All Statuses</option>
+                {% for status_value, status_label in statuses %}
+                <option value="{{ status_value }}" {% if selected_status == status_value %}selected{% endif %}>
+                    {{ status_label }}
+                </option>
+                {% endfor %}
+            </select>
+        </div>
+        <div class="col-auto">
+            <button type="submit" class="btn btn-primary">Filter</button>
+            {% if selected_project or selected_status %}
+            <a href="{% url 'claude-queue-jobs' %}" class="btn btn-secondary">Clear</a>
+            {% endif %}
+        </div>
+    </form>
+</div>
+
+<!-- Jobs Table -->
+<div class="card">
+    <div class="card-body p-0">
+        <div class="table-responsive">
+            <table class="table table-hover mb-0">
+                <thead>
+                    <tr>
+                        <th>#</th>
+                        <th>Item</th>
+                        <th>Project</th>
+                        <th>Status</th>
+                        <th>Current step</th>
+                        <th>PR</th>
+                        <th>Turns / Cost</th>
+                        <th>Created</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for job in jobs %}
+                    {% include 'partials/claude_queue_job_row.html' %}
+                    {% empty %}
+                    <tr>
+                        <td colspan="8" class="text-center text-muted py-4">No queue jobs found.</td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/templates/partials/claude_queue_job_live.html
+++ b/templates/partials/claude_queue_job_live.html
@@ -1,0 +1,73 @@
+{% comment %}
+Live status block for the job detail page. Polls itself every few seconds while
+the job is active; stops once the job settles. Shows the current step while
+running, and the result (turns/cost + PR link) or error once finished.
+Expects `job` and `active_statuses` in context.
+{% endcomment %}
+<div id="cqj-live-{{ job.id }}"
+     {% if job.status in active_statuses %}
+     hx-get="{% url 'claude-queue-job-live' job.id %}"
+     hx-trigger="every 3s"
+     hx-swap="outerHTML"
+     {% endif %}>
+
+    <div class="d-flex align-items-center gap-2 mb-3">
+        <span class="fs-5">{% include 'partials/claude_queue_status_badge.html' %}</span>
+        {% if job.status in active_statuses %}
+        <small class="text-muted"><i class="bi bi-arrow-repeat"></i> live &middot; updates automatically</small>
+        {% endif %}
+    </div>
+
+    {% if job.status == 'failed' %}
+    <div class="alert alert-danger" role="alert">
+        <h6 class="alert-heading"><i class="bi bi-exclamation-triangle"></i> Job failed</h6>
+        {% if job.error_text %}
+        <pre class="mb-0" style="white-space: pre-wrap; word-break: break-word;">{{ job.error_text|truncatechars:2000 }}</pre>
+        {% else %}
+        <p class="mb-0">No error detail was recorded.</p>
+        {% endif %}
+    </div>
+    {% else %}
+    <div class="mb-3">
+        <label class="text-muted small text-uppercase">Current step</label>
+        <div class="p-3 bg-light rounded border">
+            {% if job.progress_text %}
+            {{ job.progress_text }}
+            {% elif job.status == 'queued' %}
+            <span class="text-muted">Waiting in queue…</span>
+            {% else %}
+            <span class="text-muted">—</span>
+            {% endif %}
+        </div>
+    </div>
+    {% endif %}
+
+    {% if job.status == 'done' or job.status == 'failed' or job.status == 'cancelled' %}
+    <div class="row g-3">
+        <div class="col-md-4">
+            <div class="border rounded p-3 h-100">
+                <div class="text-muted small text-uppercase">Draft PR</div>
+                {% if job.pr_url %}
+                <a href="{{ job.pr_url }}" target="_blank" rel="noopener">
+                    <i class="bi bi-git"></i> PR #{{ job.pr_number }}
+                </a>
+                {% else %}
+                <span class="text-muted">—</span>
+                {% endif %}
+            </div>
+        </div>
+        <div class="col-md-4">
+            <div class="border rounded p-3 h-100">
+                <div class="text-muted small text-uppercase">Turns</div>
+                {% if job.num_turns is not None %}{{ job.num_turns }}{% else %}<span class="text-muted">—</span>{% endif %}
+            </div>
+        </div>
+        <div class="col-md-4">
+            <div class="border rounded p-3 h-100">
+                <div class="text-muted small text-uppercase">Cost</div>
+                {% if job.total_cost_usd is not None %}${{ job.total_cost_usd|floatformat:4 }}{% else %}<span class="text-muted">—</span>{% endif %}
+            </div>
+        </div>
+    </div>
+    {% endif %}
+</div>

--- a/templates/partials/claude_queue_job_row.html
+++ b/templates/partials/claude_queue_job_row.html
@@ -1,0 +1,47 @@
+{% comment %}
+One table row for a ClaudeQueueJob. While the job is still active it carries
+HTMX polling attributes and refreshes itself every few seconds; once it reaches
+a terminal state the swapped-in row omits those attributes and polling stops.
+Expects `job` and `active_statuses` in context.
+{% endcomment %}
+<tr id="cqj-row-{{ job.id }}"
+    style="cursor: pointer;"
+    onclick="window.location='{% url 'claude-queue-job-detail' job.id %}'"
+    {% if job.status in active_statuses %}
+    hx-get="{% url 'claude-queue-job-row' job.id %}"
+    hx-trigger="every 5s"
+    hx-swap="outerHTML"
+    {% endif %}>
+    <td class="text-muted">#{{ job.id }}</td>
+    <td>
+        <strong>{{ job.item.title }}</strong>
+        <br><small class="text-muted">Item #{{ job.item.id }}</small>
+    </td>
+    <td>{{ job.project.name }}</td>
+    <td>{% include 'partials/claude_queue_status_badge.html' %}</td>
+    <td class="cqj-progress" onclick="event.stopPropagation();">
+        {% if job.status == 'failed' and job.error_text %}
+        <span class="text-danger" title="{{ job.error_text }}">
+            <i class="bi bi-exclamation-triangle"></i> {{ job.error_text|truncatechars:80 }}
+        </span>
+        {% elif job.progress_text %}
+        <span class="text-muted">{{ job.progress_text|truncatechars:80 }}</span>
+        {% else %}
+        <span class="text-muted">—</span>
+        {% endif %}
+    </td>
+    <td>
+        {% if job.pr_url %}
+        <a href="{{ job.pr_url }}" target="_blank" rel="noopener" onclick="event.stopPropagation();">
+            <i class="bi bi-git"></i> PR #{{ job.pr_number }}
+        </a>
+        {% else %}
+        <span class="text-muted">—</span>
+        {% endif %}
+    </td>
+    <td class="text-nowrap">
+        {% if job.num_turns is not None %}{{ job.num_turns }} turns{% else %}—{% endif %}
+        {% if job.total_cost_usd is not None %}<br><small class="text-muted">${{ job.total_cost_usd|floatformat:4 }}</small>{% endif %}
+    </td>
+    <td class="text-nowrap"><small class="text-muted">{{ job.created_at|date:"Y-m-d H:i" }}</small></td>
+</tr>

--- a/templates/partials/claude_queue_status_badge.html
+++ b/templates/partials/claude_queue_status_badge.html
@@ -1,0 +1,14 @@
+{% comment %}Status badge for a ClaudeQueueJob. Expects `job` in context.{% endcomment %}
+{% if job.status == 'queued' %}
+<span class="badge bg-secondary"><i class="bi bi-hourglass-split"></i> {{ job.get_status_display }}</span>
+{% elif job.status == 'running' %}
+<span class="badge bg-primary"><span class="spinner-border spinner-border-sm" role="status" style="width:0.7rem;height:0.7rem;"></span> {{ job.get_status_display }}</span>
+{% elif job.status == 'done' %}
+<span class="badge bg-success"><i class="bi bi-check-lg"></i> {{ job.get_status_display }}</span>
+{% elif job.status == 'failed' %}
+<span class="badge bg-danger"><i class="bi bi-exclamation-triangle"></i> {{ job.get_status_display }}</span>
+{% elif job.status == 'cancelled' %}
+<span class="badge bg-dark"><i class="bi bi-slash-circle"></i> {{ job.get_status_display }}</span>
+{% else %}
+<span class="badge bg-light text-dark">{{ job.get_status_display }}</span>
+{% endif %}


### PR DESCRIPTION
## Kontext
Sichtbarkeit für die Claude-Queue: der Nutzer soll live sehen, woran Claude gerade arbeitet, ohne in Logs zu schauen. Ein 40-Turn-Batch-Lauf war bisher eine Blackbox.

## Was drin ist
- **Listen-View** aller `ClaudeQueueJob`s mit Filter nach Projekt/Status. Jede *aktive* Zeile pollt sich selbst (`hx-trigger="every 5s"`) und tauscht sich per `outerHTML` aus. Sobald ein Job terminal ist (done/failed/cancelled), enthält die eingetauschte Zeile keine Polling-Attribute mehr → Polling stoppt von selbst.
- **Detail-View** mit Live-Statusblock (pollt alle 3s solange aktiv): zeigt den aktuellen Schritt aus `progress_text` während des Laufs; nach Abschluss `num_turns` + `total_cost_usd` und einen Link zum Draft-PR (`pr_url`).
- **Fehlerfall sichtbar:** `failed`-Jobs zeigen `error_text` (gekürzt in der Liste, ausführlicher im Detail) in einem Alert — kein stilles Verschwinden.
- Wiederverwendbares Status-Badge-Partial; Sidebar-Nav-Eintrag „Claude Queue".
- HTMX-Endpunkte liefern `204` für nicht (mehr) existierende Jobs, damit mitten im Poll keine Fehlerseite auftaucht.

## Acceptance
- [x] Laufender Job zeigt aktuellen Schritt, aktualisiert sich ohne manuelles Reload (HTMX-Polling auf Row bzw. Live-Block).
- [x] Abgeschlossener Job zeigt PR-Link + Kosten/Turns.
- [x] Fehlgeschlagener Job zeigt Fehlerhinweis.

## Tests
14 Tests in `core/test_claude_queue_views.py` (Auth, Filter, Polling-Attribute je Status, done/failed/nonexistent Rendering). Alle grün; `manage.py check` sauber.

## Abhängigkeit
Baut auf #829 (`ClaudeQueueJob`-Model) auf. Dieser PR ist gegen den Branch `fix/claude-queue-job-model` gestellt, damit der Diff nur die Visibility-Änderungen zeigt. Nach Merge von #829 kann die Base auf `main` umgestellt werden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only visibility over existing job records with standard login_required; no changes to queue execution or job state transitions.
> 
> **Overview**
> Adds **authenticated UI** so users can see `ClaudeQueueJob` progress without digging through logs: a **list** with project/status filters, a **detail** page, and a **sidebar** link to “Claude Queue”.
> 
> **List and detail** render job metadata (item, project, status, progress, PR, turns/cost). **HTMX polling** refreshes active jobs only: list rows poll every 5s via `claude-queue-job-row`; the detail **live** block polls every 3s via `claude-queue-job-live`. Terminal statuses (done/failed/cancelled) swap in markup **without** `hx-get`, so polling stops automatically. **Failed** jobs surface `error_text` (truncated on the list, fuller on detail).
> 
> New routes under `/claude-queue/` wire four `@login_required` views in `core/views.py`. Missing jobs on HTMX partials return **204** (no error page mid-poll); detail 404 for unknown ids. **14 tests** in `core/test_claude_queue_views.py` cover auth, filters, polling attributes, and terminal/nonexistent behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 676e1bc11d6b1694356498560f303232212cf391. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->