### PR TITLE
chore: broaden Claude worker permissions to prefix families + Write/p…

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,12 +1,21 @@
 {
+  "hasTrustDialogAccepted": true,
   "permissions": {
+    "defaultMode": "acceptEdits",
     "allow": [
-      "Bash(python3 -c \"import django; print\\(django.get_version\\(\\)\\)\")",
-      "Bash(python3 manage.py makemigrations core)",
-      "Bash(python3 -m py_compile agira_mcp/server.py agira_mcp/client.py agira_mcp/__init__.py core/views_api.py core/models.py core/admin.py core/migrations/0063_add_user_mcp_token.py)",
-      "Bash(.venv/bin/python -c \"import mcp, httpx; from mcp.server.fastmcp import FastMCP; print\\('mcp + httpx OK'\\)\")",
-      "Bash(agira_mcp/.venv/bin/python -)",
-      "Bash(git fetch *)"
+      "Read",
+      "Edit",
+      "Write",
+      "Bash(git *)",
+      "Bash(gh *)",
+      "Bash(python *)",
+      "Bash(python3 *)",
+      "Bash(*/bin/python *)",
+      "Bash(pip *)",
+      "Bash(*/bin/pip *)",
+      "Bash(pytest *)",
+      "Bash(source *)",
+      "Bash(file *)"
     ]
   }
 }


### PR DESCRIPTION
…ython

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Local IDE/agent config only; no application runtime, auth, or data-path changes.
> 
> **Overview**
> Updates **`.claude/settings.local.json`** so Claude workers run with a wider, pattern-based permission set instead of a handful of one-off Bash commands.
> 
> **Adds** `hasTrustDialogAccepted: true` and sets **`defaultMode` to `acceptEdits`**, so file edits are auto-accepted without per-command prompts.
> 
> **Replaces** narrow allow rules (specific `manage.py` / `py_compile` / MCP import / `git fetch` lines) with **`Read`**, **`Edit`**, **`Write`**, and **`Bash(...)`** globs for common dev tooling (`git`, `gh`, `python`/`pip` in venvs, `pytest`, `source`, `file`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9373b62fc8c16fa62fa01f708df5198f324b6bc2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->