### PR TITLE
#833: Claude-Queue Enqueue-Aktion + Git-Workflow-Hinweis am Item erzwingen

### DIFF
--- a/core/services/claude_queue/branch.py
+++ b/core/services/claude_queue/branch.py
@@ -1,0 +1,18 @@
+"""Deterministic branch-name derivation for the Claude queue (#833).
+
+The branch name is a contract shared with the worker/PR-bootstrap step
+(#832): both sides must derive the exact same ``fix/<id>-<slug>`` value from
+an item, independently, without either one calling into the other.
+"""
+
+from django.utils.text import slugify
+
+
+def build_branch_name(item) -> str:
+    """Return the contract branch name ``fix/<id>-<slug>`` for an item.
+
+    The item id prefix keeps the branch unique and greppable even when two
+    items share a title; the slug is truncated to keep the ref sane.
+    """
+    slug = slugify(item.title or '')[:60].strip('-')
+    return f"fix/{item.id}-{slug}" if slug else f"fix/{item.id}"

--- a/core/services/claude_queue/enqueue.py
+++ b/core/services/claude_queue/enqueue.py
@@ -1,0 +1,73 @@
+"""Enqueue an item for Claude Code processing (#833).
+
+The UI entry point into the Claude queue pipeline: creates a queued
+``ClaudeQueueJob``, force-appends the git-workflow hint to the item's
+description, and moves the item to ``Working``. Re-enqueueing an item that
+already has an active job is a no-op (returns the existing job) so a stray
+double-click can't spawn duplicate jobs for the same item.
+"""
+
+from django.db import transaction
+
+from core.models import (
+    ClaudeQueueJob,
+    ClaudeQueueJobModel,
+    ClaudeQueueJobStatus,
+    Item,
+    ItemStatus,
+)
+from core.services.activity import ActivityService
+from core.services.claude_queue.hint import ensure_git_workflow_hint
+from core.services.workflow.item_workflow_guard import ItemWorkflowGuard
+
+# TODO(#834): once the model-selection agent lands, read `item.suggested_model`
+# here instead of always defaulting to sonnet.
+DEFAULT_CLAUDE_MODEL = ClaudeQueueJobModel.SONNET
+
+
+def _resolve_model(item) -> str:
+    """Return the Claude model to run this item with.
+
+    Degrades gracefully to DEFAULT_CLAUDE_MODEL until #834 adds
+    `suggested_model` to Item.
+    """
+    return getattr(item, 'suggested_model', None) or DEFAULT_CLAUDE_MODEL
+
+
+def enqueue_item_for_claude(item: Item, *, actor=None) -> tuple[ClaudeQueueJob, bool]:
+    """Hand ``item`` off to the Claude queue.
+
+    Returns ``(job, created)``. ``created`` is False when the item already
+    had a queued/running job — that job is returned unchanged instead of
+    creating a duplicate.
+    """
+    with transaction.atomic():
+        locked_item = Item.objects.select_for_update().get(pk=item.pk)
+
+        existing_job = ClaudeQueueJob.objects.filter(
+            item=locked_item,
+            status__in=[ClaudeQueueJobStatus.QUEUED, ClaudeQueueJobStatus.RUNNING],
+        ).order_by('-created_at').first()
+        if existing_job is not None:
+            return existing_job, False
+
+        if ensure_git_workflow_hint(locked_item):
+            locked_item.save()
+
+        ItemWorkflowGuard().transition(locked_item, ItemStatus.WORKING, actor=actor)
+
+        model = _resolve_model(locked_item)
+        job = ClaudeQueueJob.objects.create(
+            item=locked_item,
+            project=locked_item.project,
+            status=ClaudeQueueJobStatus.QUEUED,
+            model=model,
+        )
+
+    ActivityService().log(
+        verb='item.claude_enqueued',
+        target=locked_item,
+        actor=actor,
+        summary=f'Enqueued for Claude Code (job #{job.pk}, model={model})',
+    )
+    return job, True

--- a/core/services/claude_queue/hint.py
+++ b/core/services/claude_queue/hint.py
@@ -1,0 +1,41 @@
+"""Forced git-workflow hint on an item's description (#833).
+
+Every item handed off to the Claude queue must carry a human- and
+CLI-readable reminder of the git conventions the worker enforces (branch
+naming, draft PR, no direct commits to main). The hint is force-appended to
+``item.description`` on enqueue and guarded by a marker so re-enqueueing an
+item never duplicates it.
+"""
+
+from core.services.claude_queue.branch import build_branch_name
+
+GIT_WORKFLOW_HINT_MARKER = '<!-- claude-queue:git-workflow-hint -->'
+
+
+def build_git_workflow_hint(branch_name: str) -> str:
+    """Render the git-workflow hint block for a given branch name."""
+    return (
+        f"{GIT_WORKFLOW_HINT_MARKER}\n"
+        "---\n"
+        f"**Git-Workflow:** Branch `{branch_name}` von `main`, Draft-PR, "
+        "keine direkten Commits auf `main`."
+    )
+
+
+def ensure_git_workflow_hint(item) -> bool:
+    """Force-append the git-workflow hint to ``item.description`` if missing.
+
+    Idempotent: detects a prior hint via ``GIT_WORKFLOW_HINT_MARKER`` and
+    leaves the description untouched on re-enqueue. Mutates ``item`` in
+    place but does not save it — the caller controls persistence.
+
+    Returns True if the hint was appended, False if it was already present.
+    """
+    description = item.description or ''
+    if GIT_WORKFLOW_HINT_MARKER in description:
+        return False
+
+    hint = build_git_workflow_hint(build_branch_name(item))
+    separator = '\n\n' if description.strip() else ''
+    item.description = f"{description.rstrip()}{separator}{hint}\n"
+    return True

--- a/core/services/claude_queue/test_enqueue.py
+++ b/core/services/claude_queue/test_enqueue.py
@@ -1,0 +1,166 @@
+"""Tests for the Claude queue enqueue pipeline (#833): branch-name slug,
+git-workflow hint injection, and the enqueue orchestration."""
+
+from django.test import TestCase
+
+from core.models import (
+    ClaudeQueueJob,
+    ClaudeQueueJobStatus,
+    Item,
+    ItemStatus,
+    ItemType,
+    Project,
+    User,
+)
+from core.services.claude_queue.branch import build_branch_name
+from core.services.claude_queue.enqueue import enqueue_item_for_claude
+from core.services.claude_queue.hint import (
+    GIT_WORKFLOW_HINT_MARKER,
+    ensure_git_workflow_hint,
+)
+
+
+class BuildBranchNameTestCase(TestCase):
+    def setUp(self):
+        self.project = Project.objects.create(name='Test Project')
+        self.item_type = ItemType.objects.create(key='bug', name='Bug')
+
+    def _item(self, title):
+        return Item.objects.create(
+            title=title, description='desc', project=self.project, type=self.item_type,
+        )
+
+    def test_slugifies_title_and_prefixes_id(self):
+        item = self._item('Fix the Login Bug!!')
+        self.assertEqual(build_branch_name(item), f'fix/{item.id}-fix-the-login-bug')
+
+    def test_truncates_long_titles(self):
+        item = self._item('a' * 100)
+        branch = build_branch_name(item)
+        # fix/<id>- prefix + at most 60 chars of slug
+        prefix = f'fix/{item.id}-'
+        self.assertTrue(branch.startswith(prefix))
+        self.assertLessEqual(len(branch) - len(prefix), 60)
+
+    def test_falls_back_to_bare_id_for_empty_slug(self):
+        item = self._item('!!!')
+        self.assertEqual(build_branch_name(item), f'fix/{item.id}')
+
+    def test_deterministic_for_same_item(self):
+        item = self._item('Same title twice')
+        self.assertEqual(build_branch_name(item), build_branch_name(item))
+
+
+class EnsureGitWorkflowHintTestCase(TestCase):
+    def setUp(self):
+        self.project = Project.objects.create(name='Test Project')
+        self.item_type = ItemType.objects.create(key='bug', name='Bug')
+        self.item = Item.objects.create(
+            title='Fix the login bug',
+            description='Original description.',
+            project=self.project,
+            type=self.item_type,
+        )
+
+    def test_appends_hint_with_marker_and_branch_name(self):
+        appended = ensure_git_workflow_hint(self.item)
+
+        self.assertTrue(appended)
+        self.assertIn(GIT_WORKFLOW_HINT_MARKER, self.item.description)
+        self.assertIn('Original description.', self.item.description)
+        self.assertIn(build_branch_name(self.item), self.item.description)
+        self.assertIn('Draft-PR', self.item.description)
+        self.assertIn('main', self.item.description)
+
+    def test_idempotent_on_second_call(self):
+        ensure_git_workflow_hint(self.item)
+        first = self.item.description
+
+        appended_again = ensure_git_workflow_hint(self.item)
+
+        self.assertFalse(appended_again)
+        self.assertEqual(self.item.description, first)
+        self.assertEqual(self.item.description.count(GIT_WORKFLOW_HINT_MARKER), 1)
+
+    def test_works_on_empty_description(self):
+        self.item.description = ''
+        appended = ensure_git_workflow_hint(self.item)
+
+        self.assertTrue(appended)
+        self.assertIn(GIT_WORKFLOW_HINT_MARKER, self.item.description)
+
+
+class EnqueueItemForClaudeTestCase(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username='agent1', password='pw12345', email='agent1@example.com',
+        )
+        self.project = Project.objects.create(name='Test Project')
+        self.item_type = ItemType.objects.create(key='bug', name='Bug')
+        self.item = Item.objects.create(
+            title='Fix the login bug',
+            description='Original description.',
+            project=self.project,
+            type=self.item_type,
+            status=ItemStatus.BACKLOG,
+        )
+
+    def test_creates_exactly_one_job(self):
+        job, created = enqueue_item_for_claude(self.item, actor=self.user)
+
+        self.assertTrue(created)
+        self.assertEqual(ClaudeQueueJob.objects.filter(item=self.item).count(), 1)
+        self.assertEqual(job.status, ClaudeQueueJobStatus.QUEUED)
+        self.assertEqual(job.project, self.project)
+
+    def test_appends_hint_exactly_once(self):
+        enqueue_item_for_claude(self.item, actor=self.user)
+
+        self.item.refresh_from_db()
+        self.assertEqual(self.item.description.count(GIT_WORKFLOW_HINT_MARKER), 1)
+
+    def test_sets_item_status_to_working(self):
+        enqueue_item_for_claude(self.item, actor=self.user)
+
+        self.item.refresh_from_db()
+        self.assertEqual(self.item.status, ItemStatus.WORKING)
+
+    def test_defaults_model_to_sonnet_without_suggested_model_field(self):
+        # TODO(#834): once Item.suggested_model exists, this should assert
+        # that an explicit suggestion is respected instead of the default.
+        job, _ = enqueue_item_for_claude(self.item, actor=self.user)
+
+        self.assertEqual(job.model, 'sonnet')
+
+    def test_reenqueue_is_idempotent_no_duplicate_job_or_hint(self):
+        first_job, first_created = enqueue_item_for_claude(self.item, actor=self.user)
+        second_job, second_created = enqueue_item_for_claude(self.item, actor=self.user)
+
+        self.assertTrue(first_created)
+        self.assertFalse(second_created)
+        self.assertEqual(first_job.pk, second_job.pk)
+        self.assertEqual(ClaudeQueueJob.objects.filter(item=self.item).count(), 1)
+
+        self.item.refresh_from_db()
+        self.assertEqual(self.item.description.count(GIT_WORKFLOW_HINT_MARKER), 1)
+
+    def test_does_not_duplicate_job_while_one_is_running(self):
+        first_job, _ = enqueue_item_for_claude(self.item, actor=self.user)
+        first_job.transition_to(ClaudeQueueJobStatus.RUNNING)
+
+        second_job, created = enqueue_item_for_claude(self.item, actor=self.user)
+
+        self.assertFalse(created)
+        self.assertEqual(second_job.pk, first_job.pk)
+        self.assertEqual(ClaudeQueueJob.objects.filter(item=self.item).count(), 1)
+
+    def test_allows_new_job_after_previous_one_finished(self):
+        first_job, _ = enqueue_item_for_claude(self.item, actor=self.user)
+        first_job.transition_to(ClaudeQueueJobStatus.RUNNING)
+        first_job.transition_to(ClaudeQueueJobStatus.DONE)
+
+        second_job, created = enqueue_item_for_claude(self.item, actor=self.user)
+
+        self.assertTrue(created)
+        self.assertNotEqual(second_job.pk, first_job.pk)
+        self.assertEqual(ClaudeQueueJob.objects.filter(item=self.item).count(), 2)

--- a/core/test_claude_enqueue_view.py
+++ b/core/test_claude_enqueue_view.py
@@ -1,0 +1,97 @@
+"""Tests for the item-detail "an Claude übergeben" action (#833)."""
+
+from django.test import TestCase, Client
+from django.urls import reverse
+
+from core.models import (
+    ClaudeQueueJob,
+    ClaudeQueueJobStatus,
+    Item,
+    ItemStatus,
+    ItemType,
+    Project,
+    User,
+)
+from core.services.claude_queue.hint import GIT_WORKFLOW_HINT_MARKER
+
+
+class ItemClaudeEnqueueViewTestCase(TestCase):
+    def setUp(self):
+        self.client = Client()
+
+        self.user = User.objects.create_user(
+            username='testuser', password='testpass123', email='test@example.com',
+        )
+        self.user.name = 'Test User'
+        self.user.active = True
+        self.user.save()
+
+        self.project = Project.objects.create(name='Test Project')
+        self.item_type = ItemType.objects.create(key='bug', name='Bug')
+        self.item = Item.objects.create(
+            title='Fix the login bug',
+            description='Original description.',
+            project=self.project,
+            type=self.item_type,
+            status=ItemStatus.BACKLOG,
+        )
+
+    def _url(self, item_id=None):
+        return reverse('item-claude-enqueue', args=[item_id or self.item.id])
+
+    def test_requires_authentication(self):
+        response = self.client.post(self._url())
+        self.assertNotEqual(response.status_code, 200)
+
+    def test_requires_post(self):
+        self.client.login(username='testuser', password='testpass123')
+        response = self.client.get(self._url())
+        self.assertEqual(response.status_code, 405)
+
+    def test_enqueue_creates_job_appends_hint_sets_working(self):
+        self.client.login(username='testuser', password='testpass123')
+
+        response = self.client.post(self._url())
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertTrue(data['success'])
+        self.assertNotIn('no_change', data)
+
+        self.assertEqual(ClaudeQueueJob.objects.filter(item=self.item).count(), 1)
+        job = ClaudeQueueJob.objects.get(item=self.item)
+        self.assertEqual(job.status, ClaudeQueueJobStatus.QUEUED)
+        self.assertEqual(job.pk, data['job_id'])
+
+        self.item.refresh_from_db()
+        self.assertEqual(self.item.status, ItemStatus.WORKING)
+        self.assertEqual(self.item.description.count(GIT_WORKFLOW_HINT_MARKER), 1)
+
+    def test_reenqueue_does_not_duplicate_job_or_hint(self):
+        self.client.login(username='testuser', password='testpass123')
+
+        self.client.post(self._url())
+        response = self.client.post(self._url())
+
+        data = response.json()
+        self.assertTrue(data['success'])
+        self.assertTrue(data.get('no_change'))
+        self.assertEqual(ClaudeQueueJob.objects.filter(item=self.item).count(), 1)
+
+        self.item.refresh_from_db()
+        self.assertEqual(self.item.description.count(GIT_WORKFLOW_HINT_MARKER), 1)
+
+    def test_rejects_closed_item(self):
+        self.item.status = ItemStatus.CLOSED
+        self.item.save()
+        self.client.login(username='testuser', password='testpass123')
+
+        response = self.client.post(self._url())
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(ClaudeQueueJob.objects.filter(item=self.item).count(), 0)
+
+    def test_returns_404_for_unknown_item(self):
+        self.client.login(username='testuser', password='testpass123')
+        response = self.client.post(self._url(item_id=999999))
+        self.assertEqual(response.status_code, 404)

--- a/core/urls.py
+++ b/core/urls.py
@@ -67,6 +67,7 @@ urlpatterns = [
     path('items/<int:item_id>/update-parent/', views.item_update_parent, name='item-update-parent'),
     path('items/<int:item_id>/update-intern/', views.item_update_intern, name='item-update-intern'),
     path('items/<int:item_id>/take-over-responsible/', views.item_take_over_responsible, name='item-take-over-responsible'),
+    path('items/<int:item_id>/claude-enqueue/', views.item_claude_enqueue, name='item-claude-enqueue'),
     path('items/<int:item_id>/assign-responsible/', views.item_assign_responsible, name='item-assign-responsible'),
     path('items/<int:item_id>/delete/', views.item_delete, name='item-delete'),
     path('items/<int:item_id>/list-delete/', views_items.item_list_delete, name='item-list-delete'),

--- a/core/views.py
+++ b/core/views.py
@@ -1121,6 +1121,50 @@ def item_take_over_responsible(request, item_id):
 
 @login_required
 @require_http_methods(["POST"])
+def item_claude_enqueue(request, item_id):
+    """
+    "An Claude übergeben" action - enqueues the item for the Claude queue.
+
+    Force-appends the git-workflow hint to the item's description (once),
+    creates a queued ClaudeQueueJob, and moves the item to Working. If the
+    item already has an active job, no duplicate is created.
+    """
+    from core.services.claude_queue.enqueue import enqueue_item_for_claude
+
+    item = get_object_or_404(Item, id=item_id)
+
+    if item.status == ItemStatus.CLOSED:
+        return JsonResponse({
+            'success': False,
+            'error': 'Cannot enqueue a closed item for Claude.',
+        }, status=400)
+
+    try:
+        job, created = enqueue_item_for_claude(item, actor=request.user)
+
+        if not created:
+            return JsonResponse({
+                'success': True,
+                'message': f'Item already has an active Claude job (#{job.pk}).',
+                'no_change': True,
+                'job_id': job.pk,
+            })
+
+        return JsonResponse({
+            'success': True,
+            'message': f'Enqueued for Claude Code (job #{job.pk}).',
+            'job_id': job.pk,
+        })
+    except Exception as e:
+        logger.error(f"Error enqueueing item {item_id} for Claude: {e}")
+        return JsonResponse({
+            'success': False,
+            'error': str(e)
+        }, status=500)
+
+
+@login_required
+@require_http_methods(["POST"])
 def item_assign_responsible(request, item_id):
     """
     Assign action - sets responsible to selected agent user.

--- a/templates/item_detail.html
+++ b/templates/item_detail.html
@@ -161,6 +161,12 @@
                 <i class="bi bi-person-check"></i>
                 Take over
             </button>
+            {% if item.status != 'Closed' %}
+            <button type="button" class="btn btn-outline-primary" onclick="enqueueToClaude()">
+                <i class="bi bi-robot"></i>
+                An Claude übergeben
+            </button>
+            {% endif %}
             {% endif %}
             <button type="button" class="btn btn-outline-info" data-bs-toggle="modal" data-bs-target="#assignResponsibleModal">
                 <i class="bi bi-person-plus"></i>
@@ -1278,7 +1284,36 @@
             });
         }
     }
-    
+
+    // An Claude übergeben action
+    function enqueueToClaude() {
+        if (confirm('An Claude Code übergeben? Das Item wird auf "Working" gesetzt und ein Job eingereiht.')) {
+            fetch('{% url 'item-claude-enqueue' item.id %}', {
+                method: 'POST',
+                headers: {
+                    'X-CSRFToken': document.querySelector('[name=csrfmiddlewaretoken]').value,
+                    'Content-Type': 'application/json',
+                },
+            })
+            .then(response => response.json())
+            .then(data => {
+                if (data.success) {
+                    showToast('success', data.message || 'An Claude Code übergeben.');
+                    if (!data.no_change) {
+                        setTimeout(() => {
+                            window.location.reload();
+                        }, 1000);
+                    }
+                } else {
+                    showToast('error', data.error || 'Übergabe an Claude fehlgeschlagen.');
+                }
+            })
+            .catch(error => {
+                showToast('error', 'Ein Fehler ist beim Übergeben an Claude aufgetreten.');
+            });
+        }
+    }
+
     // Assign responsible action
     document.getElementById('assignResponsibleForm')?.addEventListener('submit', function(e) {
         e.preventDefault();


### PR DESCRIPTION
## Kontext

Einstiegspunkt in die Claude-Queue-Pipeline: UI-Aktion „an Claude übergeben" am Item (analog zur bestehenden Copilot-Übergabe), die den Auftrag standardisiert, damit Claude immer nach denselben Git-Konventionen arbeitet.

## Änderungen

- `core/services/claude_queue/branch.py`: `build_branch_name(item)` — deterministischer Slug `fix/<id>-<normalisierter-titel>`.
- `core/services/claude_queue/hint.py`: `ensure_git_workflow_hint(item)` — force-appended Git-Workflow-Hinweis, idempotent via Marker (kein Duplikat bei Re-Enqueue).
- `core/services/claude_queue/enqueue.py`: `enqueue_item_for_claude(item)` — Orchestrierung: Hint anhängen, Item-Status → `Working` (via `ItemWorkflowGuard`), genau ein `ClaudeQueueJob` erzeugen. Re-Enqueue mit bereits aktivem Job (queued/running) liefert den bestehenden Job zurück statt zu duplizieren.
- View + URL: `POST /items/<id>/claude-enqueue/` (`item-claude-enqueue`).
- Template: Button „An Claude übergeben" im Item-Header (Agent-only, ausgeblendet bei geschlossenen Items).

## Abhängigkeiten

- **#829** (ClaudeQueueJob-Datenmodell): bereits umgesetzt, genutzt.
- **#834** (Modell-Auswahl-Agent, `suggested_model`): **noch nicht umgesetzt**. Sauber degradiert — `_resolve_model()` liest `getattr(item, 'suggested_model', None)` mit Fallback auf `sonnet`, markiert mit `TODO(#834)` in `enqueue.py`. Sobald #834 landet, greift die echte Modellwahl automatisch ohne weitere Änderung an dieser Stelle.
- **#832** (Worker/PR-Bootstrap): liegt aktuell auf einem separaten, ungemergten Branch. Die dortige Branch-Namens-Formel (`fix/<id>-<slug>`, `slugify(title)[:60]`) wurde hier 1:1 repliziert, damit Hint-Text und künftiger Worker garantiert denselben Branchnamen erzeugen.

## Acceptance

- ✅ Enqueue erzeugt genau einen Job und ergänzt den Hinweis genau einmal.
- ✅ Re-Enqueue ist idempotent (kein doppelter Job, kein doppelter Hinweis).
- ✅ Slug/Branchname-Formel stimmt mit der von #832 überein.

## Test plan

- [x] 20 neue Tests (Service-Layer + View), alle grün: `python manage.py test core.services.claude_queue.test_enqueue core.test_claude_enqueue_view`
- [x] Bestehende Suiten ohne Regression geprüft (`core.test_claude_queue_views`, `core.test_item_detail`, `core.test_item_responsible`, `core.test_item_status_endpoint`) — verbleibende Fehler dort sind ein vorbestehendes staticfiles-Manifest-Problem in der Testumgebung, per `git stash` verifiziert unabhängig von dieser Änderung.
- [x] `python manage.py check` sauber.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Enqueue mutates item status and description and creates queue jobs under concurrency controls; workflow guard and idempotency limit duplicate work, but item state changes affect downstream Claude processing.
> 
> **Overview**
> Adds the **“An Claude übergeben”** entry point for the Claude queue: agents can hand an item off from item detail, which enqueues a `ClaudeQueueJob`, moves the item to **Working**, and standardizes git instructions on the item.
> 
> New `core/services/claude_queue/` helpers define a shared **`fix/<id>-<slug>`** branch name (`build_branch_name`), **idempotently** append a git-workflow block to `item.description` (marker + branch, draft PR, no commits to `main`), and orchestrate enqueue in `enqueue_item_for_claude` inside a transaction with row lock. **Re-enqueue** while a job is **queued** or **running** returns the existing job (`no_change` in the API) instead of duplicating jobs or hints; a new job is allowed after the previous one finishes. Model defaults to **sonnet** until `suggested_model` (#834).
> 
> **POST** `items/<id>/claude-enqueue/` (`item_claude_enqueue`) rejects closed items; the item header gets an agent-only button (hidden when closed) with confirm + JSON handling. Service and view tests cover branch slugging, hint idempotency, enqueue behavior, and the HTTP endpoint.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6191950146930d0d367e570fed4902d649109a2b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->