### PR TITLE
A pull request already exists for

### DIFF
--- a/core/management/commands/run_claude_worker.py
+++ b/core/management/commands/run_claude_worker.py
@@ -461,34 +461,75 @@ class Command(BaseCommand):
     def _open_draft_pr(self, job, branch, repo_dir):
         """Open the draft PR and record it on the job + ExternalIssueMapping.
 
-        Uses the existing ``GitHubService`` infra. On failure, falls back to
-        ``gh pr list --head`` (e.g. the PR already exists from a re-run) so a
-        transient API hiccup does not orphan the job.
+        A retried job reuses the exact same deterministic branch name as its
+        earlier attempt (``_branch_name`` is keyed on the item, not the job),
+        so an earlier attempt may already have a PR open on it. Checking for
+        that PR up front makes retries idempotent instead of hitting GitHub's
+        422 "A pull request already exists for ..." on every re-run.
+
+        If creation still races and hits that 422 (or any other API error),
+        re-check for an existing PR before falling back to ``gh pr list
+        --head`` and finally giving up.
         """
         from core.services.github.service import GitHubService
 
-        mapping = None
+        service = GitHubService()
+
+        mapping = self._find_existing_pr(job, branch, service)
+        if mapping is not None:
+            self._apply_pr_mapping(job, mapping, reused=True)
+            return
+
         try:
-            mapping = GitHubService().create_draft_pr_for_item(
+            mapping = service.create_draft_pr_for_item(
                 job.item,
                 branch_name=branch,
                 base='main',
                 title=job.item.title,
                 body=self._pr_body(job),
             )
-        except Exception as exc:  # noqa: BLE001 — fall back to gh lookup
+        except Exception as exc:  # noqa: BLE001 — a retry may hit an already-open PR
             logger.warning(
-                "Draft PR API call failed for job #%s (%s); trying gh fallback",
-                job.pk, exc,
+                "Draft PR API call failed for job #%s (%s); looking for an "
+                "existing PR on %s",
+                job.pk, exc, branch,
             )
-            mapping = self._pr_from_gh_fallback(job, branch, repo_dir)
+            mapping = (
+                self._find_existing_pr(job, branch, service)
+                or self._pr_from_gh_fallback(job, branch, repo_dir)
+            )
             if mapping is None:
                 raise
+            self._apply_pr_mapping(job, mapping, reused=True)
+            return
 
+        self._apply_pr_mapping(job, mapping, reused=False)
+
+    def _find_existing_pr(self, job, branch, service):
+        """Best-effort lookup of an already-open PR for ``branch`` via the API.
+
+        Returns None (never raises) so a lookup hiccup still lets the normal
+        create-PR path run instead of aborting the job.
+        """
+        try:
+            return service.find_open_pr_for_branch(job.item, branch)
+        except Exception as exc:  # noqa: BLE001 — fall through to PR creation
+            logger.warning(
+                "Existing-PR lookup failed for job #%s (%s)", job.pk, exc,
+            )
+            return None
+
+    def _apply_pr_mapping(self, job, mapping, *, reused):
+        """Record the PR on the job, logging whether it was reused or created."""
         job.pr_number = mapping.number
         job.pr_url = mapping.html_url
         job.save(update_fields=['pr_number', 'pr_url'])
-        self.stdout.write(f"  Draft PR #{mapping.number}: {mapping.html_url}")
+        if reused:
+            note = f"Reusing existing PR #{mapping.number} for branch {job.branch_name}"
+            self._save_progress(job, note)
+            self.stdout.write(f"  {note}: {mapping.html_url}")
+        else:
+            self.stdout.write(f"  Draft PR #{mapping.number}: {mapping.html_url}")
 
     def _pr_from_gh_fallback(self, job, branch, repo_dir):
         """Resolve an existing PR for ``branch`` via the ``gh`` CLI.

--- a/core/management/commands/test_run_claude_worker.py
+++ b/core/management/commands/test_run_claude_worker.py
@@ -530,6 +530,7 @@ class DraftPrTests(ClaudeWorkerTestBase):
             state='open', html_url='https://github.com/o/r/pull/42',
         )
         fake_service = MagicMock()
+        fake_service.find_open_pr_for_branch.return_value = None
         fake_service.create_draft_pr_for_item.return_value = mapping
 
         with patch('core.services.github.service.GitHubService',
@@ -539,6 +540,105 @@ class DraftPrTests(ClaudeWorkerTestBase):
         job.refresh_from_db()
         self.assertEqual(job.pr_number, 42)
         self.assertEqual(job.pr_url, 'https://github.com/o/r/pull/42')
+        fake_service.create_draft_pr_for_item.assert_called_once()
+
+    def test_open_draft_pr_reuses_existing_open_pr_without_creating(self):
+        """A retry hits the same deterministic branch — reuse its open PR."""
+        from unittest.mock import MagicMock
+        from core.models import ExternalIssueKind, ExternalIssueMapping
+
+        item = self._item(self.project_a)
+        job = self._job(self.project_a, item=item, branch_name='fix/x-1')
+
+        mapping = ExternalIssueMapping.objects.create(
+            item=item, github_id=555, number=42, kind=ExternalIssueKind.PR,
+            state='open', html_url='https://github.com/o/r/pull/42',
+        )
+        fake_service = MagicMock()
+        fake_service.find_open_pr_for_branch.return_value = mapping
+
+        with patch('core.services.github.service.GitHubService',
+                   return_value=fake_service):
+            Command()._open_draft_pr(job, 'fix/x-1', '/tmp/repo')
+
+        job.refresh_from_db()
+        self.assertEqual(job.pr_number, 42)
+        self.assertEqual(job.pr_url, 'https://github.com/o/r/pull/42')
+        self.assertIn('Reusing existing PR #42', job.progress_text)
+        fake_service.create_draft_pr_for_item.assert_not_called()
+
+    def test_open_draft_pr_falls_back_to_existing_pr_after_422(self):
+        """create_draft_pr_for_item 422s (already exists) -> re-check finds it."""
+        from unittest.mock import MagicMock
+        from core.models import ExternalIssueKind, ExternalIssueMapping
+        from core.services.integrations.errors import IntegrationPermanentError
+
+        item = self._item(self.project_a)
+        job = self._job(self.project_a, item=item, branch_name='fix/x-1')
+
+        mapping = ExternalIssueMapping.objects.create(
+            item=item, github_id=555, number=42, kind=ExternalIssueKind.PR,
+            state='open', html_url='https://github.com/o/r/pull/42',
+        )
+        fake_service = MagicMock()
+        fake_service.find_open_pr_for_branch.side_effect = [None, mapping]
+        fake_service.create_draft_pr_for_item.side_effect = IntegrationPermanentError(
+            "Client error (HTTP 422): {\"message\":\"Validation Failed\","
+            "\"errors\":[{\"message\":\"A pull request already exists for "
+            "o:fix/x-1.\"}]}"
+        )
+
+        with patch('core.services.github.service.GitHubService',
+                   return_value=fake_service):
+            Command()._open_draft_pr(job, 'fix/x-1', '/tmp/repo')
+
+        job.refresh_from_db()
+        self.assertEqual(job.pr_number, 42)
+        self.assertEqual(job.pr_url, 'https://github.com/o/r/pull/42')
+        self.assertIn('Reusing existing PR #42', job.progress_text)
+
+    def test_open_draft_pr_lookup_failure_still_allows_creation(self):
+        """A broken existing-PR lookup must not block the normal create path."""
+        from unittest.mock import MagicMock
+        from core.models import ExternalIssueKind, ExternalIssueMapping
+
+        item = self._item(self.project_a)
+        job = self._job(self.project_a, item=item)
+
+        mapping = ExternalIssueMapping.objects.create(
+            item=item, github_id=555, number=42, kind=ExternalIssueKind.PR,
+            state='open', html_url='https://github.com/o/r/pull/42',
+        )
+        fake_service = MagicMock()
+        fake_service.find_open_pr_for_branch.side_effect = RuntimeError('boom')
+        fake_service.create_draft_pr_for_item.return_value = mapping
+
+        with patch('core.services.github.service.GitHubService',
+                   return_value=fake_service):
+            Command()._open_draft_pr(job, 'fix/x-1', '/tmp/repo')
+
+        job.refresh_from_db()
+        self.assertEqual(job.pr_number, 42)
+        fake_service.create_draft_pr_for_item.assert_called_once()
+
+    def test_open_draft_pr_raises_when_no_pr_found_anywhere(self):
+        """No existing PR and creation fails -> propagate (real job failure)."""
+        from unittest.mock import MagicMock
+
+        item = self._item(self.project_a)
+        job = self._job(self.project_a, item=item)
+
+        fake_service = MagicMock()
+        fake_service.find_open_pr_for_branch.return_value = None
+        fake_service.create_draft_pr_for_item.side_effect = RuntimeError(
+            'network is down'
+        )
+
+        with patch('core.services.github.service.GitHubService',
+                   return_value=fake_service), \
+             patch.object(Command, '_pr_from_gh_fallback', return_value=None):
+            with self.assertRaises(RuntimeError):
+                Command()._open_draft_pr(job, 'fix/x-1', '/tmp/repo')
 
 
 class UpdatePrBodyTests(ClaudeWorkerTestBase):

--- a/core/services/github/client.py
+++ b/core/services/github/client.py
@@ -244,20 +244,23 @@ class GitHubClient:
         repo: str,
         state: str = 'all',
         since: Optional[str] = None,
+        head: Optional[str] = None,
         per_page: int = 30,
         page: int = 1,
     ) -> List[Dict[str, Any]]:
         """
         List pull requests in a repository.
-        
+
         Args:
             owner: Repository owner
             repo: Repository name
             state: Filter by state ('open', 'closed', 'all')
             since: Only PRs updated after this time (ISO 8601 timestamp)
+            head: Filter by head branch, formatted as ``owner:branch-name``
+                (GitHub only returns exact matches for this filter)
             per_page: Results per page (max 100)
             page: Page number
-            
+
         Returns:
             List of PR dictionaries
         """
@@ -267,10 +270,13 @@ class GitHubClient:
             'per_page': min(per_page, 100),
             'page': page,
         }
-        
+
+        if head:
+            params['head'] = head
+
         # Note: GitHub API for PRs doesn't support 'since' parameter directly
         # We would need to filter client-side if needed
-        
+
         return self.http.get(path, params=params)
     
     # Timeline/Events methods

--- a/core/services/github/service.py
+++ b/core/services/github/service.py
@@ -442,6 +442,52 @@ class GitHubService(IntegrationBase):
 
         return mapping
 
+    def find_open_pr_for_branch(
+        self,
+        item: Item,
+        branch_name: str,
+        user: Optional[User] = None,
+    ) -> Optional[ExternalIssueMapping]:
+        """
+        Look up an already-open pull request for ``branch_name`` via the API.
+
+        Makes draft-PR creation idempotent: a retried Claude queue job reuses
+        the same deterministic branch name as its earlier attempt (see
+        ``run_claude_worker._branch_name``), so by the time a retry gets here a
+        PR from that earlier attempt may already be open. Checking first (and
+        re-checking if creation still races and 422s) lets the worker reuse
+        that PR instead of failing on GitHub's "pull request already exists"
+        validation error.
+
+        Args:
+            item: Agira item the PR would belong to
+            branch_name: Head branch to look up, e.g. 'fix/item-42'
+            user: User whose GitHub PAT should be used (default: global token)
+
+        Returns:
+            The matching ExternalIssueMapping (kind=PR), or None if no open PR
+            targets that branch.
+        """
+        client = self._get_client(user=user)
+        owner, repo = self._get_repo_info(item)
+
+        prs = client.list_prs(owner, repo, state='open', head=f'{owner}:{branch_name}')
+        if not prs:
+            return None
+
+        github_pr = prs[0]
+        mapping, _ = ExternalIssueMapping.objects.update_or_create(
+            item=item,
+            kind=ExternalIssueKind.PR,
+            number=github_pr['number'],
+            defaults={
+                'github_id': github_pr['id'],
+                'state': self._map_state(github_pr, 'pr'),
+                'html_url': github_pr['html_url'],
+            },
+        )
+        return mapping
+
     def update_pr_body(
         self,
         item: Item,

--- a/core/services/github/test_github.py
+++ b/core/services/github/test_github.py
@@ -286,6 +286,56 @@ class GitHubServiceItemTestCase(TestCase):
         self.assertEqual(mapping.html_url,
                          'https://github.com/testowner/testrepo/pull/7')
 
+    @patch('core.services.github.client.GitHubClient.list_prs')
+    def test_find_open_pr_for_branch_returns_mapping(self, mock_list_prs):
+        """An open PR on the branch is found and recorded as an ExternalIssueMapping."""
+        mock_list_prs.return_value = [{
+            'id': 98765,
+            'number': 7,
+            'state': 'open',
+            'html_url': 'https://github.com/testowner/testrepo/pull/7',
+        }]
+
+        mapping = self.service.find_open_pr_for_branch(self.item, 'fix/test-bug-1')
+
+        call_kwargs = mock_list_prs.call_args[1]
+        self.assertEqual(call_kwargs['state'], 'open')
+        self.assertEqual(call_kwargs['head'], 'testowner:fix/test-bug-1')
+
+        self.assertIsNotNone(mapping)
+        self.assertEqual(mapping.kind, ExternalIssueKind.PR)
+        self.assertEqual(mapping.number, 7)
+        self.assertEqual(mapping.github_id, 98765)
+        self.assertEqual(mapping.html_url,
+                         'https://github.com/testowner/testrepo/pull/7')
+
+    @patch('core.services.github.client.GitHubClient.list_prs')
+    def test_find_open_pr_for_branch_returns_none_when_no_match(self, mock_list_prs):
+        mock_list_prs.return_value = []
+
+        mapping = self.service.find_open_pr_for_branch(self.item, 'fix/test-bug-1')
+
+        self.assertIsNone(mapping)
+
+    @patch('core.services.github.client.GitHubClient.list_prs')
+    def test_find_open_pr_for_branch_updates_existing_mapping(self, mock_list_prs):
+        """A second lookup for the same PR updates rather than duplicates the mapping."""
+        existing = ExternalIssueMapping.objects.create(
+            item=self.item, github_id=98765, number=7, kind=ExternalIssueKind.PR,
+            state='open', html_url='https://github.com/testowner/testrepo/pull/7',
+        )
+        mock_list_prs.return_value = [{
+            'id': 98765,
+            'number': 7,
+            'state': 'open',
+            'html_url': 'https://github.com/testowner/testrepo/pull/7',
+        }]
+
+        mapping = self.service.find_open_pr_for_branch(self.item, 'fix/test-bug-1')
+
+        self.assertEqual(mapping.pk, existing.pk)
+        self.assertEqual(ExternalIssueMapping.objects.filter(item=self.item).count(), 1)
+
     @patch('core.services.github.client.GitHubClient.update_pr')
     def test_update_pr_body(self, mock_update_pr):
         """update_pr_body overwrites the PR body via the GitHub client."""


### PR DESCRIPTION
Automated draft PR opened by the Claude queue worker for Agira item #853.

Model: Sonnet
Job: #24

---

## Zusammenfassung

Ein erneut ausgeführter Claude-Queue-Job scheiterte mit GitHub HTTP 422 ("A pull request already exists for ..."), sobald für den Job-Branch bereits ein Pull Request aus einem früheren Lauf existierte. Der PR-Erstellungspfad des Workers prüft jetzt vorab, ob für den Branch bereits ein offener PR existiert, und übernimmt diesen statt einen neuen anzulegen — Retries sind damit idempotent.

## Änderungen

- `core/services/github/client.py`: `GitHubClient.list_prs()` um optionalen `head`-Parameter (`owner:branch`) erweitert, um PRs branch-spezifisch abzufragen.
- `core/services/github/service.py`: neue Methode `GitHubService.find_open_pr_for_branch(item, branch_name)`, die einen offenen PR für den Branch über die REST-API sucht und als `ExternalIssueMapping` (Kind=PR) persistiert/aktualisiert.
- `core/management/commands/run_claude_worker.py` (`_open_draft_pr`):
  - Vor dem Erstellen wird jetzt per `find_open_pr_for_branch` geprüft, ob für den Branch bereits ein offener PR existiert; falls ja, wird dieser übernommen (`pr_number`/`pr_url` gesetzt) und kein neuer PR erstellt.
  - Schlägt die Erstellung dennoch fehl (z. B. durch eine Race und den bekannten 422 "already exists"), wird erneut nach einem bestehenden PR gesucht, bevor als letzter Ausweg der bestehende `gh pr list --head`-Fallback greift.
  - Neue Helper `_find_existing_pr` (fehlertolerant, blockiert die Job-Verarbeitung nicht bei Lookup-Fehlern) und `_apply_pr_mapping` (setzt Job-Felder, schreibt bei Wiederverwendung eine `progress_text`-Notiz "Reusing existing PR #… für branch …").
- Tests ergänzt/angepasst in `core/services/github/test_github.py` (neue `find_open_pr_for_branch`-Fälle) und `core/management/commands/test_run_claude_worker.py` (Wiederverwendung vor Erstellung, Fallback nach 422, tolerante Lookup-Fehler, echter Fehschlag bleibt ein Fehschlag).

## Warum / Entscheidungen

- **Root Cause:** `_branch_name(item)` ist rein von `item.id`/`item.title` abgeleitet, nicht vom Job. Ein Retry legt einen neuen `ClaudeQueueJob` für dasselbe Item an (FAILED hat keine ausgehenden State-Transitions, siehe `_TRANSITIONS`), landet aber auf demselben Branch wie der vorherige Lauf — deshalb kollidiert die PR-Erstellung deterministisch, nicht zufällig.
- **Primär proaktive Prüfung über die REST-API, nicht nur reaktiver Fallback**, weil der bestehende `gh pr list --head`-Fallback (`_pr_from_gh_fallback`) genau diesen Fall schon lösen sollte, in der Praxis aber am HTTP-422 vorbeigelaufen ist — vermutlich weil `gh` in der Worker-Umgebung nicht verfügbar/authentifiziert ist und der Fallback dann `None` liefert, wodurch die ursprüngliche Exception erneut geworfen wird. Die API-basierte Prüfung ist von der `gh`-CLI unabhängig und deckt den Normalfall ab, bevor überhaupt ein Request an `create_pull_request` geht.
- **Nicht: bestehenden PR schließen und neu anlegen (Fallback aus der Aufgabenstellung)**, weil der Reuse-Pfad technisch sauber umsetzbar ist (GitHub liefert den offenen PR zuverlässig über `GET /pulls?head=owner:branch`) und Schließen+Neuanlegen unnötig PR-Historie/Review-Kommentare verwerfen würde, ohne einen Vorteil zu bieten.
- **Nicht: `_branch_name` job-abhängig machen (z. B. Job-ID anhängen)**, weil das den bestehenden Zweck des Branch-Namens (ein Branch pro Item über mehrere Job-Versuche hinweg, damit Claude auf denselben Arbeitsstand aufsetzt) zerstören würde und deutlich mehr Bestandslogik (Checkout, Force-Push, Bootstrap-Commit-Erkennung) berühren müsste als nötig, um dieses Ticket zu lösen.
- **Fehlerbehandlung beim Lookup selbst ist bewusst best-effort** (`_find_existing_pr` fängt alle Exceptions ab und gibt `None` zurück): ein kaputter Lookup darf die normale Erstellung nicht blockieren, sonst würde eine neue Fehlerquelle den bisher funktionierenden Erstfall (kein bestehender PR) gefährden.
- **422-Erkennung generisch statt string-gebunden**: Nach jedem Fehler bei der PR-Erstellung wird erneut nach einem existierenden PR gesucht, unabhängig vom genauen Fehlertext. Das deckt den in der Aufgabenstellung genannten 422-Fall ab, ohne fragil an einer exakten GitHub-Fehlermeldung zu hängen, die sich ändern kann.

## Test-Hinweise

- `python manage.py test core.services.github.test_github core.management.commands.test_run_claude_worker --keepdb` — alle 88 Tests grün, inklusive neuer Fälle für Wiederverwendung eines offenen PRs, Fallback nach simuliertem 422, tolerantem Lookup-Fehler und echtem Fehschlag ohne auffindbaren PR.
- `python manage.py test core.services.claude_queue core.services.github --keepdb` — 60 Tests grün, keine Regression in Enqueue-/GitHub-Service-Logik.
- Manuell nachvollzogen: Job A erstellt Branch + Draft-PR #42 → Job B (Retry desselben Items) läuft auf denselben Branch → `_open_draft_pr` findet den offenen PR #42 über `find_open_pr_for_branch` und übernimmt ihn, ohne `create_draft_pr_for_item` aufzurufen (kein 422, `progress_text` zeigt "Reusing existing PR #42 for branch …").

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the worker’s up-front PR bootstrap path and GitHub integration; behavior change is narrow (reuse vs create) but failures here still block jobs before Claude runs.
> 
> **Overview**
> **Makes Claude queue worker draft-PR setup idempotent** when a retry uses the same item-derived branch and GitHub already has an open PR, avoiding HTTP 422 “pull request already exists” failures.
> 
> **GitHub layer:** `GitHubClient.list_prs` gains an optional `head` filter (`owner:branch`). `GitHubService.find_open_pr_for_branch` lists open PRs for that head and upserts an `ExternalIssueMapping` (kind=PR).
> 
> **Worker:** `_open_draft_pr` looks up an existing PR before `create_draft_pr_for_item`; on create failure it re-checks via API, then the existing `gh pr list --head` fallback. New helpers `_find_existing_pr` (lookup errors never block create) and `_apply_pr_mapping` (sets `pr_number`/`pr_url`, logs “Reusing existing PR #…” in `progress_text` when reused).
> 
> **Tests** cover reuse, 422 recovery, tolerant lookup failure, and hard failure when no PR is found.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e53a63590c1936731a226e4eef78de520c3083c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->