### PR TITLE
Claude-Queue: CURRENT-STEP als Markdown rendern (vorhandener Viewer, kein LLM)

### DIFF
--- a/templates/partials/claude_queue_job_live.html
+++ b/templates/partials/claude_queue_job_live.html
@@ -1,3 +1,4 @@
+{% load agira_filters %}
 {% comment %}
 Live status block for the job detail page. Polls itself every few seconds while
 the job is active; stops once the job settles. Shows the current step while
@@ -32,7 +33,7 @@ Expects `job` and `active_statuses` in context.
         <label class="text-muted small text-uppercase">Current step</label>
         <div class="p-3 rounded border">
             {% if job.progress_text %}
-            {{ job.progress_text }}
+            <div class="markdown-viewer">{{ job.progress_text|render_markdown }}</div>
             {% elif job.status == 'queued' %}
             <span class="text-muted">Waiting in queue…</span>
             {% else %}

--- a/templates/partials/claude_queue_job_row.html
+++ b/templates/partials/claude_queue_job_row.html
@@ -1,3 +1,4 @@
+{% load agira_filters %}
 {% comment %}
 One table row for a ClaudeQueueJob. While the job is still active it carries
 HTMX polling attributes and refreshes itself every few seconds; once it reaches
@@ -25,7 +26,7 @@ Expects `job` and `active_statuses` in context.
             <i class="bi bi-exclamation-triangle"></i> {{ job.error_text|truncatechars:80 }}
         </span>
         {% elif job.progress_text %}
-        <span class="text-muted">{{ job.progress_text|truncatechars:80 }}</span>
+        <span class="text-muted">{{ job.progress_text|render_markdown|striptags|truncatechars:80 }}</span>
         {% else %}
         <span class="text-muted">—</span>
         {% endif %}


### PR DESCRIPTION
Automated draft PR opened by the Claude queue worker for Agira item #842.

Model: Sonnet
Job: #10

---

## Zusammenfassung

Das CURRENT-STEP-Feld (`progress_text`) in der Claude-Queue-View wird jetzt als Markdown gerendert statt als Rohtext ausgegeben — in der Detail-Ansicht gegliedert mit Überschriften, Listen und Code-Spans, in der Listen-Vorschau als sauberer Einzeiler ohne Markdown-Syntax-Reste.

## Änderungen

- `templates/partials/claude_queue_job_live.html`: `progress_text` wird über Agiras bestehenden `render_markdown`-Filter (inkl. Bleach-Sanitizing) in einem `.markdown-viewer`-Container ausgegeben statt als reiner Text.
- `templates/partials/claude_queue_job_row.html`: Die gekürzte Vorschau in der Listen-Spalte läuft zusätzlich durch Djangos eingebauten `striptags`-Filter, bevor sie auf 80 Zeichen gekürzt wird — dadurch verschwinden Markdown-Marker (`**`, `` ` ``, `#`, `-`) aus dem Einzeiler, ohne dass ein neuer Renderer nötig war.
- Beide Partials laden `agira_filters` neu (`{% load agira_filters %}`), da Template-Filter pro eingebundenem Partial geladen werden müssen.

## Warum / Entscheidungen

- Wiederverwendung des vorhandenen `render_markdown`-Filters (`core/templatetags/agira_filters.py`, sanitisiert über `core/utils/html_sanitization.py`) statt eines neuen Renderers, weil Agira diesen Filter bereits für Item-Beschreibungen, Kommentare und Blueprints einsetzt und damit Konsistenz und Sicherheit (Bleach-Whitelist) garantiert sind.
- Nicht die Listen-Vorschau ebenfalls voll als HTML gerendert, weil in der schmalen Tabellenspalte halb abgeschnittenes HTML (z. B. ein offen gelassenes `<ul>` oder `<strong>`) optisch bricht; stattdessen `render_markdown` + `striptags` kombiniert, um reinen, lesbaren Text ohne Markdown-Müll zu erhalten — kein zusätzlicher „Markdown-Strip"-Filter nötig, da die Kombination aus vorhandenen Bausteinen ausreicht.
- Kein LLM (Haiku o. ä.) im Anzeigepfad, weil das den von Claude berichteten Text umformulieren/kürzen und damit inhaltlich verfälschen würde — auch mit Blick auf eine mögliche Weaviate-Indizierung muss der angezeigte Text exakt dem Original entsprechen. Reines Markdown-Rendering verändert nur die Darstellung, nicht den Inhalt.
- Kein rohes `{% autoescape off %}` oder direktes `mark_safe` auf dem Nutzertext, weil `progress_text` maschinengeneriert, aber freier Text aus Claudes Output ist; der bestehende sanitisierende Filter verhindert XSS, ein rohes Durchreichen von HTML wäre ein unnötiges Risiko.

## Test-Hinweise

- `core/test_claude_queue_views.py` (14 Tests) läuft unverändert grün durch, da die dort verwendeten `progress_text`-Werte reiner Text ohne Markdown-Syntax sind und nach Rendering/Sanitizing textlich identisch bleiben.
- Manuell verifiziert: `progress_text` mit `**fett**`, Codeblock und Liste ergibt in der Detail-Ansicht formatiertes HTML (`<strong>`, `<code>`, `<ul><li>`), in der Listen-Vorschau einen reinen Text-Einzeiler ohne Markdown-Marker.
- Sicherheitscheck: eingebettete `<script>`- und `onerror`-Payloads im `progress_text` werden vom bestehenden Bleach-Sanitizing in `render_markdown` entfernt, bevor `striptags` bzw. die Anzeige greift.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only template changes reusing the existing Bleach-sanitized markdown filter; no auth, data, or queue worker logic touched.
> 
> **Overview**
> Claude queue **current step** (`progress_text`) is no longer shown as plain text. The job detail live partial renders it through the existing **`render_markdown`** filter inside a **`.markdown-viewer`** wrapper so headings, lists, and code format like other Agira markdown surfaces.
> 
> The list row preview still truncates to 80 characters but now runs **`render_markdown` → `striptags` → `truncatechars`** so the column stays a single plain line without leftover `**`, backticks, or list markers. Both partials **`{% load agira_filters %}`** so the filter is available when included.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 628f98f0e33a40fb72205bef759f8b7d98f144dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->