### PR TITLE
Löschen von Claude Code Jobs in Claude queue

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -1962,6 +1962,20 @@ class ClaudeQueueJob(models.Model):
         elapsed = (timezone.now() - self.started_at).total_seconds()
         return elapsed >= CLAUDE_QUEUE_JOB_LONG_RUNNING_SECONDS
 
+    # Statuses a job may be manually deleted from — terminal states only, so a
+    # job the worker (or a queued claim) still owns can never be removed out
+    # from under it.
+    _DELETABLE_STATUSES = frozenset({
+        ClaudeQueueJobStatus.DONE,
+        ClaudeQueueJobStatus.FAILED,
+        ClaudeQueueJobStatus.CANCELLED,
+    })
+
+    @property
+    def is_deletable(self):
+        """True if this job is in a terminal state and safe to delete."""
+        return self.status in self._DELETABLE_STATUSES
+
     # Allowed state transitions for the job state machine.
     _TRANSITIONS = {
         ClaudeQueueJobStatus.QUEUED: {ClaudeQueueJobStatus.RUNNING, ClaudeQueueJobStatus.CANCELLED},

--- a/core/test_claude_queue_views.py
+++ b/core/test_claude_queue_views.py
@@ -89,6 +89,20 @@ class ClaudeQueueViewsTestCase(TestCase):
             error_text='boom: something went wrong',
         )
 
+    def _cancelled_job(self):
+        return ClaudeQueueJob.objects.create(
+            item=self.item,
+            project=self.project,
+            status=ClaudeQueueJobStatus.CANCELLED,
+        )
+
+    def _queued_job(self):
+        return ClaudeQueueJob.objects.create(
+            item=self.item,
+            project=self.project,
+            status=ClaudeQueueJobStatus.QUEUED,
+        )
+
     # ---- auth ----------------------------------------------------------
 
     def test_list_requires_authentication(self):
@@ -437,3 +451,119 @@ class ClaudeQueueViewsTestCase(TestCase):
         page_obj = response.context['page_obj']
         self.assertEqual(page_obj.paginator.count, 1)
         self.assertContains(response, 'PR #42')
+
+    # ---- is_deletable ------------------------------------------------------
+
+    def test_is_deletable_true_for_terminal_statuses(self):
+        for job in (self._done_job(), self._failed_job(), self._cancelled_job()):
+            self.assertTrue(job.is_deletable)
+
+    def test_is_deletable_false_for_active_statuses(self):
+        for job in (self._queued_job(), self._running_job()):
+            self.assertFalse(job.is_deletable)
+
+    # ---- delete --------------------------------------------------------
+
+    def test_delete_requires_authentication(self):
+        job = self._done_job()
+        response = self.client.post(reverse('claude-queue-job-delete', args=[job.id]))
+        self.assertEqual(response.status_code, 302)
+        self.assertIn('/login/', response.url)
+        self.assertTrue(ClaudeQueueJob.objects.filter(id=job.id).exists())
+
+    def test_delete_requires_post(self):
+        self.client.login(username='testuser', password='testpass123')
+        job = self._done_job()
+        response = self.client.get(reverse('claude-queue-job-delete', args=[job.id]))
+        self.assertEqual(response.status_code, 405)
+        self.assertTrue(ClaudeQueueJob.objects.filter(id=job.id).exists())
+
+    def test_delete_failed_job_succeeds(self):
+        self.client.login(username='testuser', password='testpass123')
+        job = self._failed_job()
+        response = self.client.post(reverse('claude-queue-job-delete', args=[job.id]))
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(ClaudeQueueJob.objects.filter(id=job.id).exists())
+
+    def test_delete_done_job_succeeds(self):
+        self.client.login(username='testuser', password='testpass123')
+        job = self._done_job()
+        response = self.client.post(reverse('claude-queue-job-delete', args=[job.id]))
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(ClaudeQueueJob.objects.filter(id=job.id).exists())
+
+    def test_delete_cancelled_job_succeeds(self):
+        self.client.login(username='testuser', password='testpass123')
+        job = self._cancelled_job()
+        response = self.client.post(reverse('claude-queue-job-delete', args=[job.id]))
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(ClaudeQueueJob.objects.filter(id=job.id).exists())
+
+    def test_deleted_job_no_longer_appears_in_list(self):
+        self.client.login(username='testuser', password='testpass123')
+        job = self._done_job()
+        self.client.post(reverse('claude-queue-job-delete', args=[job.id]))
+        response = self.client.get(reverse('claude-queue-jobs'))
+        self.assertNotContains(response, 'PR #42')
+
+    def test_delete_running_job_is_rejected(self):
+        self.client.login(username='testuser', password='testpass123')
+        job = self._running_job()
+        response = self.client.post(reverse('claude-queue-job-delete', args=[job.id]))
+        self.assertEqual(response.status_code, 400)
+        self.assertTrue(ClaudeQueueJob.objects.filter(id=job.id).exists())
+
+    def test_delete_queued_job_is_rejected(self):
+        self.client.login(username='testuser', password='testpass123')
+        job = self._queued_job()
+        response = self.client.post(reverse('claude-queue-job-delete', args=[job.id]))
+        self.assertEqual(response.status_code, 400)
+        self.assertTrue(ClaudeQueueJob.objects.filter(id=job.id).exists())
+
+    def test_delete_nonexistent_job_returns_404(self):
+        self.client.login(username='testuser', password='testpass123')
+        max_id = ClaudeQueueJob.objects.aggregate(Max('id'))['id__max'] or 0
+        response = self.client.post(reverse('claude-queue-job-delete', args=[max_id + 1]))
+        self.assertEqual(response.status_code, 404)
+
+    def test_delete_with_redirect_param_sets_hx_redirect_header(self):
+        self.client.login(username='testuser', password='testpass123')
+        job = self._done_job()
+        response = self.client.post(
+            reverse('claude-queue-job-delete', args=[job.id]) + '?redirect=1',
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response['HX-Redirect'], reverse('claude-queue-jobs'))
+
+    def test_delete_without_redirect_param_has_no_hx_redirect_header(self):
+        self.client.login(username='testuser', password='testpass123')
+        job = self._done_job()
+        response = self.client.post(reverse('claude-queue-job-delete', args=[job.id]))
+        self.assertEqual(response.status_code, 200)
+        self.assertNotIn('HX-Redirect', response)
+
+    # ---- delete button rendering ----------------------------------------
+
+    def test_row_shows_delete_button_for_deletable_job(self):
+        self.client.login(username='testuser', password='testpass123')
+        job = self._done_job()
+        response = self.client.get(reverse('claude-queue-job-row', args=[job.id]))
+        self.assertContains(response, reverse('claude-queue-job-delete', args=[job.id]))
+
+    def test_row_hides_delete_button_for_running_job(self):
+        self.client.login(username='testuser', password='testpass123')
+        job = self._running_job()
+        response = self.client.get(reverse('claude-queue-job-row', args=[job.id]))
+        self.assertNotContains(response, reverse('claude-queue-job-delete', args=[job.id]))
+
+    def test_detail_shows_delete_button_for_deletable_job(self):
+        self.client.login(username='testuser', password='testpass123')
+        job = self._done_job()
+        response = self.client.get(reverse('claude-queue-job-detail', args=[job.id]))
+        self.assertContains(response, reverse('claude-queue-job-delete', args=[job.id]))
+
+    def test_detail_hides_delete_button_for_running_job(self):
+        self.client.login(username='testuser', password='testpass123')
+        job = self._running_job()
+        response = self.client.get(reverse('claude-queue-job-detail', args=[job.id]))
+        self.assertNotContains(response, reverse('claude-queue-job-delete', args=[job.id]))

--- a/core/urls.py
+++ b/core/urls.py
@@ -129,6 +129,7 @@ urlpatterns = [
     path('claude-queue/<int:job_id>/', views.claude_queue_job_detail, name='claude-queue-job-detail'),
     path('claude-queue/<int:job_id>/row/', views.claude_queue_job_row, name='claude-queue-job-row'),
     path('claude-queue/<int:job_id>/live/', views.claude_queue_job_live, name='claude-queue-job-live'),
+    path('claude-queue/<int:job_id>/delete/', views.claude_queue_job_delete, name='claude-queue-job-delete'),
     path('changes/new/', views.change_create, name='change-create'),
     path('changes/<int:id>/', views.change_detail, name='change-detail'),
     path('changes/<int:id>/edit/', views.change_edit, name='change-edit'),

--- a/core/views.py
+++ b/core/views.py
@@ -913,6 +913,42 @@ def claude_queue_job_live(request, job_id):
         'active_statuses': _CLAUDE_QUEUE_ACTIVE_STATUSES,
     })
 
+
+@login_required
+@require_http_methods(["POST"])
+def claude_queue_job_delete(request, job_id):
+    """Delete a single Claude queue job.
+
+    Only terminal jobs (done/failed/cancelled) are deletable — a running or
+    queued job is still owned by the worker, so deleting it here would race
+    with claiming/processing. Used both from the list row (in-place HTMX
+    removal) and the detail page (redirect back to the list, requested via
+    the `redirect` query param, using the project's HX-Redirect convention).
+    """
+    job = get_object_or_404(ClaudeQueueJob, id=job_id)
+
+    if not job.is_deletable:
+        return HttpResponse(
+            f"Job #{job.id} has status '{job.get_status_display()}' and cannot be deleted.",
+            status=400,
+        )
+
+    item, status_label = job.item, job.get_status_display()
+    job.delete()
+
+    ActivityService().log(
+        verb='claudequeuejob.deleted',
+        target=item,
+        actor=request.user if request.user.is_authenticated else None,
+        summary=f"Claude queue job #{job_id} ({status_label}) deleted",
+    )
+
+    response = HttpResponse()
+    if request.GET.get('redirect'):
+        response['HX-Redirect'] = reverse('claude-queue-jobs')
+    return response
+
+
 @login_required
 def item_lookup(request, item_id):
     """

--- a/templates/claude_queue_job_detail.html
+++ b/templates/claude_queue_job_detail.html
@@ -19,6 +19,14 @@
                 &middot; Model: {{ job.get_model_display }}
             </p>
         </div>
+        {% if job.is_deletable %}
+        <button type="button" class="btn btn-outline-danger"
+                hx-post="{% url 'claude-queue-job-delete' job.id %}?redirect=1"
+                hx-confirm="Job #{{ job.id }} endgültig löschen?"
+                hx-on::htmx:response-error="showToast(event.detail.xhr.responseText, 'error')">
+            <i class="bi bi-trash"></i> Job löschen
+        </button>
+        {% endif %}
     </div>
 </div>
 

--- a/templates/claude_queue_jobs.html
+++ b/templates/claude_queue_jobs.html
@@ -119,6 +119,7 @@
                         <th>PR</th>
                         <th>Turns / Cost</th>
                         <th>Created</th>
+                        <th>Actions</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -126,7 +127,7 @@
                     {% include 'partials/claude_queue_job_row.html' %}
                     {% empty %}
                     <tr>
-                        <td colspan="8" class="text-center text-muted py-4">No queue jobs found.</td>
+                        <td colspan="9" class="text-center text-muted py-4">No queue jobs found.</td>
                     </tr>
                     {% endfor %}
                 </tbody>

--- a/templates/partials/claude_queue_job_row.html
+++ b/templates/partials/claude_queue_job_row.html
@@ -59,4 +59,16 @@ Expects `job` and `active_statuses` in context.
         {% if job.total_cost_usd is not None %}<br><small class="text-muted">${{ job.total_cost_usd|floatformat:4 }}</small>{% endif %}
     </td>
     <td class="text-nowrap"><small class="text-muted">{{ job.created_at|date:"Y-m-d H:i" }}</small></td>
+    <td class="text-nowrap" onclick="event.stopPropagation();">
+        {% if job.is_deletable %}
+        <button type="button" class="btn btn-outline-danger btn-sm"
+                hx-post="{% url 'claude-queue-job-delete' job.id %}"
+                hx-target="closest tr"
+                hx-swap="outerHTML swap:1s"
+                hx-confirm="Job #{{ job.id }} endgültig löschen?"
+                hx-on::htmx:response-error="showToast(event.detail.xhr.responseText, 'error')">
+            <i class="bi bi-trash"></i>
+        </button>
+        {% endif %}
+    </td>
 </tr>


### PR DESCRIPTION
Automated draft PR opened by the Claude queue worker for Agira item #892.

Model: Sonnet
Job: #66

---

## Zusammenfassung

Beendete Claude-Queue-Jobs (`done`, `failed`, `cancelled`) lassen sich jetzt einzeln manuell löschen, sowohl aus der Queue-Übersicht als auch aus der Detailansicht. `running`- und `queued`-Jobs bleiben unlöschbar, damit ein aktiver Worker-Job nicht unter laufender Verarbeitung entfernt werden kann.

## Änderungen

- `ClaudeQueueJob.is_deletable`: neue Property, die genau dann `True` liefert, wenn der Job in einem der terminalen Status `done`, `failed` oder `cancelled` ist.
- Neuer Endpunkt `claude-queue-job-delete` (`POST /claude-queue/<id>/delete/`): prüft `is_deletable` serverseitig, löscht den Job physisch (`ClaudeQueueJob.delete()`) und protokolliert die Löschung als Activity-Eintrag am zugehörigen Item. Nicht löschbare Jobs werden mit HTTP 400 abgewiesen, ohne dass ein Datensatz verändert wird.
- Queue-Liste (`claude_queue_job_row.html`): neue "Actions"-Spalte mit Löschbutton, der nur für löschbare Jobs gerendert wird; Klick löst per HTMX eine Bestätigungsabfrage aus und entfernt die Zeile bei Erfolg direkt aus der Tabelle (`hx-target="closest tr"`, leere Erfolgsantwort).
- Detailansicht (`claude_queue_job_detail.html`): gleicher Löschbutton, nur wenn löschbar; nutzt denselben Endpunkt mit `?redirect=1` und den bestehenden `HX-Redirect`-Header-Mechanismus, um nach dem Löschen zurück zur Queue-Übersicht zu navigieren.
- Fehlerfälle (z. B. Race durch parallelen Statuswechsel) zeigen über `hx-on::htmx:response-error` einen Toast mit der Serverfehlermeldung, ohne die Zeile zu entfernen.

## Warum / Entscheidungen

- Physisches Löschen statt Soft-Delete/Archiv, weil das Issue dies explizit erlaubt und im Datenmodell kein bestehendes Soft-Delete-Muster für `ClaudeQueueJob` existiert; eine neue Archivlogik wäre Scope-Erweiterung ohne Nutzen für dieses Ticket.
- `is_deletable` als eigene, benannte Property statt eines Freitext-Status-Vergleichs im View, weil der State-Machine-Code in `models.py` bereits denselben Musterstil verwendet (`is_long_running`) und die Regel so zentral und testbar an einer Stelle liegt statt verstreut in Views/Templates.
- Nicht wiederverwendet: die vorhandenen `_TRANSITIONS`-Terminalzustände (leere Ziel-Mengen) wurden nicht direkt als Ableitung für `is_deletable` genutzt, weil das die Löschregel implizit an die Transition-Tabelle koppeln würde – eine spätere Änderung der State-Machine dürfte die Löschbarkeit nicht unbeabsichtigt mitverändern; eine explizite Statusliste hält beide Konzepte bewusst getrennt.
- Ein einzelner Delete-Endpunkt für Liste und Detailansicht statt zweier separater Views, weil sich beide Aufrufer nur im gewünschten Response-Verhalten (In-place-Entfernen vs. Redirect) unterscheiden; ein optionaler `redirect`-Query-Parameter genügt dafür und vermeidet doppelte Berechtigungs-/Löschlogik.
- `HX-Redirect`-Header statt JSON-Response mit `redirect`-Feld (wie z. B. bei `item-delete`), weil für Detailseiten mit reiner HTMX-Aktion (kein `fetch`/JS-Handler) im Projekt bereits das `HX-Redirect`-Muster existiert (`ai-provider-delete`); JSON+JS hätte zusätzlichen Client-Code für einen bereits gelösten Fall erfordert.
- Kein Bulk-Delete und keine Änderung an State-Machine/Worker-Claiming, da explizit außerhalb des Scopes.

## Test-Hinweise

- `core/test_claude_queue_views.py`: neue Tests decken ab: `is_deletable` für alle fünf Status, Löschen von `done`/`failed`/`cancelled` (Erfolg, Datensatz verschwindet aus der Liste), Ablehnung für `running`/`queued` (Status 400, Datensatz bleibt bestehen), Auth-Pflicht (302), Methodenbeschränkung auf POST (405), 404 für nicht existierende Jobs, `HX-Redirect`-Header nur bei `?redirect=1`, sowie Rendering des Löschbuttons in Liste und Detailansicht nur für löschbare Jobs.
- Manuell prüfenswert: Klick auf den Löschbutton in der Queue-Liste (Zeile verschwindet ohne Reload) und in der Detailansicht (Redirect zurück zur Übersicht) mit einem `failed`-Job.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to queue visibility and hard-delete of terminal job rows; worker-owned jobs are rejected server-side with tests.
> 
> **Overview**
> Adds **manual deletion** of finished Claude queue jobs (`done`, `failed`, `cancelled`) from the queue list and job detail, while **blocking** delete for `queued` and `running` jobs so the worker is not raced.
> 
> **`ClaudeQueueJob.is_deletable`** centralizes the terminal-status rule. A new **`POST` `claude-queue-job-delete`** endpoint enforces it (400 when not deletable), hard-deletes the row, logs **`claudequeuejob.deleted`** on the item, and optionally returns **`HX-Redirect`** to the list when `?redirect=1`.
> 
> The queue table gains an **Actions** column with an HTMX delete control (confirm, row removal, error toast); the detail page uses the same endpoint with redirect after delete. **`core/test_claude_queue_views.py`** adds broad coverage for model, API, and button visibility.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b84f560f74a2695f2d5d97db203bb27d7bedfffd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->