### PR TITLE
Job exceeded the 1800s timeout and was terminated.

### DIFF
--- a/core/management/commands/run_claude_worker.py
+++ b/core/management/commands/run_claude_worker.py
@@ -68,9 +68,9 @@ from core.models import (
 
 logger = logging.getLogger(__name__)
 
-# Default wall-clock budget for a single Claude invocation (30 minutes). A hung
+# Default wall-clock budget for a single Claude invocation (60 minutes). A hung
 # job must not block its project lane forever.
-DEFAULT_TIMEOUT_SECONDS = 30 * 60
+DEFAULT_TIMEOUT_SECONDS = 60 * 60
 
 # Watchdog: if no stream event arrives for this long, SIGINT the Claude process.
 # A known stdout-buffering bug means the stream can fall silent while Claude is

--- a/core/management/commands/test_run_claude_worker.py
+++ b/core/management/commands/test_run_claude_worker.py
@@ -20,7 +20,10 @@ from unittest.mock import patch
 from django.test import TestCase
 from django.utils import timezone
 
-from core.management.commands.run_claude_worker import Command
+from core.management.commands.run_claude_worker import (
+    Command,
+    DEFAULT_TIMEOUT_SECONDS,
+)
 from core.models import (
     ClaudeQueueJob,
     ClaudeQueueJobStatus,
@@ -218,6 +221,9 @@ class ProcessJobTests(ClaudeWorkerTestBase):
 
         job.item.refresh_from_db()
         self.assertEqual(job.item.status, ItemStatus.BACKLOG)
+
+    def test_default_timeout_is_sixty_minutes(self):
+        self.assertEqual(DEFAULT_TIMEOUT_SECONDS, 3600)
 
     def test_timeout_marks_failed(self):
         job = self._claimed_job(self.project_a)

--- a/core/models.py
+++ b/core/models.py
@@ -1856,6 +1856,13 @@ class ClaudeQueueJobStatus(models.TextChoices):
     CANCELLED = 'cancelled', _('Cancelled')
 
 
+# Runtime after which a still-running job is flagged in the UI as taking
+# longer than usual. Well below the worker's hard kill timeout (60 minutes,
+# see run_claude_worker.DEFAULT_TIMEOUT_SECONDS) — this is an early warning,
+# not a failure state.
+CLAUDE_QUEUE_JOB_LONG_RUNNING_SECONDS = 15 * 60
+
+
 class ClaudeQueueJob(models.Model):
     """A queued request to have Claude Code CLI work on an Item.
 
@@ -1942,6 +1949,18 @@ class ClaudeQueueJob(models.Model):
 
     def __str__(self):
         return f"ClaudeQueueJob #{self.pk} ({self.status}) - {self.item}"
+
+    @property
+    def is_long_running(self):
+        """True if a RUNNING job has been going for longer than usual.
+
+        Derived from status + started_at + now on every access — no
+        persisted state, so it can't go stale.
+        """
+        if self.status != ClaudeQueueJobStatus.RUNNING or self.started_at is None:
+            return False
+        elapsed = (timezone.now() - self.started_at).total_seconds()
+        return elapsed >= CLAUDE_QUEUE_JOB_LONG_RUNNING_SECONDS
 
     # Allowed state transitions for the job state machine.
     _TRANSITIONS = {

--- a/core/test_claude_queue_views.py
+++ b/core/test_claude_queue_views.py
@@ -7,10 +7,12 @@ from decimal import Decimal
 from django.test import TestCase, Client
 from django.urls import reverse
 from django.db.models import Max
+from django.utils import timezone
 
 from core.models import (
     Item, Project, ItemStatus, ItemType, User,
     ClaudeQueueJob, ClaudeQueueJobStatus,
+    CLAUDE_QUEUE_JOB_LONG_RUNNING_SECONDS,
 )
 
 
@@ -204,3 +206,53 @@ class ClaudeQueueViewsTestCase(TestCase):
         max_id = ClaudeQueueJob.objects.aggregate(Max('id'))['id__max'] or 0
         response = self.client.get(reverse('claude-queue-job-live', args=[max_id + 1]))
         self.assertEqual(response.status_code, 204)
+
+    # ---- long-running warning ------------------------------------------
+
+    def _job_started(self, seconds_ago, status=ClaudeQueueJobStatus.RUNNING):
+        return ClaudeQueueJob.objects.create(
+            item=self.item,
+            project=self.project,
+            status=status,
+            started_at=timezone.now() - timezone.timedelta(seconds=seconds_ago),
+        )
+
+    def test_is_long_running_false_below_threshold(self):
+        job = self._job_started(CLAUDE_QUEUE_JOB_LONG_RUNNING_SECONDS - 60)
+        self.assertFalse(job.is_long_running)
+
+    def test_is_long_running_true_above_threshold(self):
+        job = self._job_started(CLAUDE_QUEUE_JOB_LONG_RUNNING_SECONDS + 60)
+        self.assertTrue(job.is_long_running)
+
+    def test_is_long_running_false_when_not_running(self):
+        for status in (ClaudeQueueJobStatus.DONE, ClaudeQueueJobStatus.FAILED, ClaudeQueueJobStatus.CANCELLED):
+            job = self._job_started(CLAUDE_QUEUE_JOB_LONG_RUNNING_SECONDS + 60, status=status)
+            self.assertFalse(job.is_long_running)
+
+    def test_row_no_warning_below_threshold(self):
+        self.client.login(username='testuser', password='testpass123')
+        job = self._job_started(CLAUDE_QUEUE_JOB_LONG_RUNNING_SECONDS - 60)
+        response = self.client.get(reverse('claude-queue-job-row', args=[job.id]))
+        self.assertNotContains(response, 'Dauert länger als gewöhnlich')
+
+    def test_row_shows_warning_above_threshold(self):
+        self.client.login(username='testuser', password='testpass123')
+        job = self._job_started(CLAUDE_QUEUE_JOB_LONG_RUNNING_SECONDS + 60)
+        response = self.client.get(reverse('claude-queue-job-row', args=[job.id]))
+        self.assertContains(response, 'Dauert länger als gewöhnlich')
+
+    def test_done_job_never_shows_long_running_warning(self):
+        self.client.login(username='testuser', password='testpass123')
+        job = self._job_started(
+            CLAUDE_QUEUE_JOB_LONG_RUNNING_SECONDS + 3600,
+            status=ClaudeQueueJobStatus.DONE,
+        )
+        response = self.client.get(reverse('claude-queue-job-row', args=[job.id]))
+        self.assertNotContains(response, 'Dauert länger als gewöhnlich')
+
+    def test_detail_shows_long_running_warning(self):
+        self.client.login(username='testuser', password='testpass123')
+        job = self._job_started(CLAUDE_QUEUE_JOB_LONG_RUNNING_SECONDS + 60)
+        response = self.client.get(reverse('claude-queue-job-detail', args=[job.id]))
+        self.assertContains(response, 'Dauert länger als gewöhnlich')

--- a/templates/partials/claude_queue_job_live.html
+++ b/templates/partials/claude_queue_job_live.html
@@ -19,6 +19,12 @@ Expects `job` and `active_statuses` in context.
         {% endif %}
     </div>
 
+    {% if job.is_long_running %}
+    <div class="alert alert-warning" role="alert">
+        <i class="bi bi-hourglass-split"></i> Dauert länger als gewöhnlich
+    </div>
+    {% endif %}
+
     {% if job.status == 'failed' %}
     <div class="alert alert-danger" role="alert">
         <h6 class="alert-heading"><i class="bi bi-exclamation-triangle"></i> Job failed</h6>

--- a/templates/partials/claude_queue_job_row.html
+++ b/templates/partials/claude_queue_job_row.html
@@ -19,7 +19,14 @@ Expects `job` and `active_statuses` in context.
         <br><small class="text-muted">Item #{{ job.item.id }}</small>
     </td>
     <td>{{ job.project.name }}</td>
-    <td>{% include 'partials/claude_queue_status_badge.html' %}</td>
+    <td>
+        {% include 'partials/claude_queue_status_badge.html' %}
+        {% if job.is_long_running %}
+        <span class="badge bg-warning text-dark" title="Läuft seit {{ job.started_at|date:'Y-m-d H:i' }}">
+            <i class="bi bi-hourglass-split"></i> Dauert länger als gewöhnlich
+        </span>
+        {% endif %}
+    </td>
     <td class="cqj-progress" onclick="event.stopPropagation();">
         {% if job.status == 'failed' and job.error_text %}
         <span class="text-danger" title="{{ job.error_text }}">


### PR DESCRIPTION
Automated draft PR opened by the Claude queue worker for Agira item #855.

Model: Sonnet
Job: #27

---

## Zusammenfassung

Claude-Queue-Jobs wurden bisher nach 30 Minuten hart abgebrochen, was für größere Issues zu knapp war. Das harte Kill-Timeout wurde auf 60 Minuten erhöht. Damit lange Läufe nicht unbemerkt bleiben, zeigt die Queue-Ansicht ab 15 Minuten Laufzeit eines `running`-Jobs einen farblich hervorgehobenen Warnhinweis („Dauert länger als gewöhnlich“).

## Änderungen

- `DEFAULT_TIMEOUT_SECONDS` in `run_claude_worker.py` von `30 * 60` auf `60 * 60` erhöht; der bestehende Timeout-/Watchdog-Mechanismus (`_iter_events`, `_kill`, Fehlertext „Job exceeded the {timeout}s timeout…“) blieb unverändert und terminiert Jobs jetzt einfach erst nach 60 statt 30 Minuten.
- `ClaudeQueueJob.is_long_running` als Model-Property ergänzt (`core/models.py`): leitet sich deterministisch aus `status == RUNNING` und `started_at` ab, ohne zusätzliches persistiertes Feld. Schwellenwert `CLAUDE_QUEUE_JOB_LONG_RUNNING_SECONDS = 15 * 60` als Modul-Konstante.
- Warnbadge (`bg-warning`, „Dauert länger als gewöhnlich“) in `partials/claude_queue_job_row.html` (Listenansicht) und als `alert-warning`-Block in `partials/claude_queue_job_live.html` (Detailansicht) ergänzt, jeweils an `job.is_long_running` gebunden.
- Tests ergänzt: Default-Timeout-Wert, UI-Warnung unterhalb/oberhalb der 15-Minuten-Schwelle sowie Abwesenheit der Warnung bei `done`/`failed`/`cancelled`.

## Warum / Entscheidungen

- Ableitung der Warnung als Model-Property statt als zusätzliches DB-Feld (z. B. `is_long_running_flag`), weil sich der Zustand vollständig aus `status` und `started_at` berechnen lässt und so kein zusätzlicher Schreibpfad oder Migrationsaufwand nötig ist.
- Nicht die bestehende Watchdog-/State-Machine-Logik umgebaut, weil die Aufgabe ausdrücklich nur die Ziel-Laufzeit anpassen sollte; der Kill-Pfad, die Fehlermeldung und der Endzustand (`FAILED`) bleiben unverändert.
- Nicht der Grenzwert direkt im Template als Vergleich (`{% if job.started_at|timesince > "15 minutes" %}`) berechnet, weil Django-Template-Vergleiche für Zeitdifferenzen unzuverlässig sind und die Logik so nicht testbar in Python-Unit-Tests abgedeckt werden könnte.
- Nicht zusätzlich ein serverseitiges Polling-Intervall für die Warnung eingeführt, weil die bestehende HTMX-Polling-Infrastruktur (alle 3s/5s) die Warnung bei jedem Refresh ohnehin neu berechnet.
- Keine Änderung an der Job-State-Machine, der 1-Job-pro-Projekt-Logik oder automatischer Eskalation vorgenommen, da explizit nicht im Scope dieser Aufgabe.

## Test-Hinweise

- `python manage.py test core.management.commands.test_run_claude_worker` — inkl. neuem Test für `DEFAULT_TIMEOUT_SECONDS == 3600` und bestehendem Timeout-Abbruchpfad-Test.
- `python manage.py test core.test_claude_queue_views` — inkl. neuer Tests für `is_long_running` (unterhalb/oberhalb der Schwelle, nur bei `running`) sowie für das Erscheinen/Verschwinden des Warnhinweises in Listen- und Detailansicht.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only long-running flag plus a longer worker timeout; no auth or data-model migration, and existing timeout/recovery paths are unchanged aside from the new default duration.
> 
> **Overview**
> Raises the Claude queue worker’s **hard wall-clock kill** from **30 to 60 minutes** via `DEFAULT_TIMEOUT_SECONDS` in `run_claude_worker.py`; timeout handling and failure messaging stay the same, jobs just terminate later.
> 
> Adds an **early UI warning** (not a failed state) for `running` jobs past **15 minutes**: `CLAUDE_QUEUE_JOB_LONG_RUNNING_SECONDS` and a computed `ClaudeQueueJob.is_long_running` property from `status` + `started_at`. The queue **list row** shows a warning badge and the **detail live** partial shows an alert (“Dauert länger als gewöhnlich”), refreshed by existing HTMX polling.
> 
> Tests cover the new default timeout and long-running threshold/UI behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b20a8a0c4c2ad6803894f67e68668db4fc7ba94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->