### PR TITLE
Titel-Autogenerierung schlägt fehl: Agent 'text-to-title-generator.yml' nicht gefunden

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -226,6 +226,7 @@ agents/*
 !agents/chat-summary-agent.yml
 !agents/coding-answer-agent.yml
 !agents/model-classifier-agent.yml
+!agents/text-to-title-generator.yml
 *.yml.env
 db.sqlite3
 test_db.sqlite3

--- a/agents/text-to-title-generator.yml
+++ b/agents/text-to-title-generator.yml
@@ -1,0 +1,14 @@
+name: text-to-title-generator
+description: Ein Agent, der einen passenden Titel oder Überschrift für einen gegebenen
+  Text generiert.
+provider: openai
+model: gpt-5-mini
+role: Dieser Agent analysiert den gegebenen Text und generiert daraus einen passenden,
+  aussagekräftigen Titel oder Überschrift.
+task: 'Analysieren Sie den gesamten gegebenen Text. Identifizieren Sie die Hauptpunkte
+  und das allgemeine Thema des Textes. Erzeugen Sie auf der Grundlage dieser Informationen
+  einen einzigartigen und aussagekräftigen Titel oder Überschrift, der den Inhalt
+  des Textes gut repräsentiert. Der Titel sollte prägnant sein und weniger als 15
+  Wörter enthalten. Vermeiden Sie generische Titel und versuchen Sie, die Einzigartigkeit
+  und Spezifität des Textinhalts hervorzuheben. geben nur einen Titel aus, der Deiner
+  Meinung nach am besten passt. Keine Auswahl, und keine Erklärungen. '

--- a/core/services/agents/test_agent_service.py
+++ b/core/services/agents/test_agent_service.py
@@ -323,9 +323,39 @@ class AgentServiceTestCase(TestCase):
         self.assertFalse(loaded_agent['cache']['enabled'])
 
 
+class AgentServiceRealAgentsDirTestCase(TestCase):
+    """
+    Regression tests against the real agents/ directory (not a temp dir).
+
+    These guard against agent YAML files that exist on disk but are missing
+    from the .gitignore allowlist (agents/* is ignored by default; each file
+    needs an explicit `!agents/<file>.yml` entry) or from the repo entirely.
+    """
+
+    def test_text_to_title_generator_agent_is_loadable(self):
+        """text-to-title-generator.yml must exist and load (regression for AGIRA-1PD)."""
+        agent_service = AgentService()
+        agent = agent_service.get_agent('text-to-title-generator.yml')
+        self.assertIsNotNone(agent, "Agent 'text-to-title-generator.yml' not found")
+        self.assertEqual(agent.get('name'), 'text-to-title-generator')
+        self.assertTrue(agent.get('role'))
+        self.assertTrue(agent.get('task'))
+
+    def test_text_to_title_generator_agent_is_tracked_by_git(self):
+        """The agent file must not be silently excluded by the agents/* gitignore rule."""
+        gitignore_path = Path(settings.BASE_DIR) / '.gitignore'
+        gitignore_content = gitignore_path.read_text(encoding='utf-8')
+        self.assertIn(
+            '!agents/text-to-title-generator.yml',
+            gitignore_content,
+            "agents/text-to-title-generator.yml is excluded by 'agents/*' and needs "
+            "an explicit allowlist entry in .gitignore or it will be missing after deployment",
+        )
+
+
 class AgentServiceCacheIntegrationTestCase(TestCase):
     """Integration tests for AgentService with cache functionality."""
-    
+
     def setUp(self):
         """Set up test fixtures."""
         # Create a temporary directory for test agents


### PR DESCRIPTION
Automated draft PR opened by the Claude queue worker for Agira item #846.

Model: Sonnet
Job: #13

---

## Zusammenfassung

- Beim Anlegen eines Items schlug die Titel-Autogenerierung mit „Agent 'text-to-title-generator.yml' not found" fehl.
- Ursache: Die Agent-Definition existierte weder im `agents/`-Verzeichnis noch im Repo. `AgentService` (`core/services/agents/agent_service.py`) sucht korrekt unter `BASE_DIR/agents/<filename>.yml` – der Suchpfad war nicht das Problem, die Datei fehlte schlicht.
- Zusätzliche, nicht auf den ersten Blick sichtbare Ursache: `agents/*` ist standardmäßig in `.gitignore` ausgeschlossen und jede Agent-Datei braucht einen expliziten `!agents/<datei>.yml`-Eintrag, um überhaupt versioniert/deployt zu werden. Für `text-to-title-generator.yml` fehlte dieser Eintrag, d. h. selbst eine lokal wiederhergestellte Datei wäre beim nächsten Deployment erneut verschwunden.

## Änderungen

- `agents/text-to-title-generator.yml`: neu angelegt, mit exakt der im Ticket vorgegebenen Konfiguration (Name, Beschreibung, Provider `openai`, Modell `gpt-5-mini`, Rolle, Task).
- `.gitignore`: `!agents/text-to-title-generator.yml`-Ausnahme ergänzt, damit die Datei tatsächlich getrackt und deployt wird.
- `core/services/agents/test_agent_service.py`: neue Testklasse `AgentServiceRealAgentsDirTestCase`, die gegen das echte `agents/`-Verzeichnis (nicht ein Temp-Verzeichnis) prüft, dass `text-to-title-generator.yml` ladbar ist und nicht erneut durch die `agents/*`-Gitignore-Regel verschluckt wird.

## Warum / Entscheidungen

- Nicht den Suchpfad in `AgentService` geändert, weil er bereits korrekt auf `BASE_DIR/agents/` zeigt und alle anderen Agenten dort zuverlässig gefunden werden – das eigentliche Problem war die fehlende Datei samt fehlendem Gitignore-Eintrag, nicht der Code.
- Nicht nur die YAML-Datei angelegt, ohne die Gitignore-Ausnahme zu ergänzen, weil das Problem sonst beim nächsten Deployment/Checkout in einer sauberen Umgebung identisch wieder auftreten würde (die Datei wäre lokal sichtbar, aber nie committet).
- Nicht den vorgeschlagenen Soft-Fail-Fallback ("Item ohne Auto-Titel anlegen, nur Hinweis loggen") zusätzlich implementiert, weil `_auto_generate_title_from_description` (core/views.py) das bereits tut: Exceptions werden abgefangen, geloggt und ein leerer Titel zurückgegeben, ohne die Item-Anlage zu blockieren. Der von Sentry gemeldete Fehlertext stammt exakt aus diesem bestehenden Logging-Pfad. Der einzige Endpunkt, der den Fehler als HTTP 500 mit Klartext-Meldung durchreicht, ist `ai_generate_title` – der manuelle „Titel generieren"-Button, der ohnehin nur einen Toast anzeigt und die Item-Anlage nicht blockiert; hier zusätzliche Fallback-Logik einzuführen wäre für dieses Ticket unnötiger Scope, da die Wurzelursache (fehlende Agent-Datei) behoben ist.
- Nicht versucht, generell alle Agent-Dateien gegen das Gitignore-Allowlist-Muster zu validieren (z. B. per Management-Command oder CI-Check), weil das über den gemeldeten Einzelfall hinausgeht und eine größere, separat zu entscheidende Änderung wäre.

## Test-Hinweise

- Neuer Test: `python manage.py test core.services.agents.test_agent_service.AgentServiceRealAgentsDirTestCase` (prüft Ladbarkeit der Agent-Datei sowie die Gitignore-Ausnahme). Konnte in dieser Umgebung nicht ausgeführt werden, da hier kein Django-Interpreter/venv installiert ist – bitte vor Merge in einer Umgebung mit installierten Abhängigkeiten laufen lassen.
- Manuell verifiziert: `agents/text-to-title-generator.yml` parst fehlerfrei mit `yaml.safe_load` und enthält exakt die im Ticket vorgegebenen Felder.
- Manuell verifiziert: `git status` zeigt die neue Datei jetzt als hinzufügbar an (vorher wurde sie von der `agents/*`-Gitignore-Regel stillschweigend ignoriert).
- Empfohlener manueller Test nach Deploy: neues Item unter `/items/new/` mit Beschreibung anlegen bzw. den „Titel generieren"-Button nutzen und prüfen, dass ein Titel erzeugt wird statt eines Fehler-Toasts.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a new agent config and tests only; no changes to auth, data handling, or `AgentService` lookup logic.
> 
> **Overview**
> Fixes **title auto-generation** failing with “Agent `text-to-title-generator.yml` not found” by adding the missing agent definition and ensuring it is versioned and deployed.
> 
> Adds **`agents/text-to-title-generator.yml`** (OpenAI `gpt-5-mini`, German role/task for a single concise title from input text). Extends **`.gitignore`** with `!agents/text-to-title-generator.yml` so the file is not dropped by the blanket `agents/*` ignore rule.
> 
> Adds **`AgentServiceRealAgentsDirTestCase`** regression tests against the real `agents/` tree: the agent loads via `AgentService.get_agent` and the gitignore allowlist entry is present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 961f89c7eb6ffb56a1fa91424f539a6c9c1fc908. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->