### PR TITLE
Claude-Queue: PR-Body nach erfolgreichem Lauf mit Claudes Zusammenfassung befüllen (für Weaviate-Indizierung)

### DIFF
--- a/core/management/commands/run_claude_worker.py
+++ b/core/management/commands/run_claude_worker.py
@@ -242,15 +242,16 @@ class Command(BaseCommand):
             branch = self._create_branch_and_pr(job, repo_dir)
             result = self._run_cli(job, repo_dir, timeout, idle_timeout)
         except subprocess.TimeoutExpired:
-            self._fail_job(
-                job,
-                error=f"Job exceeded the {timeout}s timeout and was terminated.",
-            )
+            error = f"Job exceeded the {timeout}s timeout and was terminated."
+            self._fail_job(job, error=error)
+            self._update_pr_body(job, error=error)
             self.stdout.write(self.style.ERROR(f"Job #{job.pk} timed out after {timeout}s"))
             return
         except Exception as exc:  # noqa: BLE001 — any setup/launch failure is a job failure
             logger.exception("Failed to run Claude for job #%s", job.pk)
-            self._fail_job(job, error=f"Worker error: {exc}")
+            error = f"Worker error: {exc}"
+            self._fail_job(job, error=error)
+            self._update_pr_body(job, error=error)
             self.stdout.write(self.style.ERROR(f"Job #{job.pk} failed: {exc}"))
             return
 
@@ -264,20 +265,22 @@ class Command(BaseCommand):
                 or result.get('stderr')
                 or f"Claude exited with status {result.get('returncode')}."
             ).strip()
-            self._fail_job(job, error=detail or "Claude reported an error.")
+            error = detail or "Claude reported an error."
+            self._fail_job(job, error=error)
+            self._update_pr_body(job, error=error)
             self.stdout.write(self.style.ERROR(f"Job #{job.pk} failed"))
             return
 
         if not result.get('saw_result'):
             # Process exited 0 but never emitted a result event — treat as a
             # failure so it is not silently marked done.
-            self._fail_job(
-                job,
-                error="Claude exited without emitting a final result event.",
-            )
+            error = "Claude exited without emitting a final result event."
+            self._fail_job(job, error=error)
+            self._update_pr_body(job, error=error)
             self.stdout.write(self.style.ERROR(f"Job #{job.pk} failed (no result event)"))
             return
 
+        self._update_pr_body(job, summary=result.get('result_text'))
         job.transition_to(ClaudeQueueJobStatus.DONE)
         self.stdout.write(self.style.SUCCESS(f"Job #{job.pk} done"))
 
@@ -466,6 +469,33 @@ class Command(BaseCommand):
             f"Model: {job.get_model_display()}\n"
             f"Job: #{job.pk}"
         )
+
+    def _update_pr_body(self, job, *, summary=None, error=None):
+        """Replace the draft PR body with Claude's run summary (or a failure note).
+
+        Runs through ``GitHubService`` — the same infra that opened the PR — so
+        there is no parallel gh path. Idempotent: always overwrites the body
+        rather than appending, so re-runs don't duplicate content. Best-effort;
+        a PR body update failure must not affect the job's own terminal status.
+        The success body is what gets indexed into Weaviate as RAG context, so
+        an empty/generic body here is a real loss, not just a readability nit.
+        """
+        if not job.pr_number:
+            return
+
+        header = self._pr_body(job)
+        if error is not None:
+            body = f"{header}\n\n---\n\n**Run failed:** {error.strip()}"
+        else:
+            text = (summary or '').strip() or '_No summary provided._'
+            body = f"{header}\n\n---\n\n## Claude Summary\n\n{text}"
+
+        try:
+            from core.services.github.service import GitHubService
+
+            GitHubService().update_pr_body(job.item, number=job.pr_number, body=body)
+        except Exception as exc:  # noqa: BLE001 — best-effort, don't fail the job over this
+            logger.warning("Failed to update PR #%s body for job #%s: %s", job.pr_number, job.pk, exc)
 
     def _push_branch(self, repo_dir, branch):
         """Push the branch after the Claude run (best-effort)."""

--- a/core/management/commands/test_run_claude_worker.py
+++ b/core/management/commands/test_run_claude_worker.py
@@ -434,3 +434,70 @@ class DraftPrTests(ClaudeWorkerTestBase):
         job.refresh_from_db()
         self.assertEqual(job.pr_number, 42)
         self.assertEqual(job.pr_url, 'https://github.com/o/r/pull/42')
+
+
+class UpdatePrBodyTests(ClaudeWorkerTestBase):
+    """_update_pr_body replaces the draft body via GitHubService, not a parallel path."""
+
+    def _job_with_pr(self, pr_number=42):
+        item = self._item(self.project_a)
+        job = self._job(self.project_a, item=item)
+        job.pr_number = pr_number
+        job.save(update_fields=['pr_number'])
+        return job
+
+    def test_success_body_includes_header_and_summary(self):
+        from unittest.mock import MagicMock
+
+        job = self._job_with_pr()
+        fake_service = MagicMock()
+
+        with patch('core.services.github.service.GitHubService',
+                   return_value=fake_service):
+            Command()._update_pr_body(job, summary='Implemented the thing.')
+
+        call_kwargs = fake_service.update_pr_body.call_args[1]
+        self.assertEqual(call_kwargs['number'], 42)
+        self.assertIn('Automated draft PR', call_kwargs['body'])
+        self.assertIn('## Claude Summary', call_kwargs['body'])
+        self.assertIn('Implemented the thing.', call_kwargs['body'])
+
+    def test_failure_body_includes_header_and_error_not_summary_heading(self):
+        from unittest.mock import MagicMock
+
+        job = self._job_with_pr()
+        fake_service = MagicMock()
+
+        with patch('core.services.github.service.GitHubService',
+                   return_value=fake_service):
+            Command()._update_pr_body(job, error='Claude reported an error.')
+
+        call_kwargs = fake_service.update_pr_body.call_args[1]
+        self.assertIn('Automated draft PR', call_kwargs['body'])
+        self.assertIn('Run failed', call_kwargs['body'])
+        self.assertIn('Claude reported an error.', call_kwargs['body'])
+        self.assertNotIn('## Claude Summary', call_kwargs['body'])
+
+    def test_no_pr_number_skips_update(self):
+        from unittest.mock import MagicMock
+
+        item = self._item(self.project_a)
+        job = self._job(self.project_a, item=item)  # pr_number left unset
+        fake_service = MagicMock()
+
+        with patch('core.services.github.service.GitHubService',
+                   return_value=fake_service):
+            Command()._update_pr_body(job, summary='Should not be sent.')
+
+        fake_service.update_pr_body.assert_not_called()
+
+    def test_body_update_failure_does_not_raise(self):
+        from unittest.mock import MagicMock
+
+        job = self._job_with_pr()
+        fake_service = MagicMock()
+        fake_service.update_pr_body.side_effect = RuntimeError('API down')
+
+        with patch('core.services.github.service.GitHubService',
+                   return_value=fake_service):
+            Command()._update_pr_body(job, summary='fine')  # must not raise

--- a/core/services/github/client.py
+++ b/core/services/github/client.py
@@ -206,6 +206,38 @@ class GitHubClient:
 
         return self.http.post(path, json=payload)
 
+    def update_pr(
+        self,
+        owner: str,
+        repo: str,
+        number: int,
+        body: Optional[str] = None,
+        title: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """
+        Update an existing pull request (e.g. its body).
+
+        Args:
+            owner: Repository owner
+            repo: Repository name
+            number: PR number
+            body: New PR body (markdown). Omitted if None.
+            title: New PR title. Omitted if None.
+
+        Returns:
+            Updated PR data as dictionary
+        """
+        path = f'/repos/{owner}/{repo}/pulls/{number}'
+        payload = {}
+
+        if body is not None:
+            payload['body'] = body
+
+        if title is not None:
+            payload['title'] = title
+
+        return self.http.patch(path, json=payload)
+
     def list_prs(
         self,
         owner: str,

--- a/core/services/github/service.py
+++ b/core/services/github/service.py
@@ -423,6 +423,49 @@ class GitHubService(IntegrationBase):
 
         return mapping
 
+    def update_pr_body(
+        self,
+        item: Item,
+        *,
+        number: int,
+        body: str,
+        actor=None,
+        user: Optional[User] = None,
+    ) -> None:
+        """
+        Overwrite the body of an existing pull request.
+
+        Used by the Claude queue worker to replace the bootstrap draft-PR body
+        with Claude's run summary once a job finishes, so the PR text is
+        meaningful content (also indexed into Weaviate for RAG) instead of a
+        static placeholder.
+
+        Args:
+            item: Agira item the PR belongs to
+            number: PR number to update
+            body: New PR body (markdown), replaces the existing body entirely
+            actor: User performing the action (optional)
+            user: User whose GitHub PAT should be used (default: global token)
+
+        Raises:
+            IntegrationDisabled: If GitHub is disabled
+            IntegrationNotConfigured: If GitHub is not configured
+            ValueError: If project doesn't have GitHub repo configured
+        """
+        client = self._get_client(user=user)
+        owner, repo = self._get_repo_info(item)
+
+        client.update_pr(owner=owner, repo=repo, number=number, body=body)
+
+        self._log_activity(
+            item=item,
+            verb='github.pr_body_updated',
+            summary=f"Updated GitHub PR #{number} body",
+            actor=actor,
+        )
+
+        logger.info(f"Updated PR #{number} body for item {item.id}")
+
     def sync_mapping(self, mapping: ExternalIssueMapping) -> ExternalIssueMapping:
         """
         Synchronize an ExternalIssueMapping with GitHub.

--- a/core/services/github/test_github.py
+++ b/core/services/github/test_github.py
@@ -286,6 +286,29 @@ class GitHubServiceItemTestCase(TestCase):
         self.assertEqual(mapping.html_url,
                          'https://github.com/testowner/testrepo/pull/7')
 
+    @patch('core.services.github.client.GitHubClient.update_pr')
+    def test_update_pr_body(self, mock_update_pr):
+        """update_pr_body overwrites the PR body via the GitHub client."""
+        mock_update_pr.return_value = {
+            'id': 98765,
+            'number': 7,
+            'state': 'open',
+            'html_url': 'https://github.com/testowner/testrepo/pull/7',
+        }
+
+        self.service.update_pr_body(
+            self.item,
+            number=7,
+            body='## Claude Summary\n\nDid the thing.',
+            actor=self.user,
+        )
+
+        call_kwargs = mock_update_pr.call_args[1]
+        self.assertEqual(call_kwargs['owner'], 'testowner')
+        self.assertEqual(call_kwargs['repo'], 'testrepo')
+        self.assertEqual(call_kwargs['number'], 7)
+        self.assertEqual(call_kwargs['body'], '## Claude Summary\n\nDid the thing.')
+
     @patch('core.services.github.client.GitHubClient.get_issue')
     def test_sync_mapping_updates_state(self, mock_get_issue):
         """Test that sync_mapping updates state from GitHub."""
@@ -694,6 +717,29 @@ class GitHubClientTestCase(TestCase):
         self.assertEqual(headers['Authorization'], 'Bearer test_token_123')
         self.assertEqual(headers['Accept'], 'application/vnd.github+json')
         self.assertEqual(headers['X-GitHub-Api-Version'], '2022-11-28')
+
+    @patch('core.services.integrations.http.httpx.Client')
+    def test_update_pr_sends_patch_with_body(self, mock_client_class):
+        """update_pr PATCHes the pull request endpoint with the new body."""
+        from core.services.github.client import GitHubClient
+
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {'id': 1, 'number': 7}
+
+        mock_client = Mock()
+        mock_client.request.return_value = mock_response
+        mock_client.__enter__ = Mock(return_value=mock_client)
+        mock_client.__exit__ = Mock(return_value=False)
+        mock_client_class.return_value = mock_client
+
+        client = GitHubClient(token='test_token_123')
+        client.update_pr('owner', 'repo', 7, body='new body')
+
+        call_kwargs = mock_client.request.call_args[1]
+        self.assertEqual(call_kwargs['method'], 'PATCH')
+        self.assertTrue(call_kwargs['url'].endswith('/repos/owner/repo/pulls/7'))
+        self.assertEqual(call_kwargs['json'], {'body': 'new body'})
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Automated draft PR opened by the Claude queue worker for Agira item #837.

Model: Sonnet
Job: #4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive GitHub API and worker post-run side effects; failures are isolated and do not alter job status transitions.
> 
> **Overview**
> After each Claude queue job finishes, the worker **replaces** the bootstrap draft PR description with either a **Claude Summary** section (success) or a **Run failed** note (timeout, worker error, CLI error, or missing result event). Updates go through **`GitHubService.update_pr_body`** (same path as PR creation), are **full overwrites** (idempotent on re-runs), and are **best-effort**—API failures are logged but do not change the job’s terminal status.
> 
> **GitHub layer:** `GitHubClient.update_pr` PATCHes `/repos/{owner}/{repo}/pulls/{number}`; `GitHubService.update_pr_body` wires that up and logs `github.pr_body_updated`. Unit tests cover the client, service, and worker `_update_pr_body` behavior (skip when no `pr_number`, success vs failure body shape).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df0e1b3a80ba0ec737c2b5a31644107b95caa175. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->