### PR TITLE
Claude-Queue: PR-Body strukturieren via PR_BODY_FILE (feste Abschnitte, Weaviate-optimiert) — Folge zu #837

### DIFF
--- a/core/management/commands/run_claude_worker.py
+++ b/core/management/commands/run_claude_worker.py
@@ -48,6 +48,7 @@ import select
 import signal
 import socket
 import subprocess
+import tempfile
 import time
 from pathlib import Path
 
@@ -89,8 +90,24 @@ DEFAULT_INTERVAL_SECONDS = 5
 # timeout itself, so if the job is still "running" its supervisor is gone.
 STALE_BUFFER_SECONDS = 60
 
-# Tools Claude may use in the headless run: read/edit files and drive git.
-ALLOWED_TOOLS = 'Read,Edit,Bash(git*)'
+# Tools Claude may use in the headless run: read/edit files, write the
+# PR_BODY_FILE (which lives outside the checkout, so Edit's "must already
+# exist with matching content" semantics don't fit), and drive git.
+ALLOWED_TOOLS = 'Read,Edit,Write,Bash(git*)'
+
+# Fixed PR body sections Claude must write into PR_BODY_FILE. Literal headings
+# so the resulting PR bodies are uniform and cleanly chunkable for the
+# Weaviate RAG index.
+PR_BODY_FILE_INSTRUCTIONS = (
+    "Schließe deine Arbeit ab, indem du einen PR-Text in die Datei unter "
+    "`$PR_BODY_FILE` schreibst. Verwende GENAU die vorgegebene "
+    "Markdown-Struktur (Überschriften wörtlich: `## Zusammenfassung`, "
+    "`## Änderungen`, `## Warum / Entscheidungen`, `## Test-Hinweise`; keine "
+    "zusätzlichen H2). Nur inhaltlicher PR-Text — kein Prozess-Geplauder, "
+    "keine Commit-Hashes, kein „Committed as\". Nenne unter „## Warum / "
+    "Entscheidungen\" ausdrücklich auch bewusst verworfene Alternativen im "
+    "Format „nicht X, weil Y\"."
+)
 
 
 class Command(BaseCommand):
@@ -236,11 +253,24 @@ class Command(BaseCommand):
         failure (setup, timeout, non-zero exit, ``is_error`` result) drives the
         job to ``failed`` with diagnostics and releases the item so it does not
         starve in ``Working``.
+
+        Claude is asked to write the PR body text into ``PR_BODY_FILE`` — a file
+        outside the checkout (so ``reset --hard``/``clean -fd`` can't touch it
+        and Claude can't accidentally commit it). It is created empty up front
+        and removed again once the job reaches a terminal state.
         """
+        pr_body_file = self._pr_body_file_path(job)
+        self._init_pr_body_file(pr_body_file)
+        try:
+            self._process_job_inner(job, timeout, idle_timeout, pr_body_file)
+        finally:
+            self._cleanup_pr_body_file(pr_body_file)
+
+    def _process_job_inner(self, job, timeout, idle_timeout, pr_body_file):
         try:
             repo_dir = self._prepare_checkout(job)
             branch = self._create_branch_and_pr(job, repo_dir)
-            result = self._run_cli(job, repo_dir, timeout, idle_timeout)
+            result = self._run_cli(job, repo_dir, timeout, idle_timeout, pr_body_file)
         except subprocess.TimeoutExpired:
             error = f"Job exceeded the {timeout}s timeout and was terminated."
             self._fail_job(job, error=error)
@@ -280,7 +310,9 @@ class Command(BaseCommand):
             self.stdout.write(self.style.ERROR(f"Job #{job.pk} failed (no result event)"))
             return
 
-        self._update_pr_body(job, summary=result.get('result_text'))
+        self._update_pr_body(
+            job, summary=result.get('result_text'), pr_body_file=pr_body_file
+        )
         job.transition_to(ClaudeQueueJobStatus.DONE)
         self.stdout.write(self.style.SUCCESS(f"Job #{job.pk} done"))
 
@@ -344,7 +376,7 @@ class Command(BaseCommand):
         payload = {
             'hasTrustDialogAccepted': True,
             'permissions': {
-                'allow': ['Read', 'Edit', 'Bash(git*)'],
+                'allow': ['Read', 'Edit', 'Write', 'Bash(git*)'],
             },
         }
         settings_file.write_text(json.dumps(payload, indent=2))
@@ -470,8 +502,8 @@ class Command(BaseCommand):
             f"Job: #{job.pk}"
         )
 
-    def _update_pr_body(self, job, *, summary=None, error=None):
-        """Replace the draft PR body with Claude's run summary (or a failure note).
+    def _update_pr_body(self, job, *, summary=None, error=None, pr_body_file=None):
+        """Replace the draft PR body with Claude's structured PR text (or a failure note).
 
         Runs through ``GitHubService`` — the same infra that opened the PR — so
         there is no parallel gh path. Idempotent: always overwrites the body
@@ -479,6 +511,10 @@ class Command(BaseCommand):
         a PR body update failure must not affect the job's own terminal status.
         The success body is what gets indexed into Weaviate as RAG context, so
         an empty/generic body here is a real loss, not just a readability nit.
+
+        On success, prefers the fixed-structure text Claude wrote to
+        ``pr_body_file``; falls back to the raw ``result_text`` summary when
+        that file is missing or empty (e.g. an older/uncooperative run).
         """
         if not job.pr_number:
             return
@@ -487,8 +523,12 @@ class Command(BaseCommand):
         if error is not None:
             body = f"{header}\n\n---\n\n**Run failed:** {error.strip()}"
         else:
-            text = (summary or '').strip() or '_No summary provided._'
-            body = f"{header}\n\n---\n\n## Claude Summary\n\n{text}"
+            structured = self._read_pr_body_file(pr_body_file) if pr_body_file else None
+            if structured:
+                body = f"{header}\n\n---\n\n{structured}"
+            else:
+                text = (summary or '').strip() or '_No summary provided._'
+                body = f"{header}\n\n---\n\n## Claude Summary\n\n{text}"
 
         try:
             from core.services.github.service import GitHubService
@@ -496,6 +536,35 @@ class Command(BaseCommand):
             GitHubService().update_pr_body(job.item, number=job.pr_number, body=body)
         except Exception as exc:  # noqa: BLE001 — best-effort, don't fail the job over this
             logger.warning("Failed to update PR #%s body for job #%s: %s", job.pr_number, job.pk, exc)
+
+    # ------------------------------------------------------------------ #
+    # PR_BODY_FILE lifecycle
+    # ------------------------------------------------------------------ #
+    def _pr_body_file_path(self, job):
+        """Path for the per-job PR body file, outside any repo checkout."""
+        return Path(tempfile.gettempdir()) / f"claude-pr-body-{job.pk}.md"
+
+    def _init_pr_body_file(self, path):
+        """Create an empty PR body file before the run so Claude can write to it."""
+        try:
+            path.write_text('')
+        except OSError as exc:
+            logger.warning("Could not create PR body file %s: %s", path, exc)
+
+    def _read_pr_body_file(self, path):
+        """Read the PR body file's stripped content, or ``None`` if missing/empty."""
+        try:
+            content = path.read_text().strip()
+        except OSError:
+            return None
+        return content or None
+
+    def _cleanup_pr_body_file(self, path):
+        """Remove the PR body file after the run; missing file is not an error."""
+        try:
+            path.unlink()
+        except OSError:
+            pass
 
     def _push_branch(self, repo_dir, branch):
         """Push the branch after the Claude run (best-effort)."""
@@ -507,7 +576,7 @@ class Command(BaseCommand):
     # ------------------------------------------------------------------ #
     # Claude Code invocation + stream parsing
     # ------------------------------------------------------------------ #
-    def _run_cli(self, job, repo_dir, timeout, idle_timeout):
+    def _run_cli(self, job, repo_dir, timeout, idle_timeout, pr_body_file):
         """Run Claude Code headless in ``repo_dir`` and parse its event stream.
 
         Returns a result dict with ``session_id``/``num_turns``/
@@ -516,7 +585,7 @@ class Command(BaseCommand):
         wall-clock budget is exhausted.
         """
         args = self._build_claude_args(job)
-        env = self._build_env(job)
+        env = self._build_env(job, pr_body_file)
 
         proc = subprocess.Popen(
             args,
@@ -552,8 +621,12 @@ class Command(BaseCommand):
             '--permission-mode', 'acceptEdits',
         ]
 
-    def _build_env(self, job):
-        env = dict(os.environ, CLAUDE_QUEUE_JOB_ID=str(job.pk))
+    def _build_env(self, job, pr_body_file):
+        env = dict(
+            os.environ,
+            CLAUDE_QUEUE_JOB_ID=str(job.pk),
+            PR_BODY_FILE=str(pr_body_file),
+        )
         api_key = getattr(settings, 'ANTHROPIC_API_KEY', '') or os.environ.get(
             'ANTHROPIC_API_KEY', ''
         )
@@ -572,6 +645,7 @@ class Command(BaseCommand):
             "Implement the change in this repository. Make focused edits and "
             "commit them to the current branch with git. Do not push."
         )
+        parts += ['', PR_BODY_FILE_INSTRUCTIONS]
         return '\n'.join(parts)
 
     def _iter_events(self, proc, timeout, idle_timeout):

--- a/core/management/commands/test_run_claude_worker.py
+++ b/core/management/commands/test_run_claude_worker.py
@@ -12,7 +12,9 @@ plus the timeout / error end-states and crash recovery.
 import json
 import os
 import subprocess
+import tempfile
 from io import StringIO
+from pathlib import Path
 from unittest.mock import patch
 
 from django.test import TestCase
@@ -501,3 +503,164 @@ class UpdatePrBodyTests(ClaudeWorkerTestBase):
         with patch('core.services.github.service.GitHubService',
                    return_value=fake_service):
             Command()._update_pr_body(job, summary='fine')  # must not raise
+
+    def test_prefers_structured_pr_body_file_over_summary(self):
+        from unittest.mock import MagicMock
+
+        job = self._job_with_pr()
+        fake_service = MagicMock()
+        pr_body_file = Path(tempfile.gettempdir()) / 'test-pr-body-structured.md'
+        structured = (
+            "## Zusammenfassung\nDid the thing.\n\n## Änderungen\n"
+            "- `a.py` — changed\n\n## Warum / Entscheidungen\n"
+            "- nicht X, weil Y\n\n## Test-Hinweise\n- ran tests"
+        )
+        pr_body_file.write_text(structured)
+        try:
+            with patch('core.services.github.service.GitHubService',
+                       return_value=fake_service):
+                Command()._update_pr_body(
+                    job, summary='Should be ignored.', pr_body_file=pr_body_file,
+                )
+        finally:
+            pr_body_file.unlink(missing_ok=True)
+
+        call_kwargs = fake_service.update_pr_body.call_args[1]
+        self.assertIn('## Zusammenfassung', call_kwargs['body'])
+        self.assertIn('## Warum / Entscheidungen', call_kwargs['body'])
+        self.assertNotIn('Should be ignored.', call_kwargs['body'])
+        self.assertNotIn('## Claude Summary', call_kwargs['body'])
+
+    def test_falls_back_to_summary_when_pr_body_file_missing(self):
+        from unittest.mock import MagicMock
+
+        job = self._job_with_pr()
+        fake_service = MagicMock()
+        missing_file = Path(tempfile.gettempdir()) / 'test-pr-body-does-not-exist.md'
+
+        with patch('core.services.github.service.GitHubService',
+                   return_value=fake_service):
+            Command()._update_pr_body(
+                job, summary='Fallback summary.', pr_body_file=missing_file,
+            )
+
+        call_kwargs = fake_service.update_pr_body.call_args[1]
+        self.assertIn('## Claude Summary', call_kwargs['body'])
+        self.assertIn('Fallback summary.', call_kwargs['body'])
+
+    def test_falls_back_to_summary_when_pr_body_file_empty(self):
+        from unittest.mock import MagicMock
+
+        job = self._job_with_pr()
+        fake_service = MagicMock()
+        empty_file = Path(tempfile.gettempdir()) / 'test-pr-body-empty.md'
+        empty_file.write_text('   \n')
+        try:
+            with patch('core.services.github.service.GitHubService',
+                       return_value=fake_service):
+                Command()._update_pr_body(
+                    job, summary='Fallback summary.', pr_body_file=empty_file,
+                )
+        finally:
+            empty_file.unlink(missing_ok=True)
+
+        call_kwargs = fake_service.update_pr_body.call_args[1]
+        self.assertIn('## Claude Summary', call_kwargs['body'])
+        self.assertIn('Fallback summary.', call_kwargs['body'])
+
+
+class PrBodyFileLifecycleTests(ClaudeWorkerTestBase):
+    """The worker creates PR_BODY_FILE before the run and removes it afterwards."""
+
+    def _claimed_job(self, project, item_status=ItemStatus.WORKING):
+        item = self._item(project, status=item_status)
+        self._job(project, item=item)
+        return Command().claim_next_job()
+
+    def test_file_created_before_run_and_removed_after(self):
+        job = self._claimed_job(self.project_a)
+        captured = {}
+
+        def fake_run_cli(job, repo_dir, timeout, idle_timeout, pr_body_file):
+            captured['path'] = pr_body_file
+            captured['existed_during_run'] = pr_body_file.exists()
+            return _ok_result()
+
+        with patch.object(Command, '_prepare_checkout', return_value='/tmp/repo'), \
+                patch.object(Command, '_create_branch_and_pr', return_value='fix/x-1'), \
+                patch.object(Command, '_push_branch'), \
+                patch.object(Command, '_run_cli', side_effect=fake_run_cli):
+            Command().process_job(job, timeout=30, idle_timeout=5)
+
+        self.assertTrue(captured['existed_during_run'])
+        self.assertFalse(captured['path'].exists())
+
+    def test_file_removed_after_a_failed_run(self):
+        job = self._claimed_job(self.project_a)
+        captured = {}
+
+        def fake_run_cli(job, repo_dir, timeout, idle_timeout, pr_body_file):
+            captured['path'] = pr_body_file
+            return _ok_result(is_error=True, result_text='exploded')
+
+        with patch.object(Command, '_prepare_checkout', return_value='/tmp/repo'), \
+                patch.object(Command, '_create_branch_and_pr', return_value='fix/x-1'), \
+                patch.object(Command, '_push_branch'), \
+                patch.object(Command, '_run_cli', side_effect=fake_run_cli):
+            Command().process_job(job, timeout=30, idle_timeout=5)
+
+        self.assertFalse(captured['path'].exists())
+
+    def test_structured_body_file_content_flows_into_pr_body(self):
+        from unittest.mock import MagicMock
+
+        job = self._claimed_job(self.project_a)
+        job.pr_number = 42
+        job.save(update_fields=['pr_number'])
+        fake_service = MagicMock()
+
+        def fake_run_cli(job, repo_dir, timeout, idle_timeout, pr_body_file):
+            pr_body_file.write_text(
+                "## Zusammenfassung\nDid it.\n\n## Änderungen\n- `a.py`\n\n"
+                "## Warum / Entscheidungen\n- nicht X, weil Y\n\n"
+                "## Test-Hinweise\n- ran tests"
+            )
+            return _ok_result()
+
+        with patch.object(Command, '_prepare_checkout', return_value='/tmp/repo'), \
+                patch.object(Command, '_create_branch_and_pr', return_value='fix/x-1'), \
+                patch.object(Command, '_push_branch'), \
+                patch.object(Command, '_run_cli', side_effect=fake_run_cli), \
+                patch('core.services.github.service.GitHubService',
+                      return_value=fake_service):
+            Command().process_job(job, timeout=30, idle_timeout=5)
+
+        call_kwargs = fake_service.update_pr_body.call_args[1]
+        self.assertIn('## Zusammenfassung', call_kwargs['body'])
+        self.assertIn('nicht X, weil Y', call_kwargs['body'])
+        self.assertNotIn('## Claude Summary', call_kwargs['body'])
+
+
+class BuildPromptAndEnvTests(ClaudeWorkerTestBase):
+    def test_prompt_includes_pr_body_file_instructions(self):
+        item = self._item(self.project_a)
+        prompt = Command()._build_prompt(item)
+
+        self.assertIn('$PR_BODY_FILE', prompt)
+        self.assertIn('## Zusammenfassung', prompt)
+        self.assertIn('## Änderungen', prompt)
+        self.assertIn('## Warum / Entscheidungen', prompt)
+        self.assertIn('## Test-Hinweise', prompt)
+        self.assertIn('nicht X, weil Y', prompt)
+
+    def test_build_env_sets_pr_body_file(self):
+        job = self._job(self.project_a)
+        pr_body_file = Path(tempfile.gettempdir()) / 'claude-pr-body-test.md'
+
+        env = Command()._build_env(job, pr_body_file)
+
+        self.assertEqual(env['PR_BODY_FILE'], str(pr_body_file))
+
+    def test_allowed_tools_includes_write(self):
+        from core.management.commands.run_claude_worker import ALLOWED_TOOLS
+        self.assertIn('Write', ALLOWED_TOOLS.split(','))


### PR DESCRIPTION
Automated draft PR opened by the Claude queue worker for Agira item #839.

Model: Sonnet
Job: #6

---

## Claude Summary

Committed. Summary of the implementation:

**`core/management/commands/run_claude_worker.py`**
- Added `PR_BODY_FILE_INSTRUCTIONS` (the fixed-structure prompt addendum) and appended it to `_build_prompt`.
- Added `Write` to `ALLOWED_TOOLS` and the checkout's trust settings, since the body file lives outside the repo (Edit's match-existing-content semantics don't fit a freshly-created empty file).
- `process_job` now creates an empty `/tmp/claude-pr-body-<job.pk>.md` before the run (`_pr_body_file_path`/`_init_pr_body_file`), passes it through `_run_cli` → `_build_env` as `PR_BODY_FILE`, and always cleans it up in a `finally` (`_cleanup_pr_body_file`), including on setup failures and timeouts.
- `_update_pr_body` now prefers the file's stripped content (`_read_pr_body_file`) over `result_text` on success; falls back cleanly to the old `## Claude Summary` format if the file is missing/empty. Error-path bodies are untouched (they never read the file), so failed runs can't produce a misleading "success" body.
- Body updates still go exclusively through `GitHubService`.

**`core/management/commands/test_run_claude_worker.py`** — added tests for: structured body preferred over summary, fallback on missing/empty file, file lifecycle (created before run, removed after both success and failure), end-to-end structured content flowing into the PR body, prompt/env wiring, and the `Write` tool being allowed.

Note: this session's sandbox only permits `git*` Bash commands (this job itself runs under the worker's own restricted checkout settings), so I couldn't execute `python manage.py test` to confirm the suite passes — I verified correctness via careful manual diff review instead. You may want to run the test suite in CI/locally to confirm.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the automation path that sets GitHub PR bodies (RAG input) and widens Claude’s tool allowlist with `Write`, though scope stays limited to the worker command and temp files outside the checkout.
> 
> **Overview**
> The Claude queue worker now asks Claude to write the **success** PR description into a per-job temp file (`PR_BODY_FILE` under `/tmp`), outside the repo checkout so `git reset`/`clean` and accidental commits cannot touch it. The prompt adds fixed German H2 sections (`## Zusammenfassung`, `## Änderungen`, `## Warum / Entscheidungen`, `## Test-Hinweise`) so draft PR bodies stay uniform for **Weaviate** indexing.
> 
> **`Write`** is added to allowed tools and checkout trust settings (the empty body file is created before the run and removed in a `finally` after terminal state). `_update_pr_body` prefers that file’s content on success and still falls back to the old `## Claude Summary` from `result_text` when the file is missing or empty; failure paths are unchanged.
> 
> Tests cover file lifecycle, structured-vs-summary preference, fallbacks, prompt/env wiring, and end-to-end body updates via `GitHubService`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 095272678a213015a89ef52a3cb855d3807eee02. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->