### PR TITLE
Authentication failed (HTTP 403): message": "API rate limit exceeded"

### DIFF
--- a/core/management/commands/github_markdown_sync_worker.py
+++ b/core/management/commands/github_markdown_sync_worker.py
@@ -14,6 +14,7 @@ from django.core.management.base import BaseCommand, CommandError
 from core.models import Project
 from core.services.github.service import GitHubService
 from core.services.github_sync.markdown_sync import MarkdownSyncService
+from core.services.integrations.errors import IntegrationRateLimited
 
 logger = logging.getLogger(__name__)
 
@@ -86,6 +87,11 @@ class Command(BaseCommand):
 
         if dry_run:
             self.stdout.write(self.style.WARNING('\nDRY RUN - No changes were made'))
+        elif markdown_stats.get('rate_limited'):
+            self.stdout.write(self.style.WARNING(
+                '\n⚠ GitHub markdown sync stopped early due to a GitHub rate limit. '
+                'It will resume on the next scheduled run.'
+            ))
         else:
             self.stdout.write(self.style.SUCCESS('\n✓ GitHub markdown sync completed successfully'))
     
@@ -113,6 +119,7 @@ class Command(BaseCommand):
             'total_files_updated': 0,
             'total_files_skipped': 0,
             'total_errors': 0,
+            'rate_limited': False,
         }
         
         # Get projects with GitHub repo configured
@@ -165,7 +172,30 @@ class Command(BaseCommand):
                 # Log errors if any
                 for error in project_stats['errors']:
                     self.stdout.write(self.style.ERROR(f"    ✗ {error}"))
-                    
+
+            except IntegrationRateLimited as e:
+                # GitHub rate limit hit: this is an expected, transient
+                # condition. Stop the entire worker run immediately - the next
+                # scheduled run will resume from where GitHub allows. We do NOT
+                # treat this as an error (no error log, no Sentry report), only
+                # a warning with enough context for diagnosis.
+                stats['rate_limited'] = True
+                logger.warning(
+                    "GitHub rate limit hit in github_markdown_sync_worker; "
+                    "stopping run early. project_id=%s repo=%s/%s detail=%s",
+                    project.id,
+                    project.github_owner,
+                    project.github_repo,
+                    e,
+                )
+                self.stdout.write(
+                    self.style.WARNING(
+                        "    ⚠ GitHub rate limit reached - stopping this run. "
+                        "Remaining projects will be processed on the next run."
+                    )
+                )
+                break
+
             except Exception as e:
                 stats['total_errors'] += 1
                 logger.error(
@@ -175,5 +205,5 @@ class Command(BaseCommand):
                 self.stdout.write(
                     self.style.ERROR(f"    ✗ Error: {e}")
                 )
-        
+
         return stats

--- a/core/management/commands/test_github_markdown_sync_worker.py
+++ b/core/management/commands/test_github_markdown_sync_worker.py
@@ -191,6 +191,122 @@ class GitHubMarkdownSyncWorkerTestCase(TestCase):
         self.assertIn('Errors: 1', output)
     
     @patch('core.management.commands.github_markdown_sync_worker.GitHubService')
+    @patch('core.management.commands.github_markdown_sync_worker.MarkdownSyncService')
+    def test_command_stops_run_on_rate_limit(self, mock_markdown_service_class, mock_github_service_class):
+        """A GitHub rate limit stops the whole run early, quietly (warning, no error/Sentry)."""
+        from core.services.integrations.errors import IntegrationRateLimited
+
+        # A second project ensures we can prove processing stops after the first.
+        Project.objects.create(
+            name='Second Project',
+            github_owner='otherowner',
+            github_repo='otherrepo',
+        )
+
+        mock_github_service = MagicMock()
+        mock_github_service.is_enabled.return_value = True
+        mock_github_service.is_configured.return_value = True
+        mock_github_service_class.return_value = mock_github_service
+
+        mock_client = MagicMock()
+        mock_github_service._get_client.return_value = mock_client
+
+        mock_markdown_service = MagicMock()
+        mock_markdown_service.sync_project_markdown_files.side_effect = IntegrationRateLimited(
+            "Rate limit exceeded (HTTP 403): API rate limit exceeded for user ID 123"
+        )
+        mock_markdown_service_class.return_value = mock_markdown_service
+
+        logger_name = 'core.management.commands.github_markdown_sync_worker'
+        out = StringIO()
+        with self.assertLogs(logger_name, level='WARNING') as log_cm:
+            call_command('github_markdown_sync_worker', stdout=out)
+
+        output = out.getvalue()
+
+        # Only the first project was attempted; the run stopped afterwards.
+        self.assertEqual(mock_markdown_service.sync_project_markdown_files.call_count, 1)
+
+        # A warning was logged (not an error), so nothing is reported to Sentry.
+        warnings = [r for r in log_cm.records if r.levelname == 'WARNING']
+        errors = [r for r in log_cm.records if r.levelname == 'ERROR']
+        self.assertTrue(any('rate limit' in r.getMessage().lower() for r in warnings))
+        self.assertEqual(errors, [])
+
+        # User-facing output shows the early stop, not an error summary.
+        self.assertIn('rate limit', output.lower())
+        self.assertIn('next', output.lower())
+        self.assertNotIn('Errors: 1', output)
+
+    @patch('core.management.commands.github_markdown_sync_worker.GitHubService')
+    @patch('core.management.commands.github_markdown_sync_worker.MarkdownSyncService')
+    def test_non_rate_limit_error_keeps_error_path(self, mock_markdown_service_class, mock_github_service_class):
+        """Non-rate-limit errors keep the existing error behaviour (error log, counted)."""
+        mock_github_service = MagicMock()
+        mock_github_service.is_enabled.return_value = True
+        mock_github_service.is_configured.return_value = True
+        mock_github_service_class.return_value = mock_github_service
+
+        mock_client = MagicMock()
+        mock_github_service._get_client.return_value = mock_client
+
+        mock_markdown_service = MagicMock()
+        mock_markdown_service.sync_project_markdown_files.side_effect = Exception("API Error")
+        mock_markdown_service_class.return_value = mock_markdown_service
+
+        logger_name = 'core.management.commands.github_markdown_sync_worker'
+        out = StringIO()
+        with self.assertLogs(logger_name, level='ERROR') as log_cm:
+            call_command('github_markdown_sync_worker', stdout=out)
+
+        output = out.getvalue()
+
+        # Still surfaced as an error (kept on the Sentry-reporting path).
+        self.assertIn('Errors: 1', output)
+        self.assertTrue(any(r.levelname == 'ERROR' for r in log_cm.records))
+
+    @patch('core.management.commands.github_markdown_sync_worker.GitHubService')
+    @patch('core.management.commands.github_markdown_sync_worker.MarkdownSyncService')
+    def test_command_reruns_normally_after_rate_limit(self, mock_markdown_service_class, mock_github_service_class):
+        """The early exit leaves no persistent lock: a later run starts normally."""
+        from core.services.integrations.errors import IntegrationRateLimited
+
+        mock_github_service = MagicMock()
+        mock_github_service.is_enabled.return_value = True
+        mock_github_service.is_configured.return_value = True
+        mock_github_service_class.return_value = mock_github_service
+
+        mock_client = MagicMock()
+        mock_github_service._get_client.return_value = mock_client
+
+        mock_markdown_service = MagicMock()
+        mock_markdown_service_class.return_value = mock_markdown_service
+
+        # First run: rate limited.
+        mock_markdown_service.sync_project_markdown_files.side_effect = IntegrationRateLimited(
+            "Rate limit exceeded (HTTP 403): API rate limit exceeded"
+        )
+        first_out = StringIO()
+        call_command('github_markdown_sync_worker', stdout=first_out)
+        self.assertIn('rate limit', first_out.getvalue().lower())
+
+        # Second (later) run: GitHub is available again, sync succeeds.
+        mock_markdown_service.sync_project_markdown_files.side_effect = None
+        mock_markdown_service.sync_project_markdown_files.return_value = {
+            'files_found': 1,
+            'files_created': 1,
+            'files_updated': 0,
+            'files_skipped': 0,
+            'errors': [],
+        }
+        second_out = StringIO()
+        call_command('github_markdown_sync_worker', stdout=second_out)
+
+        output = second_out.getvalue()
+        self.assertIn('completed successfully', output)
+        self.assertIn('Files created: 1', output)
+
+    @patch('core.management.commands.github_markdown_sync_worker.GitHubService')
     def test_command_skips_projects_without_github_repo(self, mock_github_service_class):
         """Test that command skips projects without GitHub repo configuration."""
         # Create project without GitHub repo

--- a/core/services/github_sync/markdown_sync.py
+++ b/core/services/github_sync/markdown_sync.py
@@ -14,6 +14,7 @@ from django.utils import timezone
 
 from core.models import Project, Attachment, AttachmentLink, AttachmentRole
 from core.services.github.client import GitHubClient
+from core.services.integrations.errors import IntegrationRateLimited
 from core.services.storage.service import AttachmentStorageService
 from core.services.weaviate.service import upsert_instance
 
@@ -105,12 +106,17 @@ class MarkdownSyncService:
                         stats['files_updated'] += 1
                     elif result == 'skipped':
                         stats['files_skipped'] += 1
-                        
+
+                except IntegrationRateLimited:
+                    # Rate limits are expected and must abort the whole run,
+                    # not just this file. Propagate to the worker without
+                    # logging an error / reporting to Sentry.
+                    raise
                 except Exception as e:
                     error_msg = f"Error syncing {file_info['path']}: {str(e)}"
                     logger.error(error_msg, exc_info=True)
                     stats['errors'].append(error_msg)
-            
+
             logger.info(
                 f"Sync complete for project {project.id}: "
                 f"{stats['files_created']} created, "
@@ -119,11 +125,14 @@ class MarkdownSyncService:
                 f"{len(stats['errors'])} errors"
             )
             
+        except IntegrationRateLimited:
+            # Expected condition - let the worker stop the current run quietly.
+            raise
         except Exception as e:
             error_msg = f"Failed to sync markdown files for project {project.id}: {str(e)}"
             logger.error(error_msg, exc_info=True)
             stats['errors'].append(error_msg)
-        
+
         return stats
     
     def _find_markdown_files(
@@ -177,13 +186,20 @@ class MarkdownSyncService:
                             owner, repo, item_path, ref
                         )
                         markdown_files.extend(subdir_files)
+                    except IntegrationRateLimited:
+                        # Abort the entire traversal, not just this directory.
+                        raise
                     except Exception as e:
                         logger.warning(f"Failed to search directory {item_path}: {e}")
-                        
+
+        except IntegrationRateLimited:
+            # Expected rate-limit condition - propagate silently (warning-level
+            # logging happens once at the worker level, not as an error here).
+            raise
         except Exception as e:
             logger.error(f"Failed to get repository contents at {path}: {e}")
             raise
-        
+
         return markdown_files
     
     def _sync_markdown_file(

--- a/core/services/github_sync/test_markdown_sync.py
+++ b/core/services/github_sync/test_markdown_sync.py
@@ -266,9 +266,40 @@ class MarkdownSyncServiceTestCase(TestCase):
         """Test handling GitHub API errors without crashing."""
         # Mock API error
         self.mock_client.get_repository_contents.side_effect = Exception("API Error")
-        
+
         stats = self.service.sync_project_markdown_files(self.project)
-        
+
         # Should capture error
         self.assertEqual(len(stats['errors']), 1)
         self.assertIn('API Error', stats['errors'][0])
+
+    def test_rate_limit_propagates_and_is_not_swallowed(self):
+        """Rate limits must propagate to the caller, not be collected as errors."""
+        from core.services.integrations.errors import IntegrationRateLimited
+
+        self.mock_client.get_repository_contents.side_effect = IntegrationRateLimited(
+            "Rate limit exceeded (HTTP 403): API rate limit exceeded"
+        )
+
+        # The rate limit must bubble up so the worker can stop the whole run,
+        # rather than being caught and appended to stats['errors'].
+        with self.assertRaises(IntegrationRateLimited):
+            self.service.sync_project_markdown_files(self.project)
+
+    def test_rate_limit_in_subdirectory_propagates(self):
+        """A rate limit while recursing into a subdirectory aborts the traversal."""
+        from core.services.integrations.errors import IntegrationRateLimited
+
+        def mock_get_contents(owner, repo, path='', ref=None):
+            if path == '':
+                return [
+                    {'type': 'dir', 'name': 'docs', 'path': 'docs', 'sha': 'def'},
+                ]
+            raise IntegrationRateLimited(
+                "Rate limit exceeded (HTTP 403): API rate limit exceeded"
+            )
+
+        self.mock_client.get_repository_contents.side_effect = mock_get_contents
+
+        with self.assertRaises(IntegrationRateLimited):
+            self.service.sync_project_markdown_files(self.project)

--- a/core/services/integrations/http.py
+++ b/core/services/integrations/http.py
@@ -123,26 +123,21 @@ class HTTPClient:
         """
         status = response.status_code
         truncated_text = self._truncate_response(response.text)
-        
+
+        # Rate limiting - detected before generic auth handling because some
+        # APIs (notably GitHub) signal rate limits with HTTP 403, not 429.
+        if self._is_rate_limit_response(response):
+            raise IntegrationRateLimited(
+                f"Rate limit exceeded (HTTP {status}): {truncated_text}",
+                retry_after=self._parse_retry_after(response),
+            )
+
         # Authentication errors (401/403)
         if status in (401, 403):
             raise IntegrationAuthError(
                 f"Authentication failed (HTTP {status}): {truncated_text}"
             )
-        
-        # Rate limiting (429)
-        if status == 429:
-            retry_after = response.headers.get('Retry-After')
-            try:
-                retry_after = int(retry_after) if retry_after else None
-            except (ValueError, TypeError):
-                retry_after = None
-            
-            raise IntegrationRateLimited(
-                f"Rate limit exceeded: {truncated_text}",
-                retry_after=retry_after
-            )
-        
+
         # Server errors (5xx) - temporary, retryable
         if status >= 500:
             raise IntegrationTemporaryError(
@@ -154,7 +149,53 @@ class HTTPClient:
             raise IntegrationPermanentError(
                 f"Client error (HTTP {status}): {truncated_text}"
             )
-    
+
+    def _is_rate_limit_response(self, response: httpx.Response) -> bool:
+        """
+        Determine whether a response represents a rate-limit condition.
+
+        Handles both the standard HTTP 429 and GitHub's convention of
+        returning HTTP 403 with a rate-limit marker (either the
+        ``x-ratelimit-remaining: 0`` header or a body mentioning the
+        rate limit). Genuine 403 authentication/authorization failures
+        (no rate-limit marker) are intentionally not matched here.
+
+        Args:
+            response: HTTP response object
+
+        Returns:
+            True if the response indicates a rate limit, False otherwise
+        """
+        status = response.status_code
+
+        if status == 429:
+            return True
+
+        if status == 403:
+            if response.headers.get('x-ratelimit-remaining') == '0':
+                return True
+            body = (response.text or '').lower()
+            if 'rate limit exceeded' in body or 'secondary rate limit' in body:
+                return True
+
+        return False
+
+    def _parse_retry_after(self, response: httpx.Response) -> Optional[int]:
+        """
+        Parse the ``Retry-After`` header into seconds, if present and valid.
+
+        Args:
+            response: HTTP response object
+
+        Returns:
+            Seconds to wait before retrying, or None if not provided/invalid
+        """
+        retry_after = response.headers.get('Retry-After')
+        try:
+            return int(retry_after) if retry_after else None
+        except (ValueError, TypeError):
+            return None
+
     def _should_retry(self, exception: Exception, attempt: int) -> bool:
         """
         Determine if a request should be retried.
@@ -186,11 +227,14 @@ class HTTPClient:
         # Retry on temporary errors (5xx)
         if isinstance(exception, IntegrationTemporaryError):
             return True
-        
-        # Retry on rate limits (429)
+
+        # Retry on rate limits only when the server told us how long to wait.
+        # Rate limits without a Retry-After (e.g. GitHub's primary API limit,
+        # returned as 403) reset far in the future, so retrying within the same
+        # run is pointless - surface them immediately so the caller can stop.
         if isinstance(exception, IntegrationRateLimited):
-            return True
-        
+            return exception.retry_after is not None
+
         # Don't retry on other integration errors
         return False
     

--- a/core/services/integrations/test_integrations.py
+++ b/core/services/integrations/test_integrations.py
@@ -273,6 +273,49 @@ class HTTPClientTestCase(TestCase):
         
         self.assertEqual(cm.exception.retry_after, 60)
     
+    def test_403_rate_limit_header_raises_rate_limited(self):
+        """A GitHub-style 403 rate limit is classified as IntegrationRateLimited."""
+        route = respx.get(f"{self.base_url}/test")
+        route.mock(
+            return_value=httpx.Response(
+                403,
+                headers={"x-ratelimit-remaining": "0"},
+                json={"message": "API rate limit exceeded for user ID 123"},
+            )
+        )
+
+        with self.assertRaises(IntegrationRateLimited) as cm:
+            self.client.get("/test")
+
+        self.assertIn("403", str(cm.exception))
+        # Rate limits without a Retry-After must not be retried.
+        self.assertEqual(route.call_count, 1)
+
+    def test_403_rate_limit_body_raises_rate_limited(self):
+        """A 403 whose body mentions the rate limit is classified as rate-limited."""
+        route = respx.get(f"{self.base_url}/test")
+        route.mock(
+            return_value=httpx.Response(
+                403,
+                json={"message": "API rate limit exceeded"},
+            )
+        )
+
+        with self.assertRaises(IntegrationRateLimited):
+            self.client.get("/test")
+
+        self.assertEqual(route.call_count, 1)
+
+    def test_403_without_rate_limit_marker_still_auth_error(self):
+        """A genuine 403 (no rate-limit marker) remains an auth error and is not retried."""
+        route = respx.get(f"{self.base_url}/test")
+        route.mock(return_value=httpx.Response(403, json={"error": "Forbidden"}))
+
+        with self.assertRaises(IntegrationAuthError):
+            self.client.get("/test")
+
+        self.assertEqual(route.call_count, 1)
+
     def test_500_raises_temporary_error(self):
         """Test that 500 raises IntegrationTemporaryError."""
         respx.get(f"{self.base_url}/test").mock(


### PR DESCRIPTION
Automated draft PR opened by the Claude queue worker for Agira item #851.

Model: Opus
Job: #21

---

## Zusammenfassung

GitHub-Rate-Limit-Fehler (HTTP 403 mit `API rate limit exceeded` bzw. `x-ratelimit-remaining: 0`, sowie HTTP 429) werden im `github_markdown_sync_worker` nicht mehr als Error behandelt und nicht mehr an Sentry gemeldet. Tritt ein Rate Limit auf, wird der aktuelle Worker-Lauf kontrolliert und still beendet; die Verarbeitung wird erst beim nächsten regulären Scheduling-Lauf fortgesetzt. Alle anderen Fehler behalten ihr bisheriges Verhalten.

## Änderungen

- `core/services/integrations/http.py`: Zentrale Fehlerklassifikation erweitert. Rate-Limit-Antworten werden vor der generischen 401/403-Behandlung erkannt und als `IntegrationRateLimited` klassifiziert – auch der GitHub-typische Fall HTTP 403 mit Rate-Limit-Marker (Header `x-ratelimit-remaining: 0` oder Body enthält `rate limit exceeded` / `secondary rate limit`). Neue Hilfsmethoden `_is_rate_limit_response` und `_parse_retry_after`. In `_should_retry` werden Rate Limits nur noch wiederholt, wenn ein `Retry-After` vorliegt; ohne `Retry-After` (GitHub-Primärlimit) wird sofort durchgereicht, statt künstlich erneut zu versuchen.
- `core/services/github_sync/markdown_sync.py`: `IntegrationRateLimited` wird in allen Fehlerpfaden (Dateiverarbeitung, Repository-Traversierung inkl. Unterverzeichnis-Rekursion) durchgereicht, statt als Error geloggt oder in `stats['errors']` gesammelt zu werden.
- `core/management/commands/github_markdown_sync_worker.py`: Neuer `except IntegrationRateLimited`-Zweig in der Projektschleife. Er bricht den gesamten Lauf ab (`break`), setzt das Statusfeld `rate_limited`, loggt genau eine Warning mit Kontext (Worker-Name, Projekt-ID, Repository, Fehlerdetail) und gibt eine Hinweismeldung aus. Die Abschlussmeldung weist auf die frühzeitige Beendigung hin.
- Tests: HTTP-Klassifikation (403-Rate-Limit → `IntegrationRateLimited`, kein Retry; echtes 403 → weiterhin `IntegrationAuthError`), Durchreichen des Rate Limits im `MarkdownSyncService` (auch aus Unterverzeichnissen), sowie Worker-Verhalten (früher Exit, keine weitere Verarbeitung, Warning statt Error, Nicht-Rate-Limit-Fehler unverändert, sauberer Folgelauf ohne persistenten Sperrzustand).

## Warum / Entscheidungen

- Zentrale Klassifikation im gemeinsamen `HTTPClient`, nicht pro Aufrufstelle, weil dort bereits alle HTTP-Fehler auf die `Integration*`-Fehlerklassen abgebildet werden – so bleibt die Erkennung an einer Stelle und ohne doppelte Fehlerbehandlung.
- Rate-Limit-Erkennung nur bei vorhandenem Marker, nicht generell bei jedem HTTP 403, weil echte Auth-/Berechtigungsfehler weiterhin als `IntegrationAuthError` gemeldet werden müssen (bestehender Test `test_403_raises_auth_error` bleibt gültig).
- Frühzeitiger Abbruch des gesamten Laufs über `break` in der Projektschleife und nicht nur Überspringen des aktuellen Dateipfads, weil ein Rate Limit alle folgenden GitHub-Aufrufe des Laufs betrifft; die Fortsetzung übernimmt der nächste reguläre Scheduling-Lauf.
- Kein neuer Retry und kein persistenter Sperr-/Fortschrittsmarker, weil der frühe Exit idempotent bleiben und der nächste Lauf normal starten soll; die bestehenden Pro-Datei-Transaktionen verhindern inkonsistente Zwischenzustände.
- Warning statt Error-Log (kein `exc_info`), weil `logger.error` über die Sentry-Logging-Integration als Event gemeldet würde – Rate Limits sind erwartbar und sollen kein Sentry-Rauschen erzeugen.
- Nicht ein eigenes, worker-lokales Ausparsen der Fehlermeldung, weil die vorhandene `IntegrationRateLimited`-Abstraktion genutzt werden soll und die Klassifikation sonst dupliziert würde.
- Nicht das Retry-Verhalten für andere Fehlertypen (5xx, Timeouts) angefasst; nur der Rate-Limit-Zweig wurde angepasst, um kontextfremde Änderungen zu vermeiden.

## Test-Hinweise

- Gezielte Suites laufen grün: `python manage.py test core.services.github_sync.test_markdown_sync core.management.commands.test_github_markdown_sync_worker` (23 Tests) und `core.services.github.test_github` (31 Tests).
- Die HTTP-Klassifikation wurde zusätzlich direkt gegen echte `httpx.Response`-Objekte verifiziert (403+Header, 403+Body, echtes 403, 401, 429 mit/ohne `Retry-After`, 404, 500). Hinweis: `HTTPClientTestCase` in `test_integrations.py` nutzt den Klassen-Dekorator `@respx.mock`, der mit der hier installierten `respx`-Version unter `manage.py test` nicht sauber lädt – ein bereits bestehendes, umgebungsbedingtes Problem, unabhängig von dieser Änderung.
- Vorbestehende, nicht zusammenhängende Fehlschläge in der Umgebung: fehlender Staticfiles-Manifest-Eintrag `css/site.css` und der datumsabhängige Test `test_command_syncs_various_non_closed_statuses` im separaten `github_sync_worker` (verifiziert auch ohne diese Änderung fehlschlagend).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared HTTP error handling used beyond GitHub; behavior change for 403 responses could affect other integrations if they share the same client patterns.
> 
> **Overview**
> GitHub **rate limits** (HTTP 429 and GitHub-style **403** with rate-limit markers) are no longer misclassified as auth failures or logged as errors/Sentry events during markdown sync.
> 
> The shared **`HTTPClient`** now detects rate-limit responses before generic 401/403 handling (`_is_rate_limit_response`, `_parse_retry_after`) and only **retries** rate limits when **`Retry-After`** is present; GitHub primary limits surface immediately without pointless in-run retries.
> 
> **`MarkdownSyncService`** re-raises **`IntegrationRateLimited`** through file sync and directory traversal instead of collecting it in `stats['errors']`. **`github_markdown_sync_worker`** catches it once per run: sets `rate_limited`, logs a **warning**, **breaks** the project loop, and shows a resume-on-next-run message—other exceptions keep the existing error path.
> 
> Tests cover HTTP classification, propagation from subdirs, worker early exit, and normal reruns after a limit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bfda0fa9dc5617878bf1440ee98e197c749d22d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->