### PR TITLE
Mini Dhasboard / KPI in /claude-queue/ oberhlab der JobListe und Paging einführen

### DIFF
--- a/core/test_claude_queue_views.py
+++ b/core/test_claude_queue_views.py
@@ -2,6 +2,8 @@
 Tests for the Claude Queue visibility views (list, detail, and HTMX polling
 partials).
 """
+import json
+import re
 from decimal import Decimal
 
 from django.test import TestCase, Client
@@ -256,3 +258,134 @@ class ClaudeQueueViewsTestCase(TestCase):
         job = self._job_started(CLAUDE_QUEUE_JOB_LONG_RUNNING_SECONDS + 60)
         response = self.client.get(reverse('claude-queue-job-detail', args=[job.id]))
         self.assertContains(response, 'Dauert länger als gewöhnlich')
+
+    # ---- mini dashboard --------------------------------------------------
+
+    def _job_with_data(self, cost=None, turns=None, duration_seconds=None, created_at=None):
+        started = timezone.now() - timezone.timedelta(seconds=duration_seconds) if duration_seconds is not None else None
+        finished = timezone.now() if duration_seconds is not None else None
+        job = ClaudeQueueJob.objects.create(
+            item=self.item,
+            project=self.project,
+            status=ClaudeQueueJobStatus.DONE,
+            total_cost_usd=cost,
+            num_turns=turns,
+            started_at=started,
+            finished_at=finished,
+        )
+        if created_at is not None:
+            ClaudeQueueJob.objects.filter(pk=job.pk).update(created_at=created_at)
+        return job
+
+    def test_dashboard_empty_queue_renders_without_errors(self):
+        self.client.login(username='testuser', password='testpass123')
+        response = self.client.get(reverse('claude-queue-jobs'))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context['queue_total_jobs'], 0)
+        self.assertIsNone(response.context['queue_avg_cost'])
+        self.assertIsNone(response.context['queue_avg_turns'])
+        self.assertIsNone(response.context['queue_avg_duration_display'])
+        self.assertContains(response, 'No queue jobs found.')
+
+    def test_dashboard_kpis_with_complete_data(self):
+        self.client.login(username='testuser', password='testpass123')
+        self._job_with_data(cost=Decimal('1.00'), turns=10, duration_seconds=60)
+        self._job_with_data(cost=Decimal('3.00'), turns=20, duration_seconds=120)
+        response = self.client.get(reverse('claude-queue-jobs'))
+        self.assertEqual(response.status_code, 200)
+        # Assert on context values, not rendered HTML — the KPI numbers go
+        # through the locale-aware floatformat filter (LANGUAGE_CODE=de-DE
+        # renders a comma decimal separator), so string-matching the
+        # rendered markup would be locale-fragile.
+        self.assertEqual(response.context['queue_total_jobs'], 2)
+        self.assertEqual(round(response.context['queue_avg_cost'], 4), Decimal('2.0000'))
+        self.assertEqual(response.context['queue_avg_turns'], 15.0)
+        self.assertEqual(response.context['queue_avg_duration_display'], '1m 30s')
+
+    def test_dashboard_kpis_ignore_missing_values(self):
+        self.client.login(username='testuser', password='testpass123')
+        # One job with all values, one job missing cost/turns/duration entirely.
+        self._job_with_data(cost=Decimal('4.00'), turns=8, duration_seconds=60)
+        ClaudeQueueJob.objects.create(
+            item=self.item, project=self.project, status=ClaudeQueueJobStatus.RUNNING,
+        )
+        response = self.client.get(reverse('claude-queue-jobs'))
+        self.assertEqual(response.status_code, 200)
+        # Averages should be based on the single job with data, not diluted by the empty one.
+        self.assertEqual(response.context['queue_total_jobs'], 2)
+        self.assertEqual(round(response.context['queue_avg_cost'], 4), Decimal('4.0000'))
+        self.assertEqual(response.context['queue_avg_turns'], 8.0)
+        self.assertEqual(response.context['queue_avg_duration_display'], '1m 0s')
+
+    def test_dashboard_chart_has_exactly_seven_days_using_created_at(self):
+        self.client.login(username='testuser', password='testpass123')
+        self._job_with_data(cost=Decimal('2.50'), created_at=timezone.now())
+        old_job = self._job_with_data(cost=Decimal('99.00'))
+        ClaudeQueueJob.objects.filter(pk=old_job.pk).update(
+            created_at=timezone.now() - timezone.timedelta(days=30)
+        )
+        response = self.client.get(reverse('claude-queue-jobs'))
+        self.assertEqual(response.status_code, 200)
+        match = re.search(r'\{"labels".*?\]\}', response.content.decode(), re.DOTALL)
+        self.assertIsNotNone(match)
+        chart_data = json.loads(match.group(0))
+        self.assertEqual(len(chart_data['labels']), 7)
+        self.assertEqual(len(chart_data['jobs']), 7)
+        self.assertEqual(len(chart_data['costs']), 7)
+        # Old job (30 days ago) must not be counted in the 7-day window.
+        self.assertEqual(sum(chart_data['jobs']), 1)
+        self.assertEqual(sum(chart_data['costs']), 2.5)
+        # Today (last entry) should carry the one recent job.
+        self.assertEqual(chart_data['jobs'][-1], 1)
+
+    def test_dashboard_days_without_jobs_are_zero(self):
+        self.client.login(username='testuser', password='testpass123')
+        response = self.client.get(reverse('claude-queue-jobs'))
+        self.assertEqual(response.status_code, 200)
+        match = re.search(r'\{"labels".*?\]\}', response.content.decode(), re.DOTALL)
+        chart_data = json.loads(match.group(0))
+        self.assertEqual(chart_data['jobs'], [0, 0, 0, 0, 0, 0, 0])
+        self.assertEqual(chart_data['costs'], [0, 0, 0, 0, 0, 0, 0])
+
+    # ---- pagination ------------------------------------------------------
+
+    def test_pagination_up_to_20_jobs_is_a_single_page(self):
+        self.client.login(username='testuser', password='testpass123')
+        for _ in range(20):
+            self._running_job()
+        response = self.client.get(reverse('claude-queue-jobs'))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.context['page_obj'].object_list), 20)
+        self.assertFalse(response.context['page_obj'].has_other_pages())
+
+    def test_pagination_more_than_20_jobs_spans_pages(self):
+        self.client.login(username='testuser', password='testpass123')
+        for _ in range(25):
+            self._running_job()
+        response = self.client.get(reverse('claude-queue-jobs'))
+        self.assertEqual(response.status_code, 200)
+        page_obj = response.context['page_obj']
+        self.assertEqual(len(page_obj.object_list), 20)
+        self.assertEqual(page_obj.paginator.num_pages, 2)
+
+        response_page_2 = self.client.get(reverse('claude-queue-jobs'), {'page': 2})
+        self.assertEqual(response_page_2.status_code, 200)
+        self.assertEqual(len(response_page_2.context['page_obj'].object_list), 5)
+
+    def test_pagination_zero_jobs_renders_without_errors(self):
+        self.client.login(username='testuser', password='testpass123')
+        response = self.client.get(reverse('claude-queue-jobs'))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(list(response.context['page_obj'].object_list), [])
+
+    def test_pagination_compatible_with_status_filter(self):
+        self.client.login(username='testuser', password='testpass123')
+        for _ in range(22):
+            self._running_job()
+        self._done_job()
+        response = self.client.get(
+            reverse('claude-queue-jobs'), {'status': ClaudeQueueJobStatus.DONE}
+        )
+        page_obj = response.context['page_obj']
+        self.assertEqual(page_obj.paginator.count, 1)
+        self.assertContains(response, 'PR #42')

--- a/core/views.py
+++ b/core/views.py
@@ -744,6 +744,91 @@ _CLAUDE_QUEUE_ACTIVE_STATUSES = (
 )
 
 
+def _format_duration_seconds(seconds):
+    """Render a duration in seconds as 'Hh Mm', 'Mm Ss' or 'Ss'."""
+    if seconds is None:
+        return None
+    seconds = int(seconds)
+    hours, remainder = divmod(seconds, 3600)
+    minutes, secs = divmod(remainder, 60)
+    if hours:
+        return f'{hours}h {minutes}m'
+    if minutes:
+        return f'{minutes}m {secs}s'
+    return f'{secs}s'
+
+
+def _claude_queue_dashboard_context():
+    """Aggregated KPIs + 7-day chart data, always over ALL queue jobs.
+
+    Kept separate from the filtered list query below: the dashboard reflects
+    overall queue health regardless of the project/status filter applied to
+    the table beneath it.
+    """
+    from datetime import timedelta
+
+    all_jobs = ClaudeQueueJob.objects.all()
+    total_jobs = all_jobs.count()
+
+    # Duration has no persisted field or existing helper anywhere in the
+    # project (checked models.py/admin.py/templates) — derived here from
+    # started_at/finished_at, the same pair is_long_running already uses.
+    duration_avg = all_jobs.filter(
+        started_at__isnull=False, finished_at__isnull=False,
+    ).annotate(
+        duration=models.ExpressionWrapper(
+            models.F('finished_at') - models.F('started_at'),
+            output_field=models.DurationField(),
+        )
+    ).aggregate(avg=models.Avg('duration'))['avg']
+    avg_duration_seconds = duration_avg.total_seconds() if duration_avg else None
+
+    avg_cost = all_jobs.filter(total_cost_usd__isnull=False).aggregate(
+        avg=models.Avg('total_cost_usd')
+    )['avg']
+    avg_turns = all_jobs.filter(num_turns__isnull=False).aggregate(
+        avg=models.Avg('num_turns')
+    )['avg']
+
+    # 7 calendar days incl. today, grouped on created_at using the project's
+    # established local-date convention (see ai_job_statistics()).
+    from django.db.models.functions import TruncDate
+
+    today = timezone.localdate()
+    start_of_7d = today - timedelta(days=6)
+    start_of_7d_dt = timezone.make_aware(datetime.combine(start_of_7d, time.min))
+
+    by_day_qs = (
+        all_jobs.filter(created_at__gte=start_of_7d_dt)
+        .annotate(day=TruncDate('created_at'))
+        .values('day')
+        .annotate(count=models.Count('id'), total_cost=models.Sum('total_cost_usd'))
+    )
+    by_day = {item['day']: item for item in by_day_qs}
+
+    date_labels = []
+    jobs_series = []
+    cost_series = []
+    for i in range(6, -1, -1):
+        day = today - timedelta(days=i)
+        date_labels.append(day.strftime('%d.%m.'))
+        entry = by_day.get(day)
+        jobs_series.append(entry['count'] if entry else 0)
+        cost_series.append(float(entry['total_cost']) if entry and entry['total_cost'] is not None else 0)
+
+    return {
+        'queue_total_jobs': total_jobs,
+        'queue_avg_duration_display': _format_duration_seconds(avg_duration_seconds),
+        'queue_avg_cost': avg_cost,
+        'queue_avg_turns': avg_turns,
+        'queue_chart_json': json.dumps({
+            'labels': date_labels,
+            'jobs': jobs_series,
+            'costs': cost_series,
+        }),
+    }
+
+
 @login_required
 def claude_queue_jobs(request):
     """List view of all Claude queue jobs with project/status filters."""
@@ -762,13 +847,18 @@ def claude_queue_jobs(request):
     if status_filter:
         jobs = jobs.filter(status=status_filter)
 
+    paginator = Paginator(jobs, 20)
+    page_obj = paginator.get_page(request.GET.get('page', 1))
+
     context = {
-        'jobs': jobs,
+        'jobs': page_obj,
+        'page_obj': page_obj,
         'projects': Project.objects.all().order_by('name'),
         'statuses': ClaudeQueueJobStatus.choices,
         'selected_project': project_filter,
         'selected_status': status_filter,
     }
+    context.update(_claude_queue_dashboard_context())
     return render(request, 'claude_queue_jobs.html', context)
 
 

--- a/templates/claude_queue_jobs.html
+++ b/templates/claude_queue_jobs.html
@@ -2,12 +2,67 @@
 
 {% block title %}Claude Queue - Agira{% endblock %}
 
+{% block extra_head %}
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+{% endblock %}
+
 {% block content %}
 <div class="page-header">
     <div class="d-flex justify-content-between align-items-center">
         <div>
             <h1>Claude Queue</h1>
             <p class="text-muted">Live view of what Claude Code is working on</p>
+        </div>
+    </div>
+</div>
+
+<!-- Mini Dashboard -->
+<div class="row g-3 mb-4">
+    <div class="col-md-2 col-6">
+        <div class="kpi-card">
+            <div class="kpi-icon"><i class="bi bi-list-check"></i></div>
+            <div class="kpi-content">
+                <div class="kpi-value">{{ queue_total_jobs }}</div>
+                <div class="kpi-label">Jobs</div>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-2 col-6">
+        <div class="kpi-card">
+            <div class="kpi-icon"><i class="bi bi-stopwatch"></i></div>
+            <div class="kpi-content">
+                <div class="kpi-value">{{ queue_avg_duration_display|default:"–" }}</div>
+                <div class="kpi-label">Ø Dauer</div>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-2 col-6">
+        <div class="kpi-card">
+            <div class="kpi-icon"><i class="bi bi-currency-dollar"></i></div>
+            <div class="kpi-content">
+                <div class="kpi-value">
+                    {% if queue_avg_cost is not None %}US${{ queue_avg_cost|floatformat:4 }}{% else %}–{% endif %}
+                </div>
+                <div class="kpi-label">Ø Kosten</div>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-2 col-6">
+        <div class="kpi-card">
+            <div class="kpi-icon"><i class="bi bi-arrow-repeat"></i></div>
+            <div class="kpi-content">
+                <div class="kpi-value">
+                    {% if queue_avg_turns is not None %}{{ queue_avg_turns|floatformat:1 }}{% else %}–{% endif %}
+                </div>
+                <div class="kpi-label">Ø Turns</div>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-4">
+        <div class="card h-100">
+            <div class="card-body py-2">
+                <canvas id="queueChart" style="max-height: 90px;"></canvas>
+            </div>
         </div>
     </div>
 </div>
@@ -72,6 +127,83 @@
                 </tbody>
             </table>
         </div>
+
+        <!-- Pagination Controls -->
+        {% if page_obj.has_other_pages %}
+        <nav aria-label="Page navigation" class="mt-3 pb-3 px-3">
+            <ul class="pagination justify-content-center">
+                {% if page_obj.has_previous %}
+                <li class="page-item">
+                    <a class="page-link" href="?page=1{% if selected_project %}&project={{ selected_project }}{% endif %}{% if selected_status %}&status={{ selected_status }}{% endif %}">First</a>
+                </li>
+                <li class="page-item">
+                    <a class="page-link" href="?page={{ page_obj.previous_page_number }}{% if selected_project %}&project={{ selected_project }}{% endif %}{% if selected_status %}&status={{ selected_status }}{% endif %}">Previous</a>
+                </li>
+                {% endif %}
+
+                <li class="page-item active">
+                    <span class="page-link">
+                        Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}
+                    </span>
+                </li>
+
+                {% if page_obj.has_next %}
+                <li class="page-item">
+                    <a class="page-link" href="?page={{ page_obj.next_page_number }}{% if selected_project %}&project={{ selected_project }}{% endif %}{% if selected_status %}&status={{ selected_status }}{% endif %}">Next</a>
+                </li>
+                <li class="page-item">
+                    <a class="page-link" href="?page={{ page_obj.paginator.num_pages }}{% if selected_project %}&project={{ selected_project }}{% endif %}{% if selected_status %}&status={{ selected_status }}{% endif %}">Last</a>
+                </li>
+                {% endif %}
+            </ul>
+            <div class="text-center text-muted">
+                <small>Showing {{ page_obj.start_index }} to {{ page_obj.end_index }} of {{ page_obj.paginator.count }} jobs</small>
+            </div>
+        </nav>
+        {% endif %}
     </div>
 </div>
+{% endblock %}
+
+{% block extra_js %}
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    const ctx = document.getElementById('queueChart');
+    if (ctx) {
+        const chartData = {{ queue_chart_json|safe }};
+        new Chart(ctx, {
+            data: {
+                labels: chartData.labels,
+                datasets: [
+                    {
+                        type: 'bar',
+                        label: 'Jobs',
+                        data: chartData.jobs,
+                        backgroundColor: 'rgba(13, 110, 253, 0.6)',
+                        yAxisID: 'y'
+                    },
+                    {
+                        type: 'line',
+                        label: 'Costs (US$)',
+                        data: chartData.costs,
+                        borderColor: 'rgba(220, 53, 69, 1)',
+                        backgroundColor: 'rgba(220, 53, 69, 0.1)',
+                        tension: 0.3,
+                        yAxisID: 'y1'
+                    }
+                ]
+            },
+            options: {
+                responsive: true,
+                maintainAspectRatio: true,
+                plugins: { legend: { display: true, position: 'bottom', labels: { boxHeight: 6 } } },
+                scales: {
+                    y: { beginAtZero: true, ticks: { stepSize: 1, precision: 0 } },
+                    y1: { beginAtZero: true, position: 'right', grid: { drawOnChartArea: false } }
+                }
+            }
+        });
+    }
+});
+</script>
 {% endblock %}


### PR DESCRIPTION
Automated draft PR opened by the Claude queue worker for Agira item #856.

Model: Sonnet
Job: #28

---

## Zusammenfassung

`/claude-queue/` zeigt jetzt oberhalb der Job-Liste ein kompaktes Mini-Dashboard mit vier KPIs (Anzahl Jobs, Ø Dauer, Ø Kosten, Ø Turns) und einem 7-Tage-Chart (Jobs/Tag + Kosten/Tag). Die Job-Liste ist zusätzlich serverseitig paginiert (20 Einträge/Seite).

## Änderungen

- `core/views.py`: neue Helper-Funktion `_claude_queue_dashboard_context()`, die KPIs und 7-Tage-Aggregation über **alle** `ClaudeQueueJob`-Datensätze berechnet (unabhängig vom Projekt-/Status-Filter der Liste darunter) und `_format_duration_seconds()` zur Anzeige der Dauer.
- `claude_queue_jobs()` paginiert die (weiterhin gefilterte) Job-Liste über `Paginator(jobs, 20)` und reicht `page_obj`/`queue_*`-Werte an das Template weiter.
- `templates/claude_queue_jobs.html`: Dashboard-Bereich mit vier `kpi-card`-Kacheln (bestehende CSS-Klasse aus `site.css`) und einem Chart.js-Canvas (Bar „Jobs" + Line „Costs" auf zwei Y-Achsen), sowie Pagination-Steuerung analog zu `ai_jobs_history.html`, inklusive Erhalt der Projekt-/Status-Filter in den Seiten-Links.
- `core/test_claude_queue_views.py`: neue Tests für Dashboard-Rendering (leer/vollständig/teilweise fehlende Werte), 7-Tage-Aggregation (genau 7 Punkte, `created_at`-Basis, 0 bei fehlenden Tagen) und Pagination (≤20, >20, 0 Jobs, Kompatibilität mit Status-Filter).

## Warum / Entscheidungen

- Durchschnittsdauer wird direkt aus `started_at`/`finished_at` per DB-Expression (`F('finished_at') - F('started_at')`, gefiltert auf beide Felder `isnull=False`) berechnet — nicht über eine neue Model-Property, weil es im Projekt bisher keine etablierte Duration-Ableitung gibt und der einzige Aufrufort die Aggregation im Dashboard ist; eine Property hätte nur diesen einen Nutzer und wäre eine unnötige Abstraktion.
- Kennzahlen und 7-Tage-Chart basieren auf allen Jobs (`ClaudeQueueJob.objects.all()`), unabhängig vom Projekt-/Status-Filter der Liste — nicht auf der gefilterten Queryset, weil die Aufgabenstellung explizit „alle Claude-Queue-Jobs" für die Kennzahlenbasis fordert und ein gefiltertes Dashboard bei aktivem Filter irreführend wäre.
- Durchschnittswerte filtern jeweils auf `isnull=False` je Feld statt mit `coalesce`/Default 0 zu rechnen — nicht mit künstlichen Default-Werten, weil das die Vorgabe „keine künstlichen Default-Annahmen für fehlende Einzelwerte" verletzen und die Durchschnitte verfälschen würde.
- Chart-Rendering nutzt Chart.js per CDN (bereits in `dashboard.html`/`ai_job_statistics.html` genutzt) — nicht eine neue Chart-Bibliothek, weil das Projekt Chart.js bereits als leichte Standardlösung etabliert hat und keine zusätzliche Dependency nötig ist.
- Pagination folgt exakt dem `Paginator`-Muster aus `ai_jobs_history()`/`ai_jobs_history.html` (inkl. First/Previous/Page X of Y/Next/Last und Erhalt der Query-Parameter) — nicht eine neue Pagination-Komponente, um Konsistenz mit der bestehenden Codebasis zu wahren.
- Dashboard-Query läuft als separate, ungefilterte Aggregation neben der gefilterten Listen-Query statt einer gemeinsamen Queryset — nicht als eine kombinierte Abfrage, weil Dashboard (immer alle Jobs) und Tabelle (gefiltert + paginiert) fachlich unterschiedliche Datenbasen brauchen und eine gemeinsame Query das Filterverhalten der KPIs verändert hätte.

## Test-Hinweise

- `python manage.py test core.test_claude_queue_views` — 30 Tests, alle grün (21 bestehende + 9 neue für Dashboard/Pagination).
- Abgedeckte Szenarien: leere Job-Liste (keine Exception, KPIs `None`/0), vollständige Datensätze, teilweise fehlende Kosten/Dauer/Turns (Durchschnitt ignoriert fehlende Werte statt sie als 0 zu werten), 7-Tage-Chart mit genau 7 Datenpunkten inkl. 0-Tagen und Ausschluss älterer Jobs außerhalb des Fensters, Pagination bei 0/≤20/>20 Jobs sowie Kompatibilität mit dem Status-Filter.
- Manuell geprüft: Template lädt fehlerfrei (`get_template`), keine Django-Systemcheck-Fehler (`manage.py check`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only UI and aggregation on an existing login-protected view; no auth or data-mutation paths changed.
> 
> **Overview**
> The **Claude Queue** list page now shows a **mini dashboard** above the table: total jobs, average duration, cost, and turns, plus a **7-day Chart.js** series (jobs and costs per day). Those aggregates always use **all** queue jobs, independent of the project/status filters on the list below.
> 
> `claude_queue_jobs()` **paginates** the filtered list at **20 jobs per page** (same pattern as AI jobs history), with pagination links that keep filter query params.
> 
> Backend adds `_format_duration_seconds()` and `_claude_queue_dashboard_context()` for DB-derived duration averages and `created_at`-based daily rollups. Tests cover empty/partial KPI data, the 7-day window, and pagination with filters.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68d3bd94c6c48ecafa037713571a2db37da8578a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->