### PR TITLE
feat(#832): wire real Claude Code invocation into the queue worker

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -58,6 +58,17 @@ REDIS_CACHE_PASSWORD=
 REDIS_CACHE_SOCKET_TIMEOUT=5
 REDIS_CACHE_SOCKET_CONNECT_TIMEOUT=5
 
+# Claude Code Queue Worker Configuration
+# ============================================================================
+# Base directory for per-project repo checkouts the worker operates in. This is
+# deliberately separate from the app directory: the process runs from the app
+# tree, but Claude edits inside REPO_BASE_DIR/<project.github_repo>.
+REPO_BASE_DIR=/var/lib/agira/repos
+# Executable for the headless Claude Code CLI (absolute path or a wrapper).
+CLAUDE_CLI_BIN=claude
+# Anthropic API key for the headless Claude run (API key, not the Pro subscription).
+ANTHROPIC_API_KEY=
+
 # Sentry Error Tracking Configuration (Optional - for production error monitoring)
 # Sign up at https://sentry.io to get a DSN
 # Leave empty to disable Sentry integration

--- a/agira/settings.py
+++ b/agira/settings.py
@@ -226,6 +226,19 @@ FIELD_ENCRYPTION_KEY = os.getenv('FIELD_ENCRYPTION_KEY', 'D_GzCwyVvkyI1o5qUh9rle
 AGIRA_DATA_DIR = BASE_DIR / os.getenv('AGIRA_DATA_DIR', 'data')
 AGIRA_MAX_ATTACHMENT_SIZE_MB = int(os.getenv('AGIRA_MAX_ATTACHMENT_SIZE_MB', '25'))
 
+# Claude Code Queue Worker Configuration
+# ============================================================================
+# Where the worker keeps per-project repo checkouts. This is deliberately NOT
+# the app directory: the process runs from the app tree (queue DB) but Claude
+# edits inside REPO_BASE_DIR/<project.github_repo>. Keeping them separate lets
+# dev/prod diverge via config and prevents Claude from touching the app tree.
+REPO_BASE_DIR = os.getenv('REPO_BASE_DIR', str(BASE_DIR / 'repos'))
+# Executable used for the headless Claude Code invocation (overridable so the
+# worker host can point at an absolute path / wrapper).
+CLAUDE_CLI_BIN = os.getenv('CLAUDE_CLI_BIN', 'claude')
+# API key for the headless Claude run (API key, not the Pro subscription).
+ANTHROPIC_API_KEY = os.getenv('ANTHROPIC_API_KEY', '')
+
 # Cache configuration
 # Using LocMemCache for simplicity and performance
 # In production, consider Redis or Memcached for multi-server deployments

--- a/core/management/commands/run_claude_worker.py
+++ b/core/management/commands/run_claude_worker.py
@@ -2,10 +2,23 @@
 Django management command: Claude Code queue worker.
 
 This is the *engine* of the Claude queue. It claims queued ``ClaudeQueueJob``
-rows and runs them. This command deliberately covers only **claiming &
-concurrency** plus the lifecycle scaffolding (timeout, error paths, crash
-recovery). The actual PR-creation / Claude CLI invocation is a seam
-(``_run_cli`` / the ``--cli-command`` template) that is filled in by #832.
+rows and runs them end-to-end:
+
+1. Prepare a per-project repo checkout under ``settings.REPO_BASE_DIR`` (never
+   the app directory — Claude edits there, the process runs from the app tree).
+2. Open a **draft PR up front**: branch ``fix/{item-slug}`` off ``main``, an
+   empty commit, push, then a draft PR via the existing ``GitHubService`` infra.
+   The PR reference (number/url/github-id) is written to the job and to an
+   ``ExternalIssueMapping`` (Kind=PR) *before* Claude runs, so it is
+   deterministic regardless of what Claude reports.
+3. Run Claude Code headless (``--output-format stream-json``) in the checkout,
+   parsing the event stream line-by-line to advance ``progress_text`` live and
+   to persist ``session_id`` / ``num_turns`` / ``total_cost_usd`` from the final
+   ``result`` event.
+
+The #831 frame — claiming, one-running-job-per-project concurrency, timeout and
+crash recovery — is unchanged; this command fills the seam that used to run a
+placeholder ``--cli-command``.
 
 Concurrency rules enforced here:
 
@@ -28,18 +41,23 @@ Run modes::
     python manage.py run_claude_worker --interval 5
 """
 
+import json
 import logging
 import os
+import select
 import signal
 import socket
 import subprocess
 import time
+from pathlib import Path
 
+from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.core.management.base import BaseCommand
 from django.db import connection, transaction
 from django.db.models import Exists, OuterRef, Q
 from django.utils import timezone
+from django.utils.text import slugify
 
 from core.models import (
     ClaudeQueueJob,
@@ -49,9 +67,19 @@ from core.models import (
 
 logger = logging.getLogger(__name__)
 
-# Default wall-clock budget for a single CLI invocation (30 minutes). A hung
+# Default wall-clock budget for a single Claude invocation (30 minutes). A hung
 # job must not block its project lane forever.
 DEFAULT_TIMEOUT_SECONDS = 30 * 60
+
+# Watchdog: if no stream event arrives for this long, SIGINT the Claude process.
+# A known stdout-buffering bug means the stream can fall silent while Claude is
+# still alive, so "done" is decided by process exit + result event — not by
+# stream silence — but a truly stuck run still needs a nudge.
+DEFAULT_IDLE_TIMEOUT_SECONDS = 5 * 60
+
+# After a watchdog SIGINT, give Claude this long to emit its final result event
+# and exit cleanly before escalating to SIGKILL.
+INTERRUPT_GRACE_SECONDS = 30
 
 # Default poll interval for daemon mode.
 DEFAULT_INTERVAL_SECONDS = 5
@@ -61,9 +89,8 @@ DEFAULT_INTERVAL_SECONDS = 5
 # timeout itself, so if the job is still "running" its supervisor is gone.
 STALE_BUFFER_SECONDS = 60
 
-# Placeholder command used until #832 wires the real Claude CLI invocation.
-# ``true`` exits 0 without doing anything, so a queued job cleanly reaches DONE.
-DEFAULT_CLI_COMMAND = 'true'
+# Tools Claude may use in the headless run: read/edit files and drive git.
+ALLOWED_TOOLS = 'Read,Edit,Bash(git*)'
 
 
 class Command(BaseCommand):
@@ -88,14 +115,14 @@ class Command(BaseCommand):
             '--timeout',
             type=int,
             default=DEFAULT_TIMEOUT_SECONDS,
-            help=f'Per-job CLI timeout in seconds (default: {DEFAULT_TIMEOUT_SECONDS}).',
+            help=f'Per-job wall-clock timeout in seconds (default: {DEFAULT_TIMEOUT_SECONDS}).',
         )
         parser.add_argument(
-            '--cli-command',
-            type=str,
-            default=DEFAULT_CLI_COMMAND,
-            help='Shell command executed per job (seam for #832). The job id is '
-                 'exported as CLAUDE_QUEUE_JOB_ID.',
+            '--idle-timeout',
+            type=int,
+            default=DEFAULT_IDLE_TIMEOUT_SECONDS,
+            help=f'Seconds without a stream event before the watchdog interrupts '
+                 f'the Claude process (default: {DEFAULT_IDLE_TIMEOUT_SECONDS}).',
         )
         parser.add_argument(
             '--skip-recovery',
@@ -108,7 +135,7 @@ class Command(BaseCommand):
         once = options['once']
         interval = options['interval']
         timeout = options['timeout']
-        cli_command = options['cli_command']
+        idle_timeout = options['idle_timeout']
 
         self.stdout.write(self.style.SUCCESS(
             f"Claude worker starting on {socket.gethostname()} (pid {os.getpid()})"
@@ -122,7 +149,7 @@ class Command(BaseCommand):
             if job is None:
                 self.stdout.write("No eligible job to claim.")
             else:
-                self.process_job(job, timeout, cli_command)
+                self.process_job(job, timeout, idle_timeout)
             return
 
         # Daemon mode: loop until a termination signal arrives.
@@ -134,7 +161,7 @@ class Command(BaseCommand):
                 # Nothing claimable right now — sleep, but stay responsive to signals.
                 self._interruptible_sleep(interval)
                 continue
-            self.process_job(job, timeout, cli_command)
+            self.process_job(job, timeout, idle_timeout)
         self.stdout.write(self.style.SUCCESS("Claude worker stopped."))
 
     # ------------------------------------------------------------------ #
@@ -187,8 +214,8 @@ class Command(BaseCommand):
             if job is None:
                 return None
 
-            # Take ownership *before* the long-running CLI part, and commit it
-            # with this transaction so the row is visibly ``running`` to peers.
+            # Take ownership *before* the long-running part, and commit it with
+            # this transaction so the row is visibly ``running`` to peers.
             job.worker_host = socket.gethostname()
             job.worker_pid = os.getpid()
             job.transition_to(ClaudeQueueJobStatus.RUNNING)
@@ -201,15 +228,19 @@ class Command(BaseCommand):
     # ------------------------------------------------------------------ #
     # Processing
     # ------------------------------------------------------------------ #
-    def process_job(self, job, timeout, cli_command):
+    def process_job(self, job, timeout, idle_timeout=DEFAULT_IDLE_TIMEOUT_SECONDS):
         """Run a claimed job to a terminal state (done/failed).
 
-        Wraps the CLI invocation in a timeout. Non-zero exit or timeout drives
-        the job to ``failed`` with diagnostics and releases the item so it does
-        not starve in ``Working``.
+        Prepares the checkout, opens the draft PR up front, runs Claude under a
+        wall-clock timeout + idle watchdog, and persists the result fields. Any
+        failure (setup, timeout, non-zero exit, ``is_error`` result) drives the
+        job to ``failed`` with diagnostics and releases the item so it does not
+        starve in ``Working``.
         """
         try:
-            returncode, stdout, stderr = self._run_cli(job, cli_command, timeout)
+            repo_dir = self._prepare_checkout(job)
+            branch = self._create_branch_and_pr(job, repo_dir)
+            result = self._run_cli(job, repo_dir, timeout, idle_timeout)
         except subprocess.TimeoutExpired:
             self._fail_job(
                 job,
@@ -217,48 +248,468 @@ class Command(BaseCommand):
             )
             self.stdout.write(self.style.ERROR(f"Job #{job.pk} timed out after {timeout}s"))
             return
-        except Exception as exc:  # noqa: BLE001 — any failure to launch is a job failure
-            logger.exception("Failed to launch CLI for job #%s", job.pk)
-            self._fail_job(job, error=f"Failed to launch worker CLI: {exc}")
-            self.stdout.write(self.style.ERROR(f"Job #{job.pk} failed to launch: {exc}"))
+        except Exception as exc:  # noqa: BLE001 — any setup/launch failure is a job failure
+            logger.exception("Failed to run Claude for job #%s", job.pk)
+            self._fail_job(job, error=f"Worker error: {exc}")
+            self.stdout.write(self.style.ERROR(f"Job #{job.pk} failed: {exc}"))
             return
 
-        if returncode != 0:
-            detail = (stderr or stdout or '').strip()
+        # Push whatever Claude committed onto the branch. Best-effort: Claude may
+        # have pushed already, or produced no commit — neither is fatal here.
+        self._push_branch(repo_dir, branch)
+
+        if result.get('is_error') or result.get('returncode', 0) != 0:
+            detail = (
+                result.get('result_text')
+                or result.get('stderr')
+                or f"Claude exited with status {result.get('returncode')}."
+            ).strip()
+            self._fail_job(job, error=detail or "Claude reported an error.")
+            self.stdout.write(self.style.ERROR(f"Job #{job.pk} failed"))
+            return
+
+        if not result.get('saw_result'):
+            # Process exited 0 but never emitted a result event — treat as a
+            # failure so it is not silently marked done.
             self._fail_job(
                 job,
-                error=detail or f"CLI exited with non-zero status {returncode}.",
+                error="Claude exited without emitting a final result event.",
             )
-            self.stdout.write(self.style.ERROR(
-                f"Job #{job.pk} failed (exit {returncode})"
-            ))
+            self.stdout.write(self.style.ERROR(f"Job #{job.pk} failed (no result event)"))
             return
 
-        # Success. #832 fills in PR metadata / result fields before this point.
-        if stdout.strip():
-            job.progress_text = stdout.strip()[:2000]
         job.transition_to(ClaudeQueueJobStatus.DONE)
         self.stdout.write(self.style.SUCCESS(f"Job #{job.pk} done"))
 
-    def _run_cli(self, job, cli_command, timeout):
-        """Execute the per-job CLI command under a hard timeout.
+    # ------------------------------------------------------------------ #
+    # Checkout preparation
+    # ------------------------------------------------------------------ #
+    def _prepare_checkout(self, job):
+        """Ensure a clean checkout of the project's repo under REPO_BASE_DIR.
 
-        Seam for #832: today this runs ``cli_command`` (a no-op by default);
-        #832 replaces the command with the real Claude Code invocation. Returns
-        ``(returncode, stdout, stderr)``; raises ``subprocess.TimeoutExpired``
-        on timeout.
+        Clones on first use, otherwise fetches and hard-resets to ``origin/main``
+        so each job starts from a known-clean base. Returns the checkout path.
+        The worker edits here, never in the app directory.
         """
+        project = job.project
+        repo = (project.github_repo or '').strip()
+        if not repo:
+            raise ValueError(
+                f"Project '{project.name}' has no github_repo configured."
+            )
+
+        base = Path(settings.REPO_BASE_DIR)
+        repo_dir = base / repo
+
+        if (repo_dir / '.git').is_dir():
+            self._git(['fetch', 'origin', '--prune'], cwd=str(repo_dir))
+        else:
+            base.mkdir(parents=True, exist_ok=True)
+            clone_url = self._clone_url(project)
+            # Never leak the token in stdout/logs.
+            self.stdout.write(f"  Cloning {project.github_owner}/{repo} …")
+            self._git(['clone', clone_url, str(repo_dir)], cwd=str(base))
+
+        self._git(['checkout', 'main'], cwd=str(repo_dir))
+        self._git(['reset', '--hard', 'origin/main'], cwd=str(repo_dir))
+        self._git(['clean', '-fd'], cwd=str(repo_dir))
+        self._write_trust_settings(repo_dir)
+        return str(repo_dir)
+
+    def _clone_url(self, project):
+        """Build an authenticated https clone URL for the project's repo."""
+        from core.models import GitHubConfiguration
+
+        config = GitHubConfiguration.load()
+        token = config.github_token
+        owner = project.github_owner
+        repo = project.github_repo
+        host = 'github.com'
+        if token:
+            return f"https://x-access-token:{token}@{host}/{owner}/{repo}.git"
+        return f"https://{host}/{owner}/{repo}.git"
+
+    def _write_trust_settings(self, repo_dir):
+        """Write the Claude whitelist + trust flag into the *checkout*.
+
+        These must live in the working checkout, not the app directory, so the
+        headless run does not prompt for tool permission or project trust.
+        """
+        claude_dir = Path(repo_dir) / '.claude'
+        claude_dir.mkdir(parents=True, exist_ok=True)
+        settings_file = claude_dir / 'settings.local.json'
+        payload = {
+            'hasTrustDialogAccepted': True,
+            'permissions': {
+                'allow': ['Read', 'Edit', 'Bash(git*)'],
+            },
+        }
+        settings_file.write_text(json.dumps(payload, indent=2))
+
+    # ------------------------------------------------------------------ #
+    # Branch + draft PR (the up-front trick)
+    # ------------------------------------------------------------------ #
+    def _create_branch_and_pr(self, job, repo_dir):
+        """Create ``fix/{item-slug}`` off main, empty commit, push, draft PR.
+
+        The PR is opened *before* Claude runs and its reference is written to the
+        job + an ``ExternalIssueMapping`` (Kind=PR) immediately, so it stays
+        deterministic regardless of what Claude does. Returns the branch name.
+        """
+        item = job.item
+        branch = self._branch_name(item)
+
+        self._git(['checkout', '-B', branch, 'origin/main'], cwd=repo_dir)
+        self._git(
+            ['commit', '--allow-empty', '-m',
+             f"chore: start Claude work on item #{item.id}"],
+            cwd=repo_dir,
+        )
+        self._git(
+            ['push', '--force-with-lease', '-u', 'origin', branch],
+            cwd=repo_dir,
+        )
+
+        job.branch_name = branch
+        job.save(update_fields=['branch_name'])
+
+        self._open_draft_pr(job, branch, repo_dir)
+        return branch
+
+    def _branch_name(self, item):
+        """Deterministic, collision-free branch name for an item."""
+        slug = slugify(item.title)[:50].strip('-')
+        return f"fix/{slug}-{item.id}" if slug else f"fix/item-{item.id}"
+
+    def _open_draft_pr(self, job, branch, repo_dir):
+        """Open the draft PR and record it on the job + ExternalIssueMapping.
+
+        Uses the existing ``GitHubService`` infra. On failure, falls back to
+        ``gh pr list --head`` (e.g. the PR already exists from a re-run) so a
+        transient API hiccup does not orphan the job.
+        """
+        from core.services.github.service import GitHubService
+
+        mapping = None
+        try:
+            mapping = GitHubService().create_draft_pr_for_item(
+                job.item,
+                branch_name=branch,
+                base='main',
+                title=job.item.title,
+                body=self._pr_body(job),
+            )
+        except Exception as exc:  # noqa: BLE001 — fall back to gh lookup
+            logger.warning(
+                "Draft PR API call failed for job #%s (%s); trying gh fallback",
+                job.pk, exc,
+            )
+            mapping = self._pr_from_gh_fallback(job, branch, repo_dir)
+            if mapping is None:
+                raise
+
+        job.pr_number = mapping.number
+        job.pr_url = mapping.html_url
+        job.save(update_fields=['pr_number', 'pr_url'])
+        self.stdout.write(f"  Draft PR #{mapping.number}: {mapping.html_url}")
+
+    def _pr_from_gh_fallback(self, job, branch, repo_dir):
+        """Resolve an existing PR for ``branch`` via the ``gh`` CLI.
+
+        Records an ``ExternalIssueMapping`` (Kind=PR) so the reference is stored
+        through the same infra as the primary path. Returns the mapping or None.
+        """
+        from core.models import ExternalIssueKind, ExternalIssueMapping
+
+        try:
+            proc = subprocess.run(
+                ['gh', 'pr', 'list', '--head', branch,
+                 '--state', 'all', '--json', 'number,url,id', '--limit', '1'],
+                cwd=repo_dir, capture_output=True, text=True, timeout=60,
+            )
+            if proc.returncode != 0:
+                logger.warning("gh pr list failed: %s", proc.stderr.strip())
+                return None
+            entries = json.loads(proc.stdout or '[]')
+        except (OSError, subprocess.SubprocessError, json.JSONDecodeError) as exc:
+            logger.warning("gh fallback error for job #%s: %s", job.pk, exc)
+            return None
+
+        if not entries:
+            return None
+
+        entry = entries[0]
+        # gh's `id` is the GraphQL node id (a string); ExternalIssueMapping needs
+        # a numeric github_id, so derive a stable one from the PR number if the
+        # numeric database id is unavailable.
+        github_id = entry.get('id')
+        if not isinstance(github_id, int):
+            github_id = None
+        mapping, _ = ExternalIssueMapping.objects.update_or_create(
+            item=job.item,
+            kind=ExternalIssueKind.PR,
+            number=entry['number'],
+            defaults={
+                'github_id': github_id if github_id is not None
+                else -entry['number'],
+                'state': 'open',
+                'html_url': entry['url'],
+            },
+        )
+        return mapping
+
+    def _pr_body(self, job):
+        item = job.item
+        return (
+            f"Automated draft PR opened by the Claude queue worker for "
+            f"Agira item #{item.id}.\n\n"
+            f"Model: {job.get_model_display()}\n"
+            f"Job: #{job.pk}"
+        )
+
+    def _push_branch(self, repo_dir, branch):
+        """Push the branch after the Claude run (best-effort)."""
+        try:
+            self._git(['push', 'origin', branch], cwd=repo_dir)
+        except Exception as exc:  # noqa: BLE001 — non-fatal; Claude may have pushed
+            logger.warning("Post-run push of %s failed: %s", branch, exc)
+
+    # ------------------------------------------------------------------ #
+    # Claude Code invocation + stream parsing
+    # ------------------------------------------------------------------ #
+    def _run_cli(self, job, repo_dir, timeout, idle_timeout):
+        """Run Claude Code headless in ``repo_dir`` and parse its event stream.
+
+        Returns a result dict with ``session_id``/``num_turns``/
+        ``total_cost_usd``/``is_error``/``result_text``/``saw_result``/
+        ``returncode``/``stderr``. Raises ``subprocess.TimeoutExpired`` when the
+        wall-clock budget is exhausted.
+        """
+        args = self._build_claude_args(job)
+        env = self._build_env(job)
+
+        proc = subprocess.Popen(
+            args,
+            cwd=repo_dir,
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            bufsize=1,
+        )
+        try:
+            result = self._consume_stream(
+                job, self._iter_events(proc, timeout, idle_timeout)
+            )
+        except subprocess.TimeoutExpired:
+            self._kill(proc)
+            raise
+
+        result['stderr'] = proc.stderr.read() if proc.stderr else ''
+        result['returncode'] = proc.wait()
+        return result
+
+    def _build_claude_args(self, job):
+        """Assemble the headless Claude Code command line."""
+        model = job.model or job.item.suggested_model or 'sonnet'
+        return [
+            settings.CLAUDE_CLI_BIN,
+            '-p', self._build_prompt(job.item),
+            '--model', model,
+            '--output-format', 'stream-json',
+            '--verbose',
+            '--allowedTools', ALLOWED_TOOLS,
+            '--permission-mode', 'acceptEdits',
+        ]
+
+    def _build_env(self, job):
         env = dict(os.environ, CLAUDE_QUEUE_JOB_ID=str(job.pk))
+        api_key = getattr(settings, 'ANTHROPIC_API_KEY', '') or os.environ.get(
+            'ANTHROPIC_API_KEY', ''
+        )
+        if api_key:
+            env['ANTHROPIC_API_KEY'] = api_key
+        return env
+
+    def _build_prompt(self, item):
+        """Build the task prompt Claude works from."""
+        parts = [f"# Task: {item.title}", '']
+        if item.description:
+            parts += [item.description, '']
+        if item.solution_description:
+            parts += ['## Expected solution', item.solution_description, '']
+        parts.append(
+            "Implement the change in this repository. Make focused edits and "
+            "commit them to the current branch with git. Do not push."
+        )
+        return '\n'.join(parts)
+
+    def _iter_events(self, proc, timeout, idle_timeout):
+        """Yield stdout lines, enforcing the wall-clock budget + idle watchdog.
+
+        On an idle window with no output, sends one SIGINT (the watchdog) and
+        grants a short grace period for the final result event; a second idle
+        window escalates to a timeout. "Done" is process EOF, never mere stream
+        silence.
+        """
+        deadline = time.monotonic() + timeout
+        interrupted = False
+        stdout = proc.stdout
+
+        while True:
+            now = time.monotonic()
+            if now >= deadline:
+                raise subprocess.TimeoutExpired(proc.args, timeout)
+
+            wait = min(idle_timeout, deadline - now)
+            rlist, _, _ = select.select([stdout], [], [], max(0.1, wait))
+
+            if rlist:
+                line = stdout.readline()
+                if line == '':  # EOF — process finished writing
+                    break
+                yield line
+                continue
+
+            # No output within the idle window.
+            if proc.poll() is not None:
+                break  # process already exited; drain done
+            if not interrupted:
+                logger.warning(
+                    "No Claude event for %ss; sending SIGINT (watchdog).",
+                    idle_timeout,
+                )
+                self._signal(proc, signal.SIGINT)
+                interrupted = True
+                deadline = min(deadline, time.monotonic() + INTERRUPT_GRACE_SECONDS)
+            else:
+                raise subprocess.TimeoutExpired(proc.args, timeout)
+
+    def _consume_stream(self, job, lines):
+        """Parse Claude's stream-json events, updating ``job`` as they arrive.
+
+        ``lines`` is any iterable of raw JSON lines (so it is unit-testable with
+        synthetic input). Returns the accumulated result dict.
+        """
+        result = {
+            'session_id': None,
+            'num_turns': None,
+            'total_cost_usd': None,
+            'is_error': False,
+            'result_text': '',
+            'saw_result': False,
+        }
+
+        for raw in lines:
+            raw = (raw or '').strip()
+            if not raw:
+                continue
+            try:
+                event = json.loads(raw)
+            except json.JSONDecodeError:
+                # Known stdout bug can interleave non-JSON noise — skip it.
+                continue
+
+            etype = event.get('type')
+            if etype == 'system' and event.get('subtype') == 'init':
+                result['session_id'] = event.get('session_id')
+                job.session_id = result['session_id']
+                mcp = event.get('mcp_servers') or []
+                self._save_progress(
+                    job,
+                    f"Session started ({len(mcp)} MCP server(s))",
+                    extra_fields=['session_id'],
+                )
+            elif etype == 'assistant':
+                step = self._describe_assistant(event)
+                if step:
+                    self._save_progress(job, step)
+            elif etype == 'result':
+                result['saw_result'] = True
+                result['is_error'] = bool(event.get('is_error'))
+                result['num_turns'] = event.get('num_turns')
+                result['total_cost_usd'] = event.get('total_cost_usd')
+                result['result_text'] = event.get('result') or ''
+
+                job.num_turns = result['num_turns']
+                if result['total_cost_usd'] is not None:
+                    job.total_cost_usd = result['total_cost_usd']
+                if event.get('session_id'):
+                    job.session_id = event['session_id']
+                self._save_progress(
+                    job,
+                    (result['result_text'] or 'Completed').strip(),
+                    extra_fields=['num_turns', 'total_cost_usd', 'session_id'],
+                )
+
+        return result
+
+    def _describe_assistant(self, event):
+        """Turn an assistant event into a short 'current step' line."""
+        message = event.get('message') or {}
+        content = message.get('content') or []
+        for block in content:
+            if not isinstance(block, dict):
+                continue
+            if block.get('type') == 'tool_use':
+                name = block.get('name', 'tool')
+                inp = block.get('input') or {}
+                target = (
+                    inp.get('file_path')
+                    or inp.get('command')
+                    or inp.get('path')
+                    or ''
+                )
+                return f"{name}: {target}".strip().rstrip(':')[:2000]
+        for block in content:
+            if isinstance(block, dict) and block.get('type') == 'text':
+                text = (block.get('text') or '').strip()
+                if text:
+                    return text.splitlines()[0][:2000]
+        return None
+
+    def _save_progress(self, job, text, extra_fields=None):
+        job.progress_text = (text or '')[:2000]
+        fields = ['progress_text'] + (extra_fields or [])
+        job.save(update_fields=fields)
+
+    # ------------------------------------------------------------------ #
+    # Subprocess helpers
+    # ------------------------------------------------------------------ #
+    def _git(self, args, cwd):
+        """Run a git command, raising with captured stderr on failure."""
         proc = subprocess.run(
-            cli_command,
-            shell=True,
+            ['git', *args],
+            cwd=cwd,
             capture_output=True,
             text=True,
-            timeout=timeout,
-            env=env,
+            timeout=300,
         )
-        return proc.returncode, proc.stdout, proc.stderr
+        if proc.returncode != 0:
+            raise RuntimeError(
+                f"git {' '.join(args)} failed ({proc.returncode}): "
+                f"{(proc.stderr or proc.stdout).strip()}"
+            )
+        return proc.stdout
 
+    @staticmethod
+    def _signal(proc, sig):
+        try:
+            proc.send_signal(sig)
+        except ProcessLookupError:
+            pass
+
+    def _kill(self, proc):
+        """Escalate to SIGKILL and reap the process."""
+        self._signal(proc, signal.SIGKILL)
+        try:
+            proc.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            pass
+
+    # ------------------------------------------------------------------ #
+    # Failure / item release
+    # ------------------------------------------------------------------ #
     def _fail_job(self, job, error):
         """Transition a running job to ``failed`` and release its item."""
         job.error_text = error

--- a/core/management/commands/test_run_claude_worker.py
+++ b/core/management/commands/test_run_claude_worker.py
@@ -9,6 +9,7 @@ Covers the two hard guarantees from the issue:
 plus the timeout / error end-states and crash recovery.
 """
 
+import json
 import os
 import subprocess
 from io import StringIO
@@ -26,6 +27,22 @@ from core.models import (
     ItemType,
     Project,
 )
+
+
+def _ok_result(**overrides):
+    """A successful Claude result dict as returned by ``_run_cli``."""
+    result = {
+        'session_id': 'sess-123',
+        'num_turns': 4,
+        'total_cost_usd': '0.1234',
+        'is_error': False,
+        'result_text': 'Done.',
+        'saw_result': True,
+        'returncode': 0,
+        'stderr': '',
+    }
+    result.update(overrides)
+    return result
 
 
 class ClaudeWorkerTestBase(TestCase):
@@ -121,67 +138,95 @@ class ClaimNextJobTests(ClaudeWorkerTestBase):
 
 
 class ProcessJobTests(ClaudeWorkerTestBase):
+    """The git/PR/Claude steps are patched here; each is unit-tested on its own.
+
+    These tests exercise the process_job orchestration: which result drives the
+    job to done vs failed, and item release on failure.
+    """
+
     def _claimed_job(self, project, item_status=ItemStatus.WORKING):
         item = self._item(project, status=item_status)
-        job = self._job(project, item=item)
+        self._job(project, item=item)
         return Command().claim_next_job()
 
-    def test_successful_run_marks_done(self):
+    def _run(self, job, run_cli=None, timeout=30):
+        """Run process_job with the side-effecting steps stubbed out."""
+        run_cli = run_cli if run_cli is not None else (lambda *a, **k: _ok_result())
+        with patch.object(Command, '_prepare_checkout', return_value='/tmp/repo'), \
+                patch.object(Command, '_create_branch_and_pr', return_value='fix/x-1'), \
+                patch.object(Command, '_push_branch'), \
+                patch.object(Command, '_run_cli', side_effect=run_cli):
+            Command().process_job(job, timeout=timeout, idle_timeout=5)
+
+    def test_successful_run_marks_done_and_persists_result(self):
         job = self._claimed_job(self.project_a)
-        Command().process_job(job, timeout=30, cli_command='true')
+        self._run(job)
 
         job.refresh_from_db()
         self.assertEqual(job.status, ClaudeQueueJobStatus.DONE)
         self.assertIsNotNone(job.finished_at)
         self.assertEqual(job.error_text, '')
 
+    def test_is_error_result_marks_failed(self):
+        job = self._claimed_job(self.project_a)
+        self._run(job, run_cli=lambda *a, **k: _ok_result(
+            is_error=True, result_text='exploded',
+        ))
+
+        job.refresh_from_db()
+        self.assertEqual(job.status, ClaudeQueueJobStatus.FAILED)
+        self.assertIn('exploded', job.error_text)
+        self.assertIsNotNone(job.finished_at)
+
     def test_nonzero_exit_marks_failed_and_captures_stderr(self):
         job = self._claimed_job(self.project_a)
-        Command().process_job(
-            job, timeout=30, cli_command='echo "boom" >&2; exit 3',
-        )
+        self._run(job, run_cli=lambda *a, **k: _ok_result(
+            returncode=3, saw_result=False, result_text='', stderr='boom',
+        ))
 
         job.refresh_from_db()
         self.assertEqual(job.status, ClaudeQueueJobStatus.FAILED)
         self.assertIn('boom', job.error_text)
-        self.assertIsNotNone(job.finished_at)
 
-    def test_nonzero_exit_releases_item_from_working(self):
+    def test_missing_result_event_marks_failed(self):
+        job = self._claimed_job(self.project_a)
+        self._run(job, run_cli=lambda *a, **k: _ok_result(
+            saw_result=False, result_text='',
+        ))
+
+        job.refresh_from_db()
+        self.assertEqual(job.status, ClaudeQueueJobStatus.FAILED)
+        self.assertIn('result event', job.error_text)
+
+    def test_failure_releases_item_from_working(self):
         job = self._claimed_job(self.project_a, item_status=ItemStatus.WORKING)
-        Command().process_job(job, timeout=30, cli_command='exit 1')
+        self._run(job, run_cli=lambda *a, **k: _ok_result(is_error=True))
 
         job.item.refresh_from_db()
         self.assertEqual(job.item.status, ItemStatus.BACKLOG)
 
     def test_timeout_marks_failed(self):
         job = self._claimed_job(self.project_a)
-
-        with patch.object(Command, '_run_cli', side_effect=subprocess.TimeoutExpired('cmd', 1)):
-            Command().process_job(job, timeout=1, cli_command='sleep 10')
+        self._run(
+            job, timeout=1,
+            run_cli=lambda *a, **k: (_ for _ in ()).throw(
+                subprocess.TimeoutExpired('claude', 1)
+            ),
+        )
 
         job.refresh_from_db()
         self.assertEqual(job.status, ClaudeQueueJobStatus.FAILED)
         self.assertIn('timeout', job.error_text.lower())
 
-    def test_launch_failure_marks_failed(self):
+    def test_setup_failure_marks_failed(self):
         job = self._claimed_job(self.project_a)
-
-        with patch.object(Command, '_run_cli', side_effect=OSError('no such binary')):
-            Command().process_job(job, timeout=30, cli_command='whatever')
+        with patch.object(Command, '_prepare_checkout',
+                          side_effect=RuntimeError('git clone failed')):
+            Command().process_job(job, timeout=30, idle_timeout=5)
 
         job.refresh_from_db()
         self.assertEqual(job.status, ClaudeQueueJobStatus.FAILED)
-        self.assertIn('no such binary', job.error_text)
-
-    def test_job_id_exported_to_cli_env(self):
-        job = self._claimed_job(self.project_a)
-        # Fail only if the env var isn't set, proving it is passed through.
-        Command().process_job(
-            job, timeout=30,
-            cli_command='test "$CLAUDE_QUEUE_JOB_ID" = "%d"' % job.pk,
-        )
-        job.refresh_from_db()
-        self.assertEqual(job.status, ClaudeQueueJobStatus.DONE)
+        self.assertIn('git clone failed', job.error_text)
 
 
 class CrashRecoveryTests(ClaudeWorkerTestBase):
@@ -262,7 +307,11 @@ class OnceModeTests(ClaudeWorkerTestBase):
         job = self._job(self.project_a, item=item)
 
         out = StringIO()
-        call_command('run_claude_worker', '--once', '--cli-command', 'true', stdout=out)
+        with patch.object(Command, '_prepare_checkout', return_value='/tmp/repo'), \
+                patch.object(Command, '_create_branch_and_pr', return_value='fix/x-1'), \
+                patch.object(Command, '_push_branch'), \
+                patch.object(Command, '_run_cli', return_value=_ok_result()):
+            call_command('run_claude_worker', '--once', '--skip-recovery', stdout=out)
 
         job.refresh_from_db()
         self.assertEqual(job.status, ClaudeQueueJobStatus.DONE)
@@ -271,5 +320,117 @@ class OnceModeTests(ClaudeWorkerTestBase):
         from django.core.management import call_command
 
         out = StringIO()
-        call_command('run_claude_worker', '--once', stdout=out)
+        call_command('run_claude_worker', '--once', '--skip-recovery', stdout=out)
         self.assertIn('No eligible job', out.getvalue())
+
+
+class BranchNameTests(ClaudeWorkerTestBase):
+    def test_branch_name_is_slugged_and_id_suffixed(self):
+        item = self._item(self.project_a)
+        item.title = 'Fix the Login Bug!'
+        item.save(update_fields=['title'])
+
+        branch = Command()._branch_name(item)
+        self.assertEqual(branch, f'fix/fix-the-login-bug-{item.id}')
+
+    def test_branch_name_falls_back_when_title_unsluggable(self):
+        item = self._item(self.project_a)
+        item.title = '!!!'
+        item.save(update_fields=['title'])
+
+        branch = Command()._branch_name(item)
+        self.assertEqual(branch, f'fix/item-{item.id}')
+
+
+class StreamParsingTests(ClaudeWorkerTestBase):
+    """Unit tests for _consume_stream against synthetic stream-json lines."""
+
+    def _job_with_item(self):
+        item = self._item(self.project_a)
+        return self._job(self.project_a, item=item)
+
+    def test_init_event_sets_session_id(self):
+        job = self._job_with_item()
+        lines = [json.dumps({
+            'type': 'system', 'subtype': 'init',
+            'session_id': 'sess-abc', 'mcp_servers': [{'name': 'x'}],
+        })]
+        Command()._consume_stream(job, iter(lines))
+
+        job.refresh_from_db()
+        self.assertEqual(job.session_id, 'sess-abc')
+
+    def test_assistant_tool_use_advances_progress(self):
+        job = self._job_with_item()
+        lines = [json.dumps({
+            'type': 'assistant',
+            'message': {'content': [
+                {'type': 'tool_use', 'name': 'Edit',
+                 'input': {'file_path': 'core/foo.py'}},
+            ]},
+        })]
+        Command()._consume_stream(job, iter(lines))
+
+        job.refresh_from_db()
+        self.assertEqual(job.progress_text, 'Edit: core/foo.py')
+
+    def test_result_event_persists_cost_and_turns(self):
+        job = self._job_with_item()
+        lines = [json.dumps({
+            'type': 'result', 'subtype': 'success', 'is_error': False,
+            'num_turns': 7, 'total_cost_usd': 0.42,
+            'session_id': 'sess-final', 'result': 'All done.',
+        })]
+        result = Command()._consume_stream(job, iter(lines))
+
+        self.assertTrue(result['saw_result'])
+        self.assertFalse(result['is_error'])
+        job.refresh_from_db()
+        self.assertEqual(job.num_turns, 7)
+        self.assertEqual(str(job.total_cost_usd), '0.420000')
+        self.assertEqual(job.session_id, 'sess-final')
+        self.assertEqual(job.progress_text, 'All done.')
+
+    def test_error_result_is_flagged(self):
+        job = self._job_with_item()
+        lines = [json.dumps({
+            'type': 'result', 'is_error': True, 'num_turns': 1,
+            'total_cost_usd': 0.01, 'result': 'boom',
+        })]
+        result = Command()._consume_stream(job, iter(lines))
+        self.assertTrue(result['is_error'])
+
+    def test_non_json_noise_is_ignored(self):
+        job = self._job_with_item()
+        lines = [
+            'not json at all',
+            '',
+            json.dumps({'type': 'result', 'is_error': False,
+                        'num_turns': 1, 'total_cost_usd': 0.0, 'result': 'ok'}),
+        ]
+        result = Command()._consume_stream(job, iter(lines))
+        self.assertTrue(result['saw_result'])
+
+
+class DraftPrTests(ClaudeWorkerTestBase):
+    def test_open_draft_pr_writes_job_fields(self):
+        from unittest.mock import MagicMock
+        from core.models import ExternalIssueKind, ExternalIssueMapping
+
+        item = self._item(self.project_a)
+        job = self._job(self.project_a, item=item)
+
+        mapping = ExternalIssueMapping.objects.create(
+            item=item, github_id=555, number=42, kind=ExternalIssueKind.PR,
+            state='open', html_url='https://github.com/o/r/pull/42',
+        )
+        fake_service = MagicMock()
+        fake_service.create_draft_pr_for_item.return_value = mapping
+
+        with patch('core.services.github.service.GitHubService',
+                   return_value=fake_service):
+            Command()._open_draft_pr(job, 'fix/x-1', '/tmp/repo')
+
+        job.refresh_from_db()
+        self.assertEqual(job.pr_number, 42)
+        self.assertEqual(job.pr_url, 'https://github.com/o/r/pull/42')

--- a/core/services/github/client.py
+++ b/core/services/github/client.py
@@ -165,6 +165,47 @@ class GitHubClient:
         path = f'/repos/{owner}/{repo}/pulls/{number}'
         return self.http.get(path)
     
+    def create_pull_request(
+        self,
+        owner: str,
+        repo: str,
+        title: str,
+        head: str,
+        base: str = 'main',
+        body: Optional[str] = None,
+        draft: bool = True,
+    ) -> Dict[str, Any]:
+        """
+        Create a pull request.
+
+        The head branch must already exist on the remote (the queue worker
+        pushes it before calling this).
+
+        Args:
+            owner: Repository owner
+            repo: Repository name
+            title: PR title
+            head: Name of the branch where the changes are (e.g. 'fix/item-42')
+            base: Branch to merge into (default: 'main')
+            body: PR body (markdown)
+            draft: Create as a draft PR (default: True)
+
+        Returns:
+            Created PR data as dictionary
+        """
+        path = f'/repos/{owner}/{repo}/pulls'
+        payload = {
+            'title': title,
+            'head': head,
+            'base': base,
+            'draft': draft,
+        }
+
+        if body:
+            payload['body'] = body
+
+        return self.http.post(path, json=payload)
+
     def list_prs(
         self,
         owner: str,

--- a/core/services/github/service.py
+++ b/core/services/github/service.py
@@ -349,6 +349,80 @@ class GitHubService(IntegrationBase):
         
         return mapping
     
+    def create_draft_pr_for_item(
+        self,
+        item: Item,
+        *,
+        branch_name: str,
+        base: str = 'main',
+        title: Optional[str] = None,
+        body: Optional[str] = None,
+        actor=None,
+        user: Optional[User] = None,
+    ) -> ExternalIssueMapping:
+        """
+        Create a draft pull request for an Agira item and record the mapping.
+
+        Used by the Claude queue worker to open the PR *before* Claude runs, so
+        the PR reference is deterministic regardless of what Claude reports. The
+        head branch must already exist on the remote (the worker pushes an empty
+        commit first). Reuses the standard ``ExternalIssueMapping`` (Kind=PR)
+        rather than a parallel tracking mechanism.
+
+        Args:
+            item: Agira item the PR belongs to
+            branch_name: Head branch (already pushed), e.g. 'fix/item-42'
+            base: Base branch to target (default: 'main')
+            title: PR title (default: item.title)
+            body: PR body (markdown)
+            actor: User performing the action (optional)
+            user: User whose GitHub PAT should be used (default: global token)
+
+        Returns:
+            Created ExternalIssueMapping (kind=PR)
+
+        Raises:
+            IntegrationDisabled: If GitHub is disabled
+            IntegrationNotConfigured: If GitHub is not configured
+            ValueError: If project doesn't have GitHub repo configured
+        """
+        client = self._get_client(user=user)
+        owner, repo = self._get_repo_info(item)
+
+        pr_title = title or item.title
+        github_pr = client.create_pull_request(
+            owner=owner,
+            repo=repo,
+            title=pr_title,
+            head=branch_name,
+            base=base,
+            body=body,
+            draft=True,
+        )
+
+        mapping = ExternalIssueMapping.objects.create(
+            item=item,
+            github_id=github_pr['id'],
+            number=github_pr['number'],
+            kind=ExternalIssueKind.PR,
+            state=self._map_state(github_pr, 'pr'),
+            html_url=github_pr['html_url'],
+        )
+
+        self._log_activity(
+            item=item,
+            verb='github.pr_created',
+            summary=f"Created draft PR #{github_pr['number']}: {pr_title}",
+            actor=actor,
+        )
+
+        logger.info(
+            f"Created draft PR #{github_pr['number']} for item {item.id} "
+            f"(branch {branch_name})"
+        )
+
+        return mapping
+
     def sync_mapping(self, mapping: ExternalIssueMapping) -> ExternalIssueMapping:
         """
         Synchronize an ExternalIssueMapping with GitHub.

--- a/core/services/github/test_github.py
+++ b/core/services/github/test_github.py
@@ -253,6 +253,39 @@ class GitHubServiceItemTestCase(TestCase):
         self.assertEqual(call_args[1]['body'], 'Custom body content')
         self.assertEqual(call_args[1]['labels'], ['bug', 'priority:high'])
     
+    @patch('core.services.github.client.GitHubClient.create_pull_request')
+    def test_create_draft_pr_for_item(self, mock_create_pr):
+        """Draft PR creation records an ExternalIssueMapping (kind=PR)."""
+        mock_create_pr.return_value = {
+            'id': 98765,
+            'number': 7,
+            'state': 'open',
+            'html_url': 'https://github.com/testowner/testrepo/pull/7',
+        }
+
+        mapping = self.service.create_draft_pr_for_item(
+            self.item,
+            branch_name='fix/test-bug-1',
+            base='main',
+            body='body text',
+            actor=self.user,
+        )
+
+        # Correct API call: head branch, draft=True.
+        call_kwargs = mock_create_pr.call_args[1]
+        self.assertEqual(call_kwargs['owner'], 'testowner')
+        self.assertEqual(call_kwargs['repo'], 'testrepo')
+        self.assertEqual(call_kwargs['head'], 'fix/test-bug-1')
+        self.assertEqual(call_kwargs['base'], 'main')
+        self.assertTrue(call_kwargs['draft'])
+
+        # Mapping persisted with kind=PR.
+        self.assertEqual(mapping.kind, ExternalIssueKind.PR)
+        self.assertEqual(mapping.github_id, 98765)
+        self.assertEqual(mapping.number, 7)
+        self.assertEqual(mapping.html_url,
+                         'https://github.com/testowner/testrepo/pull/7')
+
     @patch('core.services.github.client.GitHubClient.get_issue')
     def test_sync_mapping_updates_state(self, mock_get_issue):
         """Test that sync_mapping updates state from GitHub."""


### PR DESCRIPTION
## Overview

Replaces the placeholder `_run_cli` / `--cli-command` seam in `run_claude_worker` (left as a stub by the #832 merge) with the real Claude Code invocation. After a successful job, the job-detail view now fills the five previously-empty fields: **Branch**, **Draft PR**, **Current Step**, **Turns**, **Cost**.

Builds on #831 (worker frame) and #829 (`ClaudeQueueJob`); the #831 frame — claiming, one-running-job-per-project concurrency, timeout, crash recovery — is unchanged.

## What changed

**Config — repo checkout separated from the app tree** (`agira/settings.py`, `.env.example`)
- New `REPO_BASE_DIR`, `CLAUDE_CLI_BIN`, `ANTHROPIC_API_KEY`. The worker operates in `REPO_BASE_DIR/<project.github_repo>`, never the app directory.

**Draft PR up front** (`run_claude_worker.py`, `core/services/github/{service,client}.py`)
- `_prepare_checkout`: clone on first use / fetch + hard-reset to `origin/main`; writes `.claude/settings.local.json` (whitelist + `hasTrustDialogAccepted`) into the checkout.
- `_create_branch_and_pr`: branch `fix/{slug}-{id}` off main → empty commit → push → draft PR via new `GitHubService.create_draft_pr_for_item` (reuses `ExternalIssueMapping`, Kind=PR — no parallel path). `pr_number`/`pr_url` written to the job immediately; `gh pr list --head` fallback on API failure.

**Headless Claude + stream-json** (`_run_cli`, `_consume_stream`, `_iter_events`)
- `claude -p <prompt> --model <model> --output-format stream-json --verbose --allowedTools "Read,Edit,Bash(git*)" --permission-mode acceptEdits`, `cwd` = checkout, key from env, model from `job.model` / `item.suggested_model`.
- `system/init` → `session_id`; tool-calls → live `progress_text`; final `result` → `num_turns` / `total_cost_usd` / `is_error`. Idle watchdog → SIGINT (grace for the result event, then escalate). "Done" = process exit + result event, not stream silence. Non-JSON noise skipped.

## Reviewer notes

- **The `--cli-command` seam was removed entirely** (the issue said #832 replaces it). If any systemd unit / deploy script on ig-srv-02 passes `--cli-command`, it must be updated — no in-repo references remain.
- Post-run the worker does a best-effort `git push origin <branch>` in case Claude committed without pushing.

## Tests

Reworked `ProcessJobTests`/`OnceModeTests` to the new orchestration (git/PR/Claude steps patched) and added `BranchNameTests`, `StreamParsingTests`, `DraftPrTests`, plus a `create_draft_pr_for_item` service test. 55 tests pass; `manage.py check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> The worker runs subprocess git/Claude against customer repos, uses GitHub tokens for clone/push/PR creation, and force-pushes branches—operational mistakes or misconfiguration can affect remote repos and secrets handling.
> 
> **Overview**
> Replaces the placeholder `--cli-command` / no-op CLI seam in `run_claude_worker` with a full **checkout → draft PR → headless Claude → push** pipeline, while keeping the existing claim/concurrency/crash-recovery behavior.
> 
> **Configuration:** Adds `REPO_BASE_DIR`, `CLAUDE_CLI_BIN`, and `ANTHROPIC_API_KEY` so repo checkouts live outside the app tree and the worker can invoke Claude with an API key.
> 
> **Per job:** Clones or resets a checkout under `REPO_BASE_DIR`, writes `.claude/settings.local.json` for non-interactive trust, creates `fix/{slug}-{id}` with an empty commit, opens a **draft PR before Claude runs** (via new `GitHubService.create_draft_pr_for_item` / `GitHubClient.create_pull_request`), then runs `claude` with `stream-json` to update `progress_text`, `session_id`, turns, and cost. An idle watchdog sends SIGINT on silent streams; success requires a final `result` event. `--cli-command` is removed; `--idle-timeout` is added.
> 
> **GitHub:** Draft PRs are recorded on the job and as `ExternalIssueMapping` (PR), with `gh pr list` fallback if the API fails.
> 
> **Tests:** Orchestration tests patch git/PR/CLI steps; new coverage for branch naming, stream parsing, draft PR wiring, and the draft PR service method.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8090b3a122b92b114f637d9e72eb4a96558d9738. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->