### PR TITLE
rechte Sidebar aus einblenden

### DIFF
--- a/static/css/site.css
+++ b/static/css/site.css
@@ -330,10 +330,18 @@ body {
     z-index: 998;
 }
 
+.right-sidebar--hidden {
+    display: none !important;
+}
+
 /* Adjust main content when right sidebar is visible */
 @media (min-width: 992px) {
     .main-content {
         margin-right: var(--right-sidebar-width);
+    }
+
+    .main-content.right-sidebar-hidden {
+        margin-right: 0;
     }
 }
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -110,9 +110,12 @@
             <a href="{% url 'user-settings' %}" class="btn btn-sm btn-outline-primary me-2">
                 <i class="bi bi-gear"></i> Settings
             </a>
-            <a href="{% url 'logout' %}" class="btn btn-sm btn-outline-secondary">
+            <a href="{% url 'logout' %}" class="btn btn-sm btn-outline-secondary me-2">
                 <i class="bi bi-box-arrow-right"></i> Abmelden
             </a>
+            <button type="button" class="btn btn-sm btn-outline-secondary" id="rightSidebarToggle" aria-label="Rechte Sidebar ein-/ausblenden" title="Rechte Sidebar ein-/ausblenden">
+                <i class="bi bi-layout-sidebar-inset-reverse"></i>
+            </button>
         </div>
         {% endif %}
     </nav>
@@ -324,12 +327,34 @@
             sidebarToggle.addEventListener('click', function() {
                 sidebar.classList.toggle('collapsed');
                 mainContent.classList.toggle('sidebar-collapsed');
-                
+
                 // Save state to localStorage
                 const isCollapsed = sidebar.classList.contains('collapsed');
                 localStorage.setItem('sidebarCollapsed', isCollapsed);
             });
-            
+
+            // Right sidebar (Recents & Pinned) toggle
+            const rightSidebar = document.getElementById('rightSidebar');
+            const rightSidebarToggle = document.getElementById('rightSidebarToggle');
+            const RIGHT_SIDEBAR_STORAGE_KEY = 'agira.sidebar.rightVisible.v1';
+
+            if (rightSidebar && rightSidebarToggle) {
+                const storedRightVisible = localStorage.getItem(RIGHT_SIDEBAR_STORAGE_KEY);
+                const rightVisible = storedRightVisible === null ? true : storedRightVisible === 'true';
+                if (!rightVisible) {
+                    rightSidebar.classList.add('right-sidebar--hidden');
+                    mainContent.classList.add('right-sidebar-hidden');
+                }
+
+                rightSidebarToggle.addEventListener('click', function() {
+                    rightSidebar.classList.toggle('right-sidebar--hidden');
+                    mainContent.classList.toggle('right-sidebar-hidden');
+
+                    const isVisible = !rightSidebar.classList.contains('right-sidebar--hidden');
+                    localStorage.setItem(RIGHT_SIDEBAR_STORAGE_KEY, isVisible);
+                });
+            }
+
             // Handle section collapse chevron rotation
             const collapseElements = document.querySelectorAll('.collapse');
             collapseElements.forEach(function(collapseEl) {


### PR DESCRIPTION
Automated draft PR opened by the Claude queue worker for Agira item #840.

Model: Sonnet
Job: #9

---

## Zusammenfassung

Die rechte Sidebar ("Zuletzt geöffnet & Gepinnt") lässt sich jetzt über einen Button in der Topbar manuell ein- und ausblenden. Der gewählte Zustand wird in `localStorage` gespeichert und beim erneuten Laden der Seite wiederhergestellt.

## Änderungen

- Neuer Toggle-Button `#rightSidebarToggle` in der Topbar (`templates/base.html`), platziert als rechtestes Element im Bereich mit Settings/Abmelden, damit er auch bei ausgeblendeter Sidebar erreichbar bleibt.
- Toggle-Logik als Ergänzung des bestehenden Sidebar-Toggle-Scripts in `base.html`: liest/schreibt den Zustand unter dem neuen Storage-Key `agira.sidebar.rightVisible.v1` und schaltet die Klassen `right-sidebar--hidden` (auf `#rightSidebar`) sowie `right-sidebar-hidden` (auf `.main-content`) um.
- Neue CSS-Regeln in `static/css/site.css`: `.right-sidebar--hidden` blendet die Sidebar per `display: none !important` aus (überschreibt das `d-lg-block` von Bootstrap), `.main-content.right-sidebar-hidden` entfernt den `margin-right` ab dem `lg`-Breakpoint, sodass der Hauptbereich die volle Breite nutzt.
- Fehlt der Storage-Key (Erstbesuch), bleibt die Sidebar sichtbar – bisheriges Verhalten unverändert.

## Warum / Entscheidungen

- Toggle-Logik in das bestehende inline `<script>`-Block in `base.html` integriert statt in `sidebar-recents.js`, weil der analoge Mechanismus für die linke Sidebar (`sidebarToggle`/`sidebarCollapsed`) bereits genau dort liegt – das hält beide Toggle-Mechanismen konsistent am selben Ort. Nicht in `sidebar-recents.js`, weil dieses Modul ausschließlich die Recents/Pinned-Daten verwaltet, nicht die Sidebar-Sichtbarkeit als solche.
- `display: none !important` für `.right-sidebar--hidden`, weil Bootstraps `d-lg-block`-Utility-Klasse ebenfalls `!important` setzt und ab dem `lg`-Breakpoint sonst Vorrang hätte; die spätere Position in der CSS-Kaskade sorgt zusätzlich für den korrekten Sieg im Cascade-Tiebreak.
- Storage-Key `agira.sidebar.rightVisible.v1` nach bestehendem Namensschema (`agira.sidebar.recents.v1`, `agira.sidebar.pinned.v1`) gewählt statt eines neuen Präfixes, um die Konsistenz der Storage-Keys für diese Feature-Familie zu wahren.
- Bestehender Breakpoint-Mechanismus (`d-none d-lg-block`) unangetastet gelassen; der manuelle Toggle wirkt nur additiv über die neue Klasse, nicht durch Ersetzen der Bootstrap-Klassen, damit unterhalb `lg` weiterhin ausgeblendet bleibt, unabhängig vom gespeicherten Zustand.
- Keine Transition/Animation ergänzt, da laut Vorgabe ein direktes Ein-/Ausblenden ausreicht.

## Test-Hinweise

- `python manage.py check` läuft ohne Fehler; `base.html` wurde zusätzlich über den Django-Template-Loader erfolgreich geladen (Syntax-Check).
- Manuell im Browser prüfen (ab `lg`-Breakpoint, eingeloggt):
  - Klick auf den neuen Button in der Topbar blendet die rechte Sidebar aus, `.main-content` nutzt danach die volle Breite ohne Leerraum.
  - Erneuter Klick blendet die Sidebar wieder ein, `margin-right` wird wiederhergestellt.
  - Seite neu laden nach Ausblenden: Sidebar bleibt ausgeblendet (Zustand aus `localStorage` gelesen).
  - `localStorage.getItem('agira.sidebar.rightVisible.v1')` zeigt `"true"`/`"false"` entsprechend dem letzten Klick.
  - Unterhalb `lg`-Breakpoint bleibt die Sidebar wie bisher ausgeblendet, unabhängig vom gespeicherten Toggle-Zustand.
  - Pin/Unpin/Remove-Funktionalität der Recents/Pinned-Liste weiterhin unverändert nutzbar.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-only layout and localStorage changes in the base template; no auth, API, or data handling impact.
> 
> **Overview**
> Adds a **topbar control** so authenticated users can show or hide the right sidebar (Recents & Pinned) on large viewports.
> 
> Clicking `#rightSidebarToggle` toggles `right-sidebar--hidden` on `#rightSidebar` and `right-sidebar-hidden` on `.main-content`. **CSS** hides the panel with `display: none !important` (to win over Bootstrap `d-lg-block`) and clears the desktop `margin-right` on main content when hidden. Preference is stored in `localStorage` under `agira.sidebar.rightVisible.v1` (default visible when unset), mirroring the existing left sidebar toggle pattern in `base.html`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28550dc9f317b2540b44d093de987ae4dbd8cfe1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->