### PR TITLE
github-issue-creation-agent Antwort wird nicht korrekt verarbeitet

### DIFF
--- a/agents/github-issue-creation-agent.yml
+++ b/agents/github-issue-creation-agent.yml
@@ -3,6 +3,7 @@ description: Der Agent ist ein Textumformatierer und -extrapolator, der darauf s
   ist, aus unformatierten Rohtexten verständliche GitHub-Issues zu erstellen.
 provider: Claude
 model: claude-sonnet-5
+max_tokens: 4096
 role: Du bist ein Issue-Formatter. Du bekommst unstrukturierten Rohtext und sollst
   daraus ein umsetzbares GitHub-Issue erzeugen – präzise, deterministisch, ohne Floskeln.
 task: "Formatiere einen unformatierten Rohtext um, damit ein umsetzbares Issue für\

--- a/core/services/agents/agent_service.py
+++ b/core/services/agents/agent_service.py
@@ -155,6 +155,10 @@ class AgentService:
         Supports Redis-based response caching if configured in agent YAML.
         Cache lookup is performed before AI request, and successful responses
         are cached with configured TTL.
+
+        An optional top-level `max_tokens` key in the agent YAML overrides the
+        provider's default output token limit (e.g. Claude defaults to 1024,
+        which can silently truncate longer structured responses like JSON).
         
         Args:
             filename: Agent YAML filename
@@ -182,6 +186,7 @@ class AgentService:
         role = agent.get('role', '')
         task = agent.get('task', '')
         agent_params = agent.get('parameters', {})
+        max_tokens = agent.get('max_tokens')
         
         # Parse cache configuration from agent YAML
         cache_config = self.cache_service.parse_cache_config(agent)
@@ -234,7 +239,8 @@ class AgentService:
                 provider_type=provider_type,
                 user=user,
                 client_ip=client_ip,
-                agent=agent_name
+                agent=agent_name,
+                max_tokens=max_tokens
             )
             
             response_text = response.text

--- a/core/test_open_questions.py
+++ b/core/test_open_questions.py
@@ -282,7 +282,51 @@ class ItemOptimizeWithOpenQuestionsTest(TestCase):
         # Verify no open questions were created
         questions = IssueOpenQuestion.objects.filter(issue=self.item)
         self.assertEqual(questions.count(), 0)
-    
+
+    @patch('core.services.agents.agent_service.AgentService.execute_agent')
+    @patch('core.services.rag.service.RAGPipelineService.build_context')
+    def test_optimize_with_truncated_json_response_is_rejected(self, mock_build_context, mock_execute_agent):
+        """A JSON response cut off mid-generation (e.g. output token limit hit)
+        must not be written verbatim into the description field."""
+        from core.services.rag.models import RAGContext
+        mock_context = RAGContext(
+            query='Test description',
+            alpha=0.5,
+            summary='No context found',
+            items=[],
+            stats={'total_results': 0, 'deduplicated': 0}
+        )
+        mock_build_context.return_value = mock_context
+
+        # Simulate a response truncated mid-JSON (missing closing braces)
+        mock_execute_agent.return_value = (
+            '{\n  "issue": {\n    "description": "# Optimized Description\\n\\n'
+            'This is a long description that got cut off half'
+        )
+
+        # Login as agent
+        self.client.login(username='agent_user', password='testpass123')
+
+        # Get initial description
+        initial_description = self.item.description
+
+        # Call optimization endpoint
+        url = reverse('item-optimize-description-ai', kwargs={'item_id': self.item.id})
+        response = self.client.post(url)
+
+        # Check response - should be a clear error, not a silent success
+        self.assertEqual(response.status_code, 500)
+        data = response.json()
+        self.assertEqual(data['status'], 'error')
+
+        # Verify item description was NOT overwritten with broken JSON
+        self.item.refresh_from_db()
+        self.assertEqual(self.item.description, initial_description)
+
+        # Verify no open questions were created
+        questions = IssueOpenQuestion.objects.filter(issue=self.item)
+        self.assertEqual(questions.count(), 0)
+
     @patch('core.services.agents.agent_service.AgentService.execute_agent')
     @patch('core.services.rag.service.RAGPipelineService.build_context')
     def test_duplicate_questions_not_created(self, mock_build_context, mock_execute_agent):

--- a/core/views.py
+++ b/core/views.py
@@ -2155,8 +2155,18 @@ Context from similar items and related information:
                 optimized_description = cleaned_response
                 open_questions = []
         except json.JSONDecodeError:
-            # Not valid JSON after cleaning
-            # Save cleaned response (code fences removed) as fallback
+            if cleaned_response.startswith('{') or cleaned_response.startswith('['):
+                # Response was clearly meant to be JSON (e.g. an object literal)
+                # but failed to parse - most likely truncated because the
+                # provider's output token limit was hit. Surface this as an
+                # error instead of silently writing the broken JSON/partial
+                # JSON into the description field.
+                raise ValueError(
+                    "AI agent returned malformed JSON (response may have been "
+                    "truncated by the provider's output token limit)"
+                )
+            # Not JSON at all - treat as a plain-text response (backward
+            # compatibility with agents that don't return the JSON envelope)
             optimized_description = cleaned_response
             open_questions = []
         


### PR DESCRIPTION
Automated draft PR opened by the Claude queue worker for Agira item #841.

Model: Sonnet
Job: #8

---

## Claude Summary

The fix is committed. Root cause: the `github-issue-creation-agent` Claude call had no explicit `max_tokens`, so it silently fell back to the provider's 1024-token default — long generated issues got cut off mid-JSON, and the view's fallback parsing then wrote that broken/truncated text straight into the description field.

Changes made (all committed to the current branch, not pushed):
- `agents/github-issue-creation-agent.yml`: added `max_tokens: 4096`
- `core/services/agents/agent_service.py`: wired the previously-unused per-agent config through to the AI router's `max_tokens` param
- `core/views.py`: JSON-looking-but-unparseable responses now raise an error instead of being saved as the description (plain-text fallback responses are untouched)
- `core/test_open_questions.py`: added a regression test for the truncated-JSON case

I wasn't able to run the Django test suite in this sandbox (headless worker mode restricts Bash to `git*` only), so please run `core.test_item_ai_optimize` and `core.test_open_questions` before merging. The PR body has been written to `$PR_BODY_FILE` per the workflow instructions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes AI description optimization behavior (errors vs silent save) and agent token limits; limited scope but affects a user-facing write path on item descriptions.
> 
> **Overview**
> Fixes **github-issue-creation-agent** output being cut off at Claude’s default **1024** `max_tokens`, which produced incomplete JSON that the optimize-description flow then saved as the item description.
> 
> **`max_tokens: 4096`** is set on that agent, and **`AgentService.execute_agent`** now passes optional per-agent **`max_tokens`** through to the AI router (previously ignored in YAML).
> 
> On **`item-optimize-description-ai`**, if the agent reply **looks like JSON** (`{` / `[`) but **`json.loads` fails**, the endpoint **errors** instead of treating the fragment as plain text; non-JSON agent replies still use the existing plain-text fallback.
> 
> A regression test asserts truncated JSON returns **500**, leaves the description unchanged, and does not create open questions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b11123935778ca9a9f6d58e7362875bbb65986e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->