### PR TITLE
Anpassung Dashboard in /claude-queue/

### DIFF
--- a/core/test_claude_queue_views.py
+++ b/core/test_claude_queue_views.py
@@ -9,6 +9,7 @@ from decimal import Decimal
 from django.test import TestCase, Client
 from django.urls import reverse
 from django.db.models import Max
+from django.template.defaultfilters import floatformat
 from django.utils import timezone
 
 from core.models import (
@@ -346,6 +347,53 @@ class ClaudeQueueViewsTestCase(TestCase):
         chart_data = json.loads(match.group(0))
         self.assertEqual(chart_data['jobs'], [0, 0, 0, 0, 0, 0, 0])
         self.assertEqual(chart_data['costs'], [0, 0, 0, 0, 0, 0, 0])
+
+    def test_dashboard_cost_kpi_rendered_with_two_decimals(self):
+        self.client.login(username='testuser', password='testpass123')
+        self._job_with_data(cost=Decimal('1.00'), turns=10, duration_seconds=60)
+        self._job_with_data(cost=Decimal('2.2345'), turns=20, duration_seconds=120)
+        response = self.client.get(reverse('claude-queue-jobs'))
+        self.assertEqual(response.status_code, 200)
+        expected_cost = floatformat(response.context['queue_avg_cost'], 2)
+        self.assertContains(response, f'US${expected_cost}')
+        # Guard against a regression back to more decimal places.
+        self.assertNotContains(response, f'US${floatformat(response.context["queue_avg_cost"], 4)}')
+
+    def test_dashboard_turns_kpi_rendered_without_decimals(self):
+        self.client.login(username='testuser', password='testpass123')
+        self._job_with_data(cost=Decimal('1.00'), turns=9, duration_seconds=60)
+        self._job_with_data(cost=Decimal('1.00'), turns=10, duration_seconds=60)
+        response = self.client.get(reverse('claude-queue-jobs'))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context['queue_avg_turns'], 9.5)
+        expected_turns = floatformat(response.context['queue_avg_turns'], 0)
+        self.assertContains(response, expected_turns)
+        self.assertNotIn(',', expected_turns)
+        self.assertNotIn('.', expected_turns)
+
+    def test_dashboard_kpis_render_without_errors_when_all_values_missing(self):
+        self.client.login(username='testuser', password='testpass123')
+        ClaudeQueueJob.objects.create(
+            item=self.item, project=self.project, status=ClaudeQueueJobStatus.RUNNING,
+        )
+        response = self.client.get(reverse('claude-queue-jobs'))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, '–')  # the "–" placeholder for empty KPIs
+
+    def test_dashboard_chart_canvas_is_placed_below_kpi_cards(self):
+        self.client.login(username='testuser', password='testpass123')
+        response = self.client.get(reverse('claude-queue-jobs'))
+        self.assertEqual(response.status_code, 200)
+        content = response.content.decode()
+        kpi_row_index = content.index('Ø Turns')
+        chart_index = content.index('id="queueChart"')
+        self.assertGreater(chart_index, kpi_row_index)
+
+    def test_dashboard_chart_container_has_increased_height(self):
+        self.client.login(username='testuser', password='testpass123')
+        response = self.client.get(reverse('claude-queue-jobs'))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'height: 320px;')
 
     # ---- pagination ------------------------------------------------------
 

--- a/templates/claude_queue_jobs.html
+++ b/templates/claude_queue_jobs.html
@@ -17,8 +17,8 @@
 </div>
 
 <!-- Mini Dashboard -->
-<div class="row g-3 mb-4">
-    <div class="col-md-2 col-6">
+<div class="row g-3 mb-3">
+    <div class="col-md-3 col-6">
         <div class="kpi-card">
             <div class="kpi-icon"><i class="bi bi-list-check"></i></div>
             <div class="kpi-content">
@@ -27,7 +27,7 @@
             </div>
         </div>
     </div>
-    <div class="col-md-2 col-6">
+    <div class="col-md-3 col-6">
         <div class="kpi-card">
             <div class="kpi-icon"><i class="bi bi-stopwatch"></i></div>
             <div class="kpi-content">
@@ -36,32 +36,37 @@
             </div>
         </div>
     </div>
-    <div class="col-md-2 col-6">
+    <div class="col-md-3 col-6">
         <div class="kpi-card">
             <div class="kpi-icon"><i class="bi bi-currency-dollar"></i></div>
             <div class="kpi-content">
                 <div class="kpi-value">
-                    {% if queue_avg_cost is not None %}US${{ queue_avg_cost|floatformat:4 }}{% else %}–{% endif %}
+                    {% if queue_avg_cost is not None %}US${{ queue_avg_cost|floatformat:2 }}{% else %}–{% endif %}
                 </div>
                 <div class="kpi-label">Ø Kosten</div>
             </div>
         </div>
     </div>
-    <div class="col-md-2 col-6">
+    <div class="col-md-3 col-6">
         <div class="kpi-card">
             <div class="kpi-icon"><i class="bi bi-arrow-repeat"></i></div>
             <div class="kpi-content">
                 <div class="kpi-value">
-                    {% if queue_avg_turns is not None %}{{ queue_avg_turns|floatformat:1 }}{% else %}–{% endif %}
+                    {% if queue_avg_turns is not None %}{{ queue_avg_turns|floatformat:0 }}{% else %}–{% endif %}
                 </div>
                 <div class="kpi-label">Ø Turns</div>
             </div>
         </div>
     </div>
-    <div class="col-md-4">
-        <div class="card h-100">
-            <div class="card-body py-2">
-                <canvas id="queueChart" style="max-height: 90px;"></canvas>
+</div>
+
+<div class="row g-3 mb-4">
+    <div class="col-12">
+        <div class="card">
+            <div class="card-body">
+                <div style="height: 320px;">
+                    <canvas id="queueChart"></canvas>
+                </div>
             </div>
         </div>
     </div>
@@ -195,7 +200,7 @@ document.addEventListener('DOMContentLoaded', function() {
             },
             options: {
                 responsive: true,
-                maintainAspectRatio: true,
+                maintainAspectRatio: false,
                 plugins: { legend: { display: true, position: 'bottom', labels: { boxHeight: 6 } } },
                 scales: {
                     y: { beginAtZero: true, ticks: { stepSize: 1, precision: 0 } },


### PR DESCRIPTION
Automated draft PR opened by the Claude queue worker for Agira item #858.

Model: Sonnet
Job: #30

---

## Zusammenfassung
- Das 7-Tage-Chart im Mini-Dashboard von `/claude-queue/` steht jetzt unterhalb der KPI-Kacheln in einer eigenen, vollbreiten Reihe statt in einer schmalen Spalte neben ihnen.
- Das Chart hat deutlich mehr vertikalen Platz (fester 320px-Container statt 90px-Canvas), wodurch Achsen, Balken/Linie und Legende besser lesbar sind.
- Die Ø-Kosten-KPI wird jetzt immer mit genau 2 Nachkommastellen angezeigt.
- Die Ø-Turns-KPI wird jetzt als ganze Zahl ohne Nachkommastellen angezeigt.

## Änderungen
- `templates/claude_queue_jobs.html`: KPI-Kacheln (Jobs, Ø Dauer, Ø Kosten, Ø Turns) in eine eigene 4-spaltige Reihe verschoben; darunter eine neue volle Zeile mit dem Chart in einem Container fester Höhe (320px). Chart.js-Option `maintainAspectRatio` auf `false` gesetzt, damit das Chart die neue Containerhöhe tatsächlich ausfüllt statt sein altes Seitenverhältnis beizubehalten.
- Kosten-Filter von `floatformat:4` auf `floatformat:2` geändert.
- Turns-Filter von `floatformat:1` auf `floatformat:0` geändert.
- `core/test_claude_queue_views.py`: Tests ergänzt, die die Chart-Position unterhalb der KPI-Kacheln, die erhöhte Chart-Höhe sowie die Kosten-/Turns-Formatierung im gerenderten HTML prüfen; zusätzlicher Test für das fehlerfreie Rendern, wenn alle KPI-Werte fehlen.

## Warum / Entscheidungen
- Nicht die Berechnung von `queue_avg_cost`/`queue_avg_turns` in `core/views.py` gerundet, weil die Aufgabe ausdrücklich nur die Anzeige betrifft und die Rohwerte weiterhin für andere Konsumenten (z. B. Tests, die auf exakte Averages prüfen) unverändert bleiben sollen.
- Die Dauer-KPI (`queue_avg_duration_display`) unverändert gelassen, weil `_format_duration_seconds` bereits ganzzahlige Werte im Format „Xh Ym“ liefert — hier bestand kein Dezimalstellen-Problem.
- Nicht `maintainAspectRatio: true` mit einem größeren `max-height`-Wert am Canvas beibehalten, weil Chart.js dabei weiterhin das ursprüngliche Canvas-Seitenverhältnis erzwingt und die gewünschte Höhenvergrößerung im Browser nicht zuverlässig sichtbar wird; stattdessen ein Container mit fester Höhe plus `maintainAspectRatio: false`, was die tatsächliche Pixel-Höhe direkt steuert.
- Keine neue Chart-Bibliothek und keine Änderung an Datenbasis, Aggregation, Zeitraum oder Filter-/Paging-Verhalten, wie im Scope gefordert.

## Test-Hinweise
- `python manage.py test core.test_claude_queue_views` — alle 35 Tests (30 bestehende + 5 neue) grün.
- Neue Tests decken ab: Chart-Canvas erscheint im HTML nach den KPI-Kacheln, Chart-Container hat die erhöhte Höhe (320px), Kosten werden mit 2 Nachkommastellen gerendert (inkl. Regressionsschutz gegen 4 Nachkommastellen), Turns werden ohne Komma/Punkt gerendert, und das Dashboard rendert fehlerfrei, wenn alle KPI-Werte fehlen.
- Manuell im Browser zu prüfen: `/claude-queue/` aufrufen und visuell bestätigen, dass das Chart unterhalb der KPI-Kacheln sitzt, sichtbar höher ist als zuvor und es keine Browser-Console-Fehler gibt.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Template and test-only changes on an internal dashboard; no auth, data, or aggregation logic changes.
> 
> **Overview**
> The **Claude Queue** mini-dashboard at `/claude-queue/` is reworked so KPI tiles and the 7-day chart read more clearly.
> 
> **KPI row:** The four cards (Jobs, Ø Dauer, Ø Kosten, Ø Turns) now sit in a full-width row (`col-md-3` each). **Ø Kosten** is shown with **2** decimal places (`floatformat:2`, was 4). **Ø Turns** is shown as a **whole number** (`floatformat:0`, was 1). Backend averages are unchanged; only template formatting.
> 
> **Chart:** The chart moves **below** the KPI row in its own full-width card with a **320px** tall container (replacing a narrow side column and ~90px canvas). Chart.js uses **`maintainAspectRatio: false`** so the chart fills that height.
> 
> **Tests:** Five new view tests in `core/test_claude_queue_views.py` lock in cost/turns display, chart order vs KPIs, 320px height, and safe rendering when KPI values are missing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 995d6dc535befa61a02f053c51cfd120bd37c88c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->