### PR TITLE
GitHub Webhook überprüfen "closed + merged: true reagieren und den Rest freundlich ignorieren"

### DIFF
--- a/core/test_github_pr_webhook.py
+++ b/core/test_github_pr_webhook.py
@@ -32,6 +32,7 @@ def pr_payload(*, action='closed', number=42, github_id=9001, merged=True, state
         'id': github_id,
         'number': number,
         'state': state,
+        'merged': merged,
         'html_url': f'https://github.com/testowner/testrepo/pull/{number}',
     }
     if merged:
@@ -123,15 +124,65 @@ class GitHubPRWebhookTestCase(TestCase):
         self.item.refresh_from_db()
         self.assertEqual(self.item.status, ItemStatus.TESTING)
 
-    def test_closed_unmerged_pr_does_not_change_item_status(self):
+    def test_closed_unmerged_pr_is_ignored(self):
         response = self._post(pr_payload(merged=False, state='closed'))
         self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.json()['ignored'])
 
         self.item.refresh_from_db()
         self.assertEqual(self.item.status, ItemStatus.WORKING)
 
         self.mapping.refresh_from_db()
-        self.assertEqual(self.mapping.state, 'closed')
+        self.assertEqual(self.mapping.state, 'open')
+
+        self.job.refresh_from_db()
+        self.assertFalse(self.job.pr_state)
+
+    def test_opened_action_is_ignored(self):
+        response = self._post(pr_payload(action='opened', merged=False, state='open'))
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.json()['ignored'])
+
+        self.item.refresh_from_db()
+        self.assertEqual(self.item.status, ItemStatus.WORKING)
+
+        self.mapping.refresh_from_db()
+        self.assertEqual(self.mapping.state, 'open')
+
+    def test_synchronize_action_is_ignored(self):
+        response = self._post(pr_payload(action='synchronize', merged=False, state='open'))
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.json()['ignored'])
+
+        self.item.refresh_from_db()
+        self.assertEqual(self.item.status, ItemStatus.WORKING)
+
+        self.mapping.refresh_from_db()
+        self.assertEqual(self.mapping.state, 'open')
+
+    def test_labeled_action_is_ignored(self):
+        response = self._post(pr_payload(action='labeled', merged=False, state='open'))
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.json()['ignored'])
+
+        self.item.refresh_from_db()
+        self.assertEqual(self.item.status, ItemStatus.WORKING)
+
+    def test_ready_for_review_action_is_ignored(self):
+        response = self._post(pr_payload(action='ready_for_review', merged=False, state='open'))
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.json()['ignored'])
+
+        self.item.refresh_from_db()
+        self.assertEqual(self.item.status, ItemStatus.WORKING)
+
+    def test_unknown_action_is_ignored(self):
+        response = self._post(pr_payload(action='review_requested', merged=False, state='open'))
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.json()['ignored'])
+
+        self.item.refresh_from_db()
+        self.assertEqual(self.item.status, ItemStatus.WORKING)
 
     def test_unmatched_github_id_is_ignored(self):
         response = self._post(pr_payload(github_id=99999999))

--- a/core/views_webhooks.py
+++ b/core/views_webhooks.py
@@ -49,9 +49,21 @@ def github_pull_request_webhook(request):
     except (ValueError, TypeError):
         return HttpResponseBadRequest("Invalid JSON")
 
+    action = payload.get('action')
     pull_request_data = payload.get('pull_request')
     if not pull_request_data:
         return HttpResponseBadRequest("Missing pull_request payload")
+
+    # GitHub fires `pull_request` for many actions (opened, synchronize,
+    # labeled, ready_for_review, closed-without-merge, ...). Only a merge
+    # is business-relevant here; everything else is acked and dropped so it
+    # can't touch item status or mapping/job state.
+    if action != 'closed' or not pull_request_data.get('merged'):
+        logger.info(
+            f"Ignoring GitHub pull_request webhook: action={action!r}, "
+            f"merged={pull_request_data.get('merged')!r}"
+        )
+        return JsonResponse({'ignored': True, 'event': event, 'action': action})
 
     result = GitHubService().apply_pr_webhook_event(pull_request_data)
     return JsonResponse(result)


### PR DESCRIPTION
Automated draft PR opened by the Claude queue worker for Agira item #847.

Model: Sonnet
Job: #14

---

## Zusammenfassung

Der GitHub-`pull_request`-Webhook-Handler verarbeitet fachlich nur noch Merge-Events (`action=closed` und `pull_request.merged=true`). Alle anderen `pull_request`-Actions werden mit HTTP 200 bestätigt, ohne Item-Status, Mapping- oder Job-Zustand zu verändern.

## Änderungen

- `core/views_webhooks.py`: Vor dem Aufruf von `GitHubService().apply_pr_webhook_event()` wird jetzt geprüft, ob `action == 'closed'` und `pull_request.merged` wahr ist. Trifft das nicht zu, wird der Request geloggt und mit `{'ignored': True, 'event': event, 'action': action}` (HTTP 200) beantwortet, ohne die Service-Schicht überhaupt anzufassen.
- `core/test_github_pr_webhook.py`: Test-Helper `pr_payload()` setzt jetzt zusätzlich das reale GitHub-Feld `pull_request.merged` (Boolean), nicht nur `merged_at`. Bestehender Test für "closed + unmerged" umbenannt/angepasst (`test_closed_unmerged_pr_is_ignored`) auf das neue Ignorier-Verhalten (Mapping/Job bleiben unverändert). Neue Tests für `opened`, `synchronize`, `labeled`, `ready_for_review` und eine unbekannte Action, alle erwarten 200 + `ignored: true` ohne Seiteneffekte.

## Warum / Entscheidungen

- Filterung im View statt im Service platziert, weil die Signatur-/Event-Prüfung dort schon existiert und die Service-Methode (`apply_pr_webhook_event`) bewusst generisch bleibt (wird z. B. auch von manuellen Syncs mit anderen Datenquellen genutzt) — nicht die Service-Methode selbst mit einer Action-Prüfung verschmutzen, weil sie kein Wissen über den Webhook-`action`-Wert haben soll.
- Geprüft wird `pull_request.merged` (Boolean), nicht `merged_at` (Timestamp), weil die Aufgabenstellung explizit dieses Feld nennt und es im echten GitHub-Payload zuverlässig vorhanden ist; `_map_state()` in der Service-Schicht bleibt unverändert und nutzt weiterhin `merged_at`, da sie auch von der REST-API-Synchronisation (`sync_item`) verwendet wird und dort nicht angefasst werden sollte.
- Bestehendes "ignored"-Response-Format (`{'ignored': True, 'event': ...}`) wiederverwendet statt eines neuen Formats, nur um `'action'` ergänzt, damit Konsumenten/Logs nachvollziehen können, welche Action ignoriert wurde.
- Bewusst kein Whitelisting einzelner PR-Actions (z. B. Liste erlaubter Actions), sondern ein Blacklist-artiger früher Return für alles außer dem Merge-Fall — nicht eine Action-Liste pflegen, weil GitHub jederzeit neue Actions einführen kann und die Anforderung ohnehin "nur Merge verarbeiten, Rest ignorieren" lautet, nicht "bestimmte Actions verarbeiten".
- Der bisherige Test für `closed + merged=false` erwartete noch eine Mapping-Aktualisierung auf `state='closed'`; das widersprach der neuen Anforderung ("Ignorierte Events verändern keinen Merge-Zustand fälschlich") und wurde daher angepasst statt parallel zwei sich widersprechende Verhalten zu unterstützen.

## Test-Hinweise

- `python manage.py test core.test_github_pr_webhook -v 2` — alle 13 Tests grün, darunter:
  - `action=closed` + `merged=true` → wird normal verarbeitet (Item Working→Testing, Mapping/Job auf `merged`).
  - `action=closed` + `merged=false` → 200, `ignored=true`, Item/Mapping/Job unverändert.
  - `action=opened`, `synchronize`, `labeled`, `ready_for_review`, unbekannte Action → jeweils 200, `ignored=true`, keine Statusänderung.
  - Erneute Zustellung desselben Merge-Events bleibt idempotent (Item bleibt in `Testing`).
- Keine weiteren Aufrufer von `apply_pr_webhook_event`/`github_pull_request_webhook` im Code gefunden, die von der neuen Filterung betroffen wären.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which webhook payloads mutate item and external-issue state; the narrower gate reduces accidental updates from non-merge events but misclassification could still skip or mishandle merges.
> 
> **Overview**
> **GitHub `pull_request` webhooks** now drive item/mapping/job updates **only** when `action` is `closed` and `pull_request.merged` is true. Every other action (opened, synchronize, labeled, closed-without-merge, etc.) gets HTTP 200 with `ignored: true` and an `action` field, **without** calling `GitHubService().apply_pr_webhook_event()`.
> 
> This replaces prior behavior where a **closed but unmerged** PR could still update mapping state. Ignored deliveries no longer change item status, mapping `state`, or job `pr_state`.
> 
> Tests were extended: `pr_payload()` includes the real `merged` boolean, the unmerged-close case asserts full no-op, and several non-merge actions are covered.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a347521a9f6ffd75f5e0397280a3a63730ca4eb0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->