### PR TITLE
Preise Models werden nicht angezeigt

### DIFF
--- a/core/services/ai/pricing.py
+++ b/core/services/ai/pricing.py
@@ -2,8 +2,53 @@
 Cost calculation for AI API usage.
 """
 
-from decimal import Decimal
+from decimal import Decimal, InvalidOperation
 from typing import Optional
+
+
+def parse_price_input(value: Optional[str]) -> Optional[Decimal]:
+    """
+    Parse a user-supplied token price into a Decimal.
+
+    Accepts both the technical format (``0.01``) and the German decimal
+    format (``0,01``). Empty or whitespace-only input is treated as "no
+    price" and returns ``None``.
+
+    Args:
+        value: Raw price string from a form field (or ``None``).
+
+    Returns:
+        The parsed :class:`~decimal.Decimal`, or ``None`` for empty input.
+
+    Raises:
+        ValueError: If the value is non-empty but cannot be parsed as a
+            decimal number.
+
+    Example:
+        >>> parse_price_input('0,01')
+        Decimal('0.01')
+        >>> parse_price_input('0.01')
+        Decimal('0.01')
+        >>> parse_price_input('') is None
+        True
+    """
+    if value is None:
+        return None
+
+    normalized = value.strip()
+    if not normalized:
+        return None
+
+    # Normalize the German decimal separator to a dot so both "0,01" and
+    # "0.01" parse identically. Thousands separators are not expected here
+    # (prices are small, per-1M-token values), so a bare comma is treated
+    # as a decimal separator.
+    normalized = normalized.replace(',', '.')
+
+    try:
+        return Decimal(normalized)
+    except (InvalidOperation, ValueError) as exc:
+        raise ValueError(f"Invalid price value: {value!r}") from exc
 
 
 def calculate_cost(

--- a/core/test_ai_model_pricing.py
+++ b/core/test_ai_model_pricing.py
@@ -1,0 +1,138 @@
+"""
+Tests for AI Model token-price parsing, persistence and display.
+
+Regression coverage for issue #852: saved input/output token prices were
+rendered as ``0,00`` in the ``/ai-providers/<id>/`` view because Django
+localized the DecimalField values with a German comma, which an HTML
+``<input type="number">`` cannot display.
+"""
+
+from decimal import Decimal
+
+from django.test import TestCase, Client
+from django.urls import reverse
+
+from core.models import AIProvider, AIModel, User
+from core.services.ai.pricing import parse_price_input
+
+
+class ParsePriceInputTestCase(TestCase):
+    """Unit tests for the locale-robust price parser."""
+
+    def test_parses_technical_format(self):
+        self.assertEqual(parse_price_input('0.01'), Decimal('0.01'))
+
+    def test_parses_german_format(self):
+        self.assertEqual(parse_price_input('0,01'), Decimal('0.01'))
+
+    def test_parses_larger_german_value(self):
+        self.assertEqual(parse_price_input('15,50'), Decimal('15.50'))
+
+    def test_empty_string_returns_none(self):
+        self.assertIsNone(parse_price_input(''))
+
+    def test_whitespace_returns_none(self):
+        self.assertIsNone(parse_price_input('   '))
+
+    def test_none_returns_none(self):
+        self.assertIsNone(parse_price_input(None))
+
+    def test_invalid_value_raises(self):
+        with self.assertRaises(ValueError):
+            parse_price_input('abc')
+
+
+class AIModelPriceDisplayTestCase(TestCase):
+    """Integration tests for loading, displaying and saving model prices."""
+
+    def setUp(self):
+        self.client = Client()
+        self.user = User.objects.create_user(
+            username='admin',
+            email='admin@example.com',
+            password='pass',
+            is_superuser=True,
+        )
+        self.client.force_login(self.user)
+
+        self.provider = AIProvider.objects.create(
+            name='Test Provider',
+            provider_type='OpenAI',
+            api_key='test-key',
+            active=True,
+        )
+        self.model = AIModel.objects.create(
+            provider=self.provider,
+            name='Test Model',
+            model_id='test-model',
+            input_price_per_1m_tokens=Decimal('0.5000'),
+            output_price_per_1m_tokens=Decimal('1.5000'),
+        )
+
+    def test_saved_prices_render_with_dot_separator(self):
+        """Stored non-zero prices must appear in the number inputs (not as 0,00)."""
+        url = reverse('ai-provider-detail', args=[self.provider.id])
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        content = response.content.decode()
+
+        # Values must be rendered with a dot so <input type="number"> displays them.
+        self.assertIn('value="0.5000"', content)
+        self.assertIn('value="1.5000"', content)
+
+        # They must NOT be localized with a comma inside the value attribute.
+        self.assertNotIn('value="0,5000"', content)
+        self.assertNotIn('value="1,5000"', content)
+
+    def test_update_field_accepts_technical_format(self):
+        url = reverse('ai-model-update-field', args=[self.provider.id, self.model.id])
+        response = self.client.post(url, {
+            'field': 'input_price_per_1m_tokens',
+            'value': '2.25',
+        })
+        self.assertEqual(response.status_code, 204)
+        self.model.refresh_from_db()
+        self.assertEqual(self.model.input_price_per_1m_tokens, Decimal('2.25'))
+
+    def test_update_field_accepts_german_format(self):
+        url = reverse('ai-model-update-field', args=[self.provider.id, self.model.id])
+        response = self.client.post(url, {
+            'field': 'output_price_per_1m_tokens',
+            'value': '3,75',
+        })
+        self.assertEqual(response.status_code, 204)
+        self.model.refresh_from_db()
+        self.assertEqual(self.model.output_price_per_1m_tokens, Decimal('3.75'))
+
+    def test_saved_price_survives_reload(self):
+        """Change a price and confirm it is displayed unchanged after reload."""
+        update_url = reverse('ai-model-update-field', args=[self.provider.id, self.model.id])
+        self.client.post(update_url, {
+            'field': 'input_price_per_1m_tokens',
+            'value': '0,01',
+        })
+
+        detail_url = reverse('ai-provider-detail', args=[self.provider.id])
+        content = self.client.get(detail_url).content.decode()
+        self.assertIn('value="0.0100"', content)
+
+    def test_create_model_accepts_german_format(self):
+        url = reverse('ai-model-create', args=[self.provider.id])
+        response = self.client.post(url, {
+            'name': 'New Model',
+            'model_id': 'new-model',
+            'input_price_per_1m_tokens': '0,02',
+            'output_price_per_1m_tokens': '0,04',
+        })
+        self.assertEqual(response.status_code, 200)
+        created = AIModel.objects.get(model_id='new-model')
+        self.assertEqual(created.input_price_per_1m_tokens, Decimal('0.02'))
+        self.assertEqual(created.output_price_per_1m_tokens, Decimal('0.04'))
+
+    def test_update_field_rejects_negative(self):
+        url = reverse('ai-model-update-field', args=[self.provider.id, self.model.id])
+        response = self.client.post(url, {
+            'field': 'input_price_per_1m_tokens',
+            'value': '-1.0',
+        })
+        self.assertEqual(response.status_code, 400)

--- a/core/views.py
+++ b/core/views.py
@@ -14,6 +14,7 @@ from django.utils import timezone
 from django.urls import reverse
 from django.conf import settings
 from decimal import Decimal, InvalidOperation
+from core.services.ai.pricing import parse_price_input
 from datetime import datetime, date, time
 import logging
 import os
@@ -6638,16 +6639,19 @@ def ai_model_create(request, provider_id):
     provider = get_object_or_404(AIProvider, id=provider_id)
     
     try:
-        # Get input values and convert empty strings to None for decimal fields
-        input_price = request.POST.get('input_price_per_1m_tokens', '').strip()
-        output_price = request.POST.get('output_price_per_1m_tokens', '').strip()
-        
+        # Parse prices (accepts both "0.01" and German "0,01"); empty -> None
+        try:
+            input_price = parse_price_input(request.POST.get('input_price_per_1m_tokens'))
+            output_price = parse_price_input(request.POST.get('output_price_per_1m_tokens'))
+        except ValueError:
+            return HttpResponse("Invalid price value", status=400)
+
         model = AIModel.objects.create(
             provider=provider,
             name=request.POST.get('name'),
             model_id=request.POST.get('model_id'),
-            input_price_per_1m_tokens=input_price if input_price else None,
-            output_price_per_1m_tokens=output_price if output_price else None,
+            input_price_per_1m_tokens=input_price,
+            output_price_per_1m_tokens=output_price,
             active=request.POST.get('active') == 'on',
             is_default=request.POST.get('is_default') == 'on'
         )
@@ -6680,11 +6684,14 @@ def ai_model_update(request, provider_id, model_id):
         model.name = request.POST.get('name', model.name)
         model.model_id = request.POST.get('model_id', model.model_id)
         
-        # Handle decimal fields - convert empty strings to None
-        input_price = request.POST.get('input_price_per_1m_tokens', '').strip()
-        output_price = request.POST.get('output_price_per_1m_tokens', '').strip()
-        model.input_price_per_1m_tokens = input_price if input_price else None
-        model.output_price_per_1m_tokens = output_price if output_price else None
+        # Parse prices (accepts both "0.01" and German "0,01"); empty -> None
+        try:
+            model.input_price_per_1m_tokens = parse_price_input(
+                request.POST.get('input_price_per_1m_tokens'))
+            model.output_price_per_1m_tokens = parse_price_input(
+                request.POST.get('output_price_per_1m_tokens'))
+        except ValueError:
+            return HttpResponse("Invalid price value", status=400)
         
         model.active = request.POST.get('active') == 'on'
         model.is_default = request.POST.get('is_default') == 'on'
@@ -6742,25 +6749,19 @@ def ai_model_update_field(request, provider_id, model_id):
         value = request.POST.get('value', '').strip()
         
         if field in ['input_price_per_1m_tokens', 'output_price_per_1m_tokens']:
-            # Validate and convert to Decimal if value is provided
-            if value:
-                try:
-                    decimal_value = Decimal(value)
-                    if decimal_value < 0:
-                        return HttpResponse("Price cannot be negative", status=400)
-                except (InvalidOperation, ValueError):
-                    return HttpResponse("Invalid price value", status=400)
-                
-                if field == 'input_price_per_1m_tokens':
-                    model.input_price_per_1m_tokens = decimal_value
-                else:
-                    model.output_price_per_1m_tokens = decimal_value
+            # Parse price (accepts both "0.01" and German "0,01"); empty -> None
+            try:
+                decimal_value = parse_price_input(value)
+            except ValueError:
+                return HttpResponse("Invalid price value", status=400)
+
+            if decimal_value is not None and decimal_value < 0:
+                return HttpResponse("Price cannot be negative", status=400)
+
+            if field == 'input_price_per_1m_tokens':
+                model.input_price_per_1m_tokens = decimal_value
             else:
-                # Empty value sets to None
-                if field == 'input_price_per_1m_tokens':
-                    model.input_price_per_1m_tokens = None
-                else:
-                    model.output_price_per_1m_tokens = None
+                model.output_price_per_1m_tokens = decimal_value
         else:
             return HttpResponse("Invalid field", status=400)
         

--- a/templates/partials/ai_models_list.html
+++ b/templates/partials/ai_models_list.html
@@ -1,3 +1,4 @@
+{% load l10n %}
 {% if error_message %}
 <!-- Error notification -->
 <div class="alert alert-danger alert-dismissible fade show mb-3" role="alert">
@@ -67,7 +68,7 @@ function showPriceSaveSuccess(element) {
                            min="0"
                            class="form-control form-control-sm price-input" 
                            style="max-width: 120px;"
-                           value="{{ model.input_price_per_1m_tokens|default:'' }}"
+                           value="{% localize off %}{{ model.input_price_per_1m_tokens|default:'' }}{% endlocalize %}"
                            hx-post="{% url 'ai-model-update-field' provider.id model.id %}"
                            hx-trigger="blur changed"
                            hx-vals='{"field": "input_price_per_1m_tokens"}'
@@ -83,7 +84,7 @@ function showPriceSaveSuccess(element) {
                            min="0"
                            class="form-control form-control-sm price-input" 
                            style="max-width: 120px;"
-                           value="{{ model.output_price_per_1m_tokens|default:'' }}"
+                           value="{% localize off %}{{ model.output_price_per_1m_tokens|default:'' }}{% endlocalize %}"
                            hx-post="{% url 'ai-model-update-field' provider.id model.id %}"
                            hx-trigger="blur changed"
                            hx-vals='{"field": "output_price_per_1m_tokens"}'


### PR DESCRIPTION
Automated draft PR opened by the Claude queue worker for Agira item #852.

Model: Opus
Job: #23

---

## Zusammenfassung

Behebt das Problem, dass im View `/ai-providers/<id>/` gespeicherte Token-Preise (Input/Output) trotz korrekt persistierter Werte immer als `0,00` angezeigt wurden. Ursache war die deutsche Lokalisierung der `DecimalField`-Werte im Template: Django rendert bei `LANGUAGE_CODE = 'de-DE'` Dezimalzahlen mit Komma (`0,5000`), ein HTML-`<input type="number">` erwartet aber zwingend einen Punkt als Dezimaltrennzeichen und kann einen Komma-Wert nicht darstellen – das Feld blieb leer bzw. zeigte den Platzhalter `0.00`.

## Änderungen

- `templates/partials/ai_models_list.html`: Die beiden Preis-Inputs rendern ihren Wert jetzt innerhalb `{% localize off %}…{% endlocalize %}`, sodass der gespeicherte Decimal-Wert mit Punkt (`0.5000`) im `value`-Attribut landet und vom Number-Input korrekt angezeigt wird.
- `core/services/ai/pricing.py`: Neuer Helfer `parse_price_input()`, der einen Preis-String robust in ein `Decimal` umwandelt – akzeptiert sowohl das technische Format (`0.01`) als auch das deutsche Format (`0,01`); leere Eingabe ergibt `None`, ungültige Eingabe wirft `ValueError`.
- `core/views.py`: `ai_model_create`, `ai_model_update` und `ai_model_update_field` verwenden nun durchgängig `parse_price_input()` statt Ad-hoc-Konvertierung. Dadurch werden deutsche Dezimaleingaben zuverlässig verarbeitet und ungültige Werte sauber mit HTTP 400 abgewiesen, statt still auf `0`/Fehler zu laufen.
- `core/test_ai_model_pricing.py`: Regressionstests für das Laden/Anzeigen gespeicherter Preise (Rendering mit Punkt, nicht als `0,00`), für Speichern-und-Reload sowie Unit-Tests für das Parsing beider Dezimalformate.

## Warum / Entscheidungen

- Rendering mit `{% localize off %}` statt Umstellung des projektweiten `USE_I18N`/`LANGUAGE_CODE`, weil die deutsche Lokalisierung im Rest der Anwendung erwünscht ist; nur der maschinenlesbare `value` eines Number-Inputs darf nicht lokalisiert werden.
- Zentraler Helfer `parse_price_input()` statt dreifach dupliziertem `Decimal()`-Parsing, weil die drei Handler bisher uneinheitlich waren (`ai_model_update_field` konvertierte via `Decimal`, `create`/`update` gaben den Roh-String weiter) und so deutsche Eingaben je nach Pfad fehlschlugen.
- Komma wird als Dezimaltrennzeichen normalisiert (`replace(',', '.')`), nicht als Tausendertrennzeichen, weil Token-Preise kleine Pro-1M-Werte sind und kein Tausenderformat auftritt.
- Nicht den `unlocalize`-Filter verwendet, weil dieser bei `None` den String `"None"` erzeugt hätte; der `{% localize off %}`-Block kombiniert sauber mit `|default:''`.
- Bewusst nicht die HTMX-/JS-Serialisierung verändert, weil ein Number-Input bereits immer mit Punkt submittet und die serverseitige Normalisierung zusätzlich manuell im Komma-Format gesendete Werte abfängt.

## Test-Hinweise

- `python manage.py test core.test_ai_model_pricing --settings=agira.test_settings` – 13 Tests grün.
- Manuell: unter `/ai-providers/<id>/` einen Preis (z. B. `0,01` oder `0.01`) setzen, Feld verlassen (Auto-Save via HTMX), Seite neu laden – der Wert bleibt sichtbar und konsistent mit der Datenbank.
- Hinweis: Die bestehenden Suites `core.test_ai_views`/`core.test_ai_rbac` weisen bereits vor dieser Änderung 25 Fehler auf (unverändert); diese sind vom Fix unabhängig.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to admin AI provider UI and price parsing; no auth or billing calculation changes beyond form handling.
> 
> **Overview**
> Fixes **#852**: saved per-1M token prices on `/ai-providers/<id>/` appeared empty or as `0,00` because Django localized decimals with a comma in `<input type="number">` `value` attributes, which only accept dot-separated numbers.
> 
> **Display:** `ai_models_list.html` wraps price field values in `{% localize off %}` so stored decimals render with a dot (e.g. `0.5000`).
> 
> **Input:** Adds `parse_price_input()` in `pricing.py` to accept `0.01` and German `0,01`, map empty input to `None`, and reject invalid values. `ai_model_create`, `ai_model_update`, and `ai_model_update_field` use it instead of ad-hoc `Decimal()` / raw string handling, with HTTP 400 on bad input and unchanged negative-price checks on HTMX field updates.
> 
> **Tests:** New `core/test_ai_model_pricing.py` covers parsing, dot rendering, German saves, create/update flows, and negative rejection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5f39ba3ae553fc9a478b042c15dfdef89f5b07c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->