### PR TITLE
AI-Description-Optimierung: fehlende Robustheit bei fehlerhafter/leerer LLM-Antwort

### DIFF
--- a/agents/github-issue-creation-agent.yml
+++ b/agents/github-issue-creation-agent.yml
@@ -1,31 +1,12 @@
 name: github-issue-creation-agent
-description: Der Agent ist ein Textumformatierer und -extrapolator, der darauf spezialisiert
-  ist, aus unformatierten Rohtexten verständliche GitHub-Issues zu erstellen.
+description: Der Agent ist ein Textumformatierer und -extrapolator, der darauf spezialisiert ist, aus unformatierten Rohtexten verständliche GitHub-Issues zu erstellen.
 provider: Claude
 model: claude-sonnet-5
-max_tokens: 4096
-role: Du bist ein Issue-Formatter. Du bekommst unstrukturierten Rohtext und sollst
-  daraus ein umsetzbares GitHub-Issue erzeugen – präzise, deterministisch, ohne Floskeln.
-task: "Formatiere einen unformatierten Rohtext um, damit ein umsetzbares Issue für\
-  \ GitHub entsteht. Zielperson: GitHub Copilot Agent (maschinelle Ausführung). Optimiere\
-  \ den Text daher so, das er gut für eine Maschine verständlich ist. Ergänze fehlende\
-  \ Details nur kontextbezogen. Keine kontextfremden Neuerungen. Wenn Infos fehlen,\
-  \ explizit als „Offene Fragen/Unklar“ ausgeben. Github Copilot hat den kompletten\
-  \ Source Code und Zugriff auf alle Dokumentation (die Du hier nicht hast). Stelle\
-  \ daher keine Fragen, die sich i.d.R. aus dem Projektkontext ohnehin ergeben. Stelle\
-  \ nur dann offene Fragen, wenn die Umsetzung ohne diese Information nicht möglich\
-  \ wäre.\r\nWenn Du im Context den Du mit dazu bekommen hast explicit hinweise auf\
-  \ GutHub Issues findest die eine Anhängigkeit oder Verwandt/Ähnlich sind, dann nehme\
-  \ diese Issue mit auf in \"Ähnliche Aufgaben\" und füge einen unbedingt die Issue\
-  \ ID mit dem dem Präfix \"#\" hinzu (z.B. #230) mit hinzu. Wenn es sich um einen\
-  \ Task aus unserem lokalen bestand handelt, füge einen Link zu dem Task hin. Primäre\
-  \ soll aber auf die GitHub issues verwiesen werden, da Copilot keine Zugriff auf\
-  \ unsere Items hat. Füge maximal 6 Referenzen in das Issue ein, aufsteigend nach\
-  \ Relevanz.\r\n\r\nAntworte immer im folgenden JSON Format:\r\n```JSON\r\n{\r\n\
-  \  \"issue\": {\r\n    \"description\": \"Vollständiger Issue-Text (Markdown)\"\r\
-  \n  },\r\n  \"open_questions\": [\r\n    \"Was soll passieren, wenn Feld X leer\
-  \ ist?\",\r\n    \"Darf Objekt Y gelöscht werden, wenn untergeordnete Elemente existieren?\"\
-  \r\n  ]\r\n}\r\n```"
+max_tokens: 8192
+role: Du bist ein Issue-Formatter. Du bekommst unstrukturierten Rohtext und sollst daraus ein umsetzbares GitHub-Issue erzeugen – präzise, deterministisch, ohne Floskeln.
+task: "Formatiere einen unformatierten Rohtext um, damit ein umsetzbares Issue für GitHub entsteht. Zielperson: GitHub Copilot Agent (maschinelle Ausführung). Optimiere den Text daher so, das er gut für eine Maschine verständlich ist. Ergänze fehlende Details nur kontextbezogen. Keine kontextfremden Neuerungen. Wenn Infos fehlen, explizit als „Offene Fragen/Unklar“ ausgeben. Github Copilot hat den kompletten Source Code und Zugriff auf alle Dokumentation (die Du hier nicht hast). Stelle daher keine Fragen, die sich i.d.R. aus dem Projektkontext ohnehin ergeben. Stelle nur dann offene Fragen, wenn die Umsetzung ohne diese Information nicht möglich wäre.\r\nWenn Du im Context den Du mit dazu bekommen hast explicit hinweise auf GutHub Issues findest die eine Anhängigkeit oder Verwandt/Ähnlich sind, dann nehme diese Issue mit auf in \"Ähnliche Aufgaben\" und füge einen unbedingt die Issue ID mit dem dem Präfix \"#\" hinzu (z.B. #230) mit hinzu. Wenn es sich um einen Task aus unserem lokalen\
+  \ bestand handelt, füge einen Link zu dem Task hin. Primäre soll aber auf die GitHub issues verwiesen werden, da Copilot keine Zugriff auf unsere Items hat. Füge maximal 6 Referenzen in das Issue ein, aufsteigend nach Relevanz.\r\n\r\nAntworte immer im folgenden JSON Format:\r\n```JSON\r\n{\r\n  \"issue\": {\r\n    \"description\": \"Vollständiger Issue-Text (Markdown)\"\r\n  },\r\n  \"open_questions\": [\r\n    \"Was soll passieren, wenn Feld X leer ist?\",\r\n    \"Darf Objekt Y gelöscht werden, wenn untergeordnete Elemente existieren?\"\r\n  ]\r\n}\r\n```\n\nWICHTIG - Antwortformat: Antworte AUSSCHLIESSLICH mit dem oben gezeigten JSON-Objekt. Kein Text davor oder danach, keine Markdown-Codeblock-Fences (```), keine Erklärungen. Die Antwort muss direkt mit \"{\" beginnen und mit \"}\" enden und syntaktisch vollständig valides JSON sein (alle Klammern und Anführungszeichen korrekt geschlossen). Falls der vollständige Issue-Text zu lang würde, kürze den Inhalt von \"description\" so, dass\
+  \ die JSON-Antwort in jedem Fall vollständig und valide bleibt - liefere niemals eine mitten im JSON abgeschnittene Antwort. Das Feld \"description\" darf niemals leer sein."
 cache:
   enabled: true
   ttl_seconds: 120

--- a/core/services/exceptions.py
+++ b/core/services/exceptions.py
@@ -24,8 +24,21 @@ class ServiceNotConfigured(ServiceError):
 class ServiceDisabled(ServiceError):
     """
     Raised when attempting to use a service that is explicitly disabled.
-    
+
     Example:
         If Weaviate integration is disabled in the configuration.
+    """
+    pass
+
+
+class AIResponseFormatError(ServiceError):
+    """
+    Raised when an AI agent's response cannot be turned into usable output,
+    e.g. it is empty or the JSON is malformed/truncated.
+
+    This represents an expected, recoverable upstream hiccup (bad or
+    incomplete LLM output) rather than a bug in Agira itself, so callers
+    should surface it as a clear, actionable message instead of a generic
+    server error.
     """
     pass

--- a/core/test_open_questions.py
+++ b/core/test_open_questions.py
@@ -314,12 +314,63 @@ class ItemOptimizeWithOpenQuestionsTest(TestCase):
         url = reverse('item-optimize-description-ai', kwargs={'item_id': self.item.id})
         response = self.client.post(url)
 
-        # Check response - should be a clear error, not a silent success
-        self.assertEqual(response.status_code, 500)
+        # Check response - should be a clear, user-facing error, not a
+        # generic 500/unhandled exception
+        self.assertEqual(response.status_code, 422)
         data = response.json()
         self.assertEqual(data['status'], 'error')
+        self.assertTrue(data['message'])
 
         # Verify item description was NOT overwritten with broken JSON
+        self.item.refresh_from_db()
+        self.assertEqual(self.item.description, initial_description)
+
+        # Verify no open questions were created
+        questions = IssueOpenQuestion.objects.filter(issue=self.item)
+        self.assertEqual(questions.count(), 0)
+
+    @patch('core.services.agents.agent_service.AgentService.execute_agent')
+    @patch('core.services.rag.service.RAGPipelineService.build_context')
+    def test_optimize_with_empty_description_response_is_rejected(self, mock_build_context, mock_execute_agent):
+        """An agent response that parses fine but carries an empty
+        description (e.g. AGIRA-1PG) must not wipe out the item's
+        description and must surface a clear, user-facing error."""
+        from core.services.rag.models import RAGContext
+        mock_context = RAGContext(
+            query='Test description',
+            alpha=0.5,
+            summary='No context found',
+            items=[],
+            stats={'total_results': 0, 'deduplicated': 0}
+        )
+        mock_build_context.return_value = mock_context
+
+        # Simulate a well-formed JSON envelope with an empty description
+        mock_execute_agent.return_value = json.dumps({
+            "issue": {
+                "description": "   "
+            },
+            "open_questions": []
+        })
+
+        # Login as agent
+        self.client.login(username='agent_user', password='testpass123')
+
+        # Get initial description
+        initial_description = self.item.description
+
+        # Call optimization endpoint
+        url = reverse('item-optimize-description-ai', kwargs={'item_id': self.item.id})
+        response = self.client.post(url)
+
+        # Check response - should be a clear, user-facing error, not a
+        # generic 500/unhandled exception
+        self.assertEqual(response.status_code, 422)
+        data = response.json()
+        self.assertEqual(data['status'], 'error')
+        self.assertTrue(data['message'])
+
+        # Verify item description was NOT wiped out
         self.item.refresh_from_db()
         self.assertEqual(self.item.description, initial_description)
 

--- a/core/views.py
+++ b/core/views.py
@@ -2049,14 +2049,15 @@ def _sync_answered_questions_to_description(item):
 def item_optimize_description_ai(request, item_id):
     """
     Optimize item description using AI and RAG.
-    
+
     Uses RAG to gather context and then calls the github-issue-creation-agent
     to generate an optimized, machine-readable GitHub issue description.
-    
+
     Only available to users with Agent role.
     """
     from core.services.rag import build_extended_context
-    
+    from core.services.exceptions import AIResponseFormatError
+
     # Check user role
     if not request.user.is_authenticated or request.user.role != UserRole.AGENT:
         return JsonResponse({
@@ -2161,7 +2162,7 @@ Context from similar items and related information:
                 # provider's output token limit was hit. Surface this as an
                 # error instead of silently writing the broken JSON/partial
                 # JSON into the description field.
-                raise ValueError(
+                raise AIResponseFormatError(
                     "AI agent returned malformed JSON (response may have been "
                     "truncated by the provider's output token limit)"
                 )
@@ -2169,10 +2170,10 @@ Context from similar items and related information:
             # compatibility with agents that don't return the JSON envelope)
             optimized_description = cleaned_response
             open_questions = []
-        
+
         # Validate we have a description
         if not optimized_description:
-            raise ValueError("AI agent returned empty description")
+            raise AIResponseFormatError("AI agent returned empty description")
         
         # Update item description (only the issue.description part)
         item.description = optimized_description
@@ -2218,7 +2219,34 @@ Context from similar items and related information:
         return JsonResponse({
             'status': 'ok'
         })
-        
+
+    except AIResponseFormatError as e:
+        # Expected, recoverable upstream hiccup (empty or malformed/truncated
+        # LLM output) rather than a bug in Agira - log it as a warning and
+        # give the user an actionable hint instead of a generic 500.
+        import logging
+        logger = logging.getLogger(__name__)
+        logger.warning(
+            f"AI description optimization got an unusable response for item {item_id}: {str(e)}"
+        )
+
+        activity_service = ActivityService()
+        activity_service.log(
+            verb='item.description.ai_error',
+            target=item,
+            actor=request.user,
+            summary=f'AI description optimization got an unusable AI response: {str(e)}',
+        )
+
+        return JsonResponse({
+            'status': 'error',
+            'message': (
+                'Die KI-Antwort konnte nicht verarbeitet werden (leer oder '
+                'unvollständig). Die Beschreibung wurde nicht verändert. '
+                'Bitte versuche es erneut.'
+            )
+        }, status=422)
+
     except Exception as e:
         # Log activity - error
         activity_service = ActivityService()
@@ -2228,11 +2256,11 @@ Context from similar items and related information:
             actor=request.user,
             summary=f'AI description optimization failed: {str(e)}',
         )
-        
+
         import logging
         logger = logging.getLogger(__name__)
         logger.error(f"AI description optimization failed for item {item_id}: {str(e)}")
-        
+
         return JsonResponse({
             'status': 'error',
             'message': str(e)


### PR DESCRIPTION
Automated draft PR opened by the Claude queue worker for Agira item #845.

Model: Sonnet
Job: #15

---

## Zusammenfassung

Die AI-Description-Optimierung (`/items/{item_id}/ai/optimize-description/`) brach bei leeren oder mitten im JSON abgeschnittenen LLM-Antworten mit einer unkontrollierten 500-Exception ab (Sentry AGIRA-1PM, AGIRA-1PG). Ursache war ein zu knappes `max_tokens`-Limit für den `github-issue-creation-agent` unter Claude/Sonnet sowie ein Prompt, der das erwartete JSON-Antwortformat nicht hart genug einforderte. Zusätzlich wurde jeder dieser erwarteten, wiederherstellbaren Fälle wie ein echter Serverfehler behandelt.

## Änderungen

- `agents/github-issue-creation-agent.yml`: `max_tokens` von 4096 auf 8192 verdoppelt; Prompt um einen expliziten Abschnitt ergänzt, der ausschließlich valides, vollständiges JSON ohne Codeblock-Fences und ohne leeres `description`-Feld verlangt und den Agenten anweist, den Text notfalls zu kürzen statt abgeschnitten zu antworten.
- `core/services/exceptions.py`: Neue Exception `AIResponseFormatError` (Subklasse von `ServiceError`) für erwartete, wiederherstellbare LLM-Antwortprobleme (leer/unparsbar), abgegrenzt von echten Servicefehlern.
- `core/views.py` (`item_optimize_description_ai`): Die beiden bisherigen `ValueError`-Fälle (malformed JSON, leere Description) werfen jetzt `AIResponseFormatError`. Ein eigener `except`-Zweig fängt diese vor dem generischen Handler ab, loggt als `warning` (statt `error`) und liefert einen HTTP 422 mit einem verständlichen, handlungsleitenden Hinweistext statt der rohen technischen Fehlermeldung. Echte unerwartete Exceptions laufen weiterhin über den bestehenden generischen 500-Pfad.
- `core/test_open_questions.py`: Bestehender Regressionstest für abgeschnittenes JSON auf den neuen Statuscode (422) angepasst; neuer Test für den Fall einer syntaktisch validen, aber leeren `description` (AGIRA-1PG) ergänzt, der prüft, dass die Item-Beschreibung unverändert bleibt und ein klarer 422-Fehler zurückkommt.

## Warum / Entscheidungen

- **max_tokens verdoppeln statt Modellwechsel:** Der Bug tritt laut Sentry nur bei Claude/Sonnet auf (Default-Limit 1024, YAML-Override bisher 4096), nicht bei OpenAI/GPT-5.x. Eine weitere Erhöhung ist die risikoärmste, sofort wirksame Maßnahme; nicht den Provider für diesen Agenten auf OpenAI umgestellt, weil das eine funktionale Verhaltensänderung des Agenten wäre und über den Scope dieses Bugfixes hinausgeht.
- **Prompt schärfen statt Response-Reparatur/Nachbearbeitung:** Ein strikterer Prompt reduziert die Wahrscheinlichkeit fehlerhafter Antworten an der Quelle. Nicht implementiert: automatisches "JSON-Reparieren" (z. B. fehlende schließende Klammern ergänzen), weil das stillschweigend unvollständige/erfundene Inhalte in die Beschreibung schreiben könnte – genau das Verhalten, das der vorherige Fix (#841) bewusst verhindert hat.
- **422 statt 500 für erwartete LLM-Fehlantworten:** Eine leere oder unparsbare LLM-Antwort ist ein bekanntes, wiederkehrendes Upstream-Problem, kein Bug in Agira – 422 mit klarem Hinweistext bildet das korrekt ab und trennt es im Monitoring (Sentry-Rauschen) von echten Serverfehlern. Nicht auf 200 mit `status: 'error'` gesetzt, weil das bestehende Fehler-Handling im Frontend (HTMX) unabhängig vom Statuscode bereits die `message` aus der JSON-Antwort anzeigt und ein 4xx-Code für Monitoring/Logs aussagekräftiger bleibt als ein "erfolgreicher" 200er mit Fehlerinhalt.
- **Kein automatischer Retry gegen ein zweites LLM-Request:** Im Vorschlag als "ggf. retryen" erwähnt, aber bewusst nicht umgesetzt, weil ein serverseitiger Auto-Retry Kosten verdoppelt und bei einem strukturell zu kurzen Prompt/Limit denselben Fehler erneut produzieren kann; die Kombination aus höherem `max_tokens` und geschärftem Prompt adressiert die Ursache, während der Nutzer bei einem verbleibenden Einzelfall den Button einfach erneut klicken kann.
- **Bestehenden Verb-String für Activity-Log wiederverwendet** (`item.description.ai_error`) statt einen neuen einzuführen, weil das Feld freitextbasiert ist und beide Fälle (erwartet/unerwartet) weiterhin unter derselben Aktivitätskategorie im Item-Verlauf sichtbar sein sollen; die `summary` unterscheidet die Fälle inhaltlich.

## Test-Hinweise

- `core/test_open_questions.py::ItemOptimizeWithOpenQuestionsTest::test_optimize_with_truncated_json_response_is_rejected` (angepasst auf 422) und neu `test_optimize_with_empty_description_response_is_rejected` decken beide Sentry-Fälle mit simulierten Agent-Antworten ab und prüfen, dass die Item-Beschreibung dabei unverändert bleibt und keine Open Questions erzeugt werden.
- Bestehender Test `core/test_item_ai_optimize.py::test_optimize_description_handles_ai_error` (generische Exception, nicht AI-Response-Format) bleibt bei Statuscode 500 – unverändert, da er einen echten, unerwarteten Fehler simuliert.
- Manuell verifiziert: Die YAML-Datei bleibt nach der Prompt-Ergänzung gültig und lädt mit denselben Top-Level-Schlüsseln wie zuvor (`python3 -c "import yaml; yaml.safe_load(open('agents/github-issue-creation-agent.yml'))"`).
- Nicht ausführbar in dieser Sandbox: Der volle Django-Testlauf (`manage.py test`), da hier keine Django-Umgebung installiert ist. Bitte in der CI/lokalen Dev-Umgebung mit `python manage.py test core.test_open_questions core.test_item_ai_optimize` gegenprüfen.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to the Agent-role optimize-description endpoint and agent config; success paths unchanged and genuine errors still return 500.
> 
> **Overview**
> **AI description optimization** no longer turns empty or broken LLM JSON into 500 errors or corrupted item text. The `github-issue-creation-agent` now uses **`max_tokens: 8192`** (was 4096) and a stricter prompt that requires raw, complete JSON with a non-empty `description`, shortening content if needed instead of truncating mid-response.
> 
> **`item_optimize_description_ai`** raises **`AIResponseFormatError`** for malformed/truncated JSON and empty descriptions; a dedicated handler returns **HTTP 422** with a German user message, logs a **warning**, and leaves the item unchanged. Unexpected failures still return 500.
> 
> Tests expect **422** for truncated JSON and add coverage for whitespace-only `description` responses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bcdba988ba2c15b2d48043d5344d2dc38d09bb05. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->