### PR TITLE
Claude-Queue: CURRENT-STEP-Feld unlesbar (weißer Text auf weißem Hintergrund)

### DIFF
--- a/templates/partials/claude_queue_job_live.html
+++ b/templates/partials/claude_queue_job_live.html
@@ -30,7 +30,7 @@ Expects `job` and `active_statuses` in context.
     {% else %}
     <div class="mb-3">
         <label class="text-muted small text-uppercase">Current step</label>
-        <div class="p-3 bg-light rounded border">
+        <div class="p-3 rounded border">
             {% if job.progress_text %}
             {{ job.progress_text }}
             {% elif job.status == 'queued' %}


### PR DESCRIPTION
Automated draft PR opened by the Claude queue worker for Agira item #838.

Model: Sonnet
Job: #5

---

## Claude Summary

Fixed and committed. The `bg-light` class on the Current Step container conflicted with the page's dark theme (`data-bs-theme="dark"`), producing light-on-light text. Removed it so the box now matches the styling of the other detail fields (Draft PR, Turns, Cost), which never had that class — this fixes contrast in all job statuses without touching the failed-state alert box (unaffected) or other fields.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CSS class removal on a template partial; no logic, auth, or data changes.
> 
> **Overview**
> Fixes unreadable **Current step** text on the Claude queue job live partial when the app uses Bootstrap dark theme (`data-bs-theme="dark"`).
> 
> Removes the `bg-light` class from the current-step container so it uses the same `p-3 rounded border` styling as the Draft PR / Turns / Cost fields. The failed-state danger alert is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81b1e7dba46f83b1363fefce05cadd7808c9f868. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->