### PR TITLE
Agira MCP Server / Endpoint

### DIFF
--- a/agira_mcp/server.py
+++ b/agira_mcp/server.py
@@ -121,7 +121,13 @@ def get_project(project_id: int) -> dict:
 
 @mcp.tool()
 def list_open_items(project_id: int | None = None) -> list:
-    """List open items (status != Closed). Optionally scoped to one project."""
+    """
+    List open items (status != Closed). Optionally scoped to one project.
+
+    Each returned item includes ``id`` and ``status`` (the canonical
+    ItemStatus value, e.g. "Working", "Review") as top-level fields, so the
+    id-to-status mapping never requires a separate lookup.
+    """
     client = _client()
     if project_id is not None:
         return client.get_project_open_items(project_id)
@@ -130,13 +136,25 @@ def list_open_items(project_id: int | None = None) -> list:
 
 @mcp.tool()
 def get_item(item_id: int) -> dict:
-    """Get a single Agira item by its numeric id."""
+    """
+    Get a single Agira item by its numeric id.
+
+    The response includes ``id`` and ``status`` (the canonical ItemStatus
+    value) as top-level fields.
+    """
     return _client().get_item(item_id)
 
 
 @mcp.tool()
 def get_item_context(item_id: int) -> dict:
-    """Get RAG context (related knowledge) for an item, useful for answering."""
+    """
+    Get RAG context (related knowledge) for an item, useful for answering.
+
+    Each context object (``layer_a``/``layer_b``/``layer_c``/``all_items``)
+    includes ``object_id`` (the id of the underlying item/object) and
+    ``status`` (its canonical status, when the object type has one, e.g.
+    Agira items) as top-level fields.
+    """
     return _client().get_item_context(item_id)
 
 

--- a/core/services/rag/config.py
+++ b/core/services/rag/config.py
@@ -16,6 +16,7 @@ FIELD_MAPPING = {
     "item_id": "parent_object_id",  # parent_object_id may contain item_id for comments
     "updated_at": "updated_at",
     "source": "source_system",
+    "status": "status",
 }
 
 # Default values

--- a/core/services/rag/extended_service.py
+++ b/core/services/rag/extended_service.py
@@ -772,6 +772,7 @@ class ExtendedRAGPipelineService:
                         'link': props.get(FIELD_MAPPING['link']),
                         'source': props.get(FIELD_MAPPING['source']),
                         'updated_at': props.get(FIELD_MAPPING['updated_at']),
+                        'status': props.get(FIELD_MAPPING['status']),
                         'score': getattr(obj.metadata, 'score', None),
                         'search_type': 'semantic' if alpha >= 0.5 else 'keyword'
                     }
@@ -1105,6 +1106,7 @@ class ExtendedRAGPipelineService:
                 relevance_score=result.get('final_score') or result.get('score'),
                 link=result.get('link'),
                 updated_at=str(result.get('updated_at')) if result.get('updated_at') else None,
+                status=result.get('status'),
             )
             
             # Classify into layers (Issue #407: Documentation-centric)

--- a/core/services/rag/models.py
+++ b/core/services/rag/models.py
@@ -20,6 +20,7 @@ class RAGContextObject:
         relevance_score: Relevance score from search (0-1, higher is better)
         link: URL/link to the object
         updated_at: Last update timestamp as string
+        status: Canonical status of the object (e.g. item.status), if applicable
     """
     object_type: str
     object_id: str
@@ -29,11 +30,12 @@ class RAGContextObject:
     relevance_score: Optional[float]
     link: Optional[str]
     updated_at: Optional[str]
-    
+    status: Optional[str] = None
+
     def to_dict(self) -> dict:
         """
         Convert to JSON-serializable dictionary.
-        
+
         Returns:
             Dictionary with all fields as primitive types
         """
@@ -46,6 +48,7 @@ class RAGContextObject:
             'relevance_score': self.relevance_score,
             'link': self.link,
             'updated_at': self.updated_at,
+            'status': self.status,
         }
 
 

--- a/core/services/rag/test_extended_rag.py
+++ b/core/services/rag/test_extended_rag.py
@@ -184,30 +184,32 @@ class SearchTestCase(TestCase):
             'url': '/items/123/',
             'source_system': 'agira',
             'updated_at': '2024-01-01',
+            'status': 'Working',
         }
         mock_obj.metadata.score = 0.85
-        
+
         mock_response = Mock()
         mock_response.objects = [mock_obj]
-        
+
         mock_collection = Mock()
         mock_collection.query.hybrid.return_value = mock_response
-        
+
         mock_client = Mock()
         mock_client.collections.get.return_value = mock_collection
         mock_get_client.return_value = mock_client
-        
+
         results = ExtendedRAGPipelineService._perform_search(
             query_text="test",
             alpha=0.6,
             limit=10
         )
-        
+
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0]['object_id'], '123')
         self.assertEqual(results[0]['object_type'], 'item')
         self.assertEqual(results[0]['title'], 'Test Item')
         self.assertEqual(results[0]['score'], 0.85)
+        self.assertEqual(results[0]['status'], 'Working')
     
     @patch('core.services.rag.extended_service.get_client')
     @patch('core.services.rag.extended_service.is_available')
@@ -441,13 +443,28 @@ class LayerSeparationTestCase(TestCase):
         ]
         
         layer_a, layer_b, layer_c = ExtendedRAGPipelineService._separate_into_layers(results)
-        
+
         # Layer A: up to 3
         self.assertLessEqual(len(layer_a), 3)
         # Layer B: up to 3
         self.assertLessEqual(len(layer_b), 3)
         # Layer C: up to 2
         self.assertLessEqual(len(layer_c), 2)
+
+    def test_layers_propagate_status(self):
+        """Each RAGContextObject built by layer separation should carry its status."""
+        results = [
+            {'object_id': '1', 'object_type': 'item', 'content': 'Item 1', 'title': 'I1',
+             'score': 0.9, 'status': 'Working'},
+            {'object_id': '2', 'object_type': 'item', 'content': 'Item 2', 'title': 'I2',
+             'score': 0.8, 'status': 'Closed'},
+        ]
+
+        _, layer_b, _ = ExtendedRAGPipelineService._separate_into_layers(results)
+
+        by_id = {item.object_id: item.status for item in layer_b}
+        self.assertEqual(by_id['1'], 'Working')
+        self.assertEqual(by_id['2'], 'Closed')
 
 
 class ContextTextFormattingTestCase(TestCase):
@@ -667,14 +684,15 @@ class JSONSerializationTestCase(TestCase):
             source='agira',
             relevance_score=0.85,
             link='http://example.com/item/123',
-            updated_at='2024-01-01 12:00:00'
+            updated_at='2024-01-01 12:00:00',
+            status='Working'
         )
-        
+
         result = obj.to_dict()
-        
+
         # Should be a dict
         self.assertIsInstance(result, dict)
-        
+
         # Should have all fields
         self.assertEqual(result['object_type'], 'item')
         self.assertEqual(result['object_id'], '123')
@@ -684,10 +702,28 @@ class JSONSerializationTestCase(TestCase):
         self.assertEqual(result['relevance_score'], 0.85)
         self.assertEqual(result['link'], 'http://example.com/item/123')
         self.assertEqual(result['updated_at'], '2024-01-01 12:00:00')
-        
+        self.assertEqual(result['status'], 'Working')
+
         # Should be JSON serializable
         json_str = json.dumps(result)
         self.assertIsInstance(json_str, str)
+
+    def test_rag_context_object_to_dict_status_defaults_to_none(self):
+        """RAGContextObject.to_dict() should default status to None when not applicable."""
+        obj = RAGContextObject(
+            object_type='attachment',
+            object_id='456',
+            title='Test Attachment',
+            content='Test content',
+            source='agira',
+            relevance_score=0.5,
+            link=None,
+            updated_at=None,
+        )
+
+        result = obj.to_dict()
+
+        self.assertIsNone(result['status'])
     
     def test_optimized_query_to_dict(self):
         """OptimizedQuery.to_dict() should produce JSON-serializable dict."""

--- a/core/test_customgpt_api.py
+++ b/core/test_customgpt_api.py
@@ -10,6 +10,7 @@ This module tests the API endpoints for CustomGPT Actions including:
 """
 import json
 import os
+from unittest.mock import patch
 from django.test import TestCase, Client
 from django.contrib.auth import get_user_model
 
@@ -17,6 +18,8 @@ from core.models import (
     Organisation, UserOrganisation, Project, ProjectStatus,
     ItemType, Item, ItemStatus, UserRole
 )
+from core.services.rag.models import RAGContextObject
+from core.services.rag.extended_service import ExtendedRAGContext
 
 User = get_user_model()
 
@@ -251,6 +254,7 @@ class CustomGPTItemsAPITest(TestCase):
         data = json.loads(response.content)
         self.assertEqual(data['id'], self.open_item.id)
         self.assertEqual(data['title'], 'Open Item')
+        self.assertEqual(data['status'], ItemStatus.WORKING)
     
     def test_get_item_not_found(self):
         """Test GET /api/customgpt/items/{id} with invalid ID."""
@@ -352,6 +356,7 @@ class CustomGPTItemsAPITest(TestCase):
         # Should only return open item, not closed
         self.assertEqual(len(data), 1)
         self.assertEqual(data[0]['id'], self.open_item.id)
+        self.assertEqual(data[0]['status'], ItemStatus.WORKING)
 
 
 class CustomGPTItemContextAPITest(TestCase):
@@ -417,6 +422,44 @@ class CustomGPTItemContextAPITest(TestCase):
         # Items should be a list (may be empty if Weaviate not configured)
         self.assertIsInstance(data['items'], list)
     
+    def test_get_item_context_includes_status_per_item(self):
+        """Related items in the RAG context must expose their status directly."""
+        related_item = RAGContextObject(
+            object_type='item',
+            object_id='42',
+            title='Related Item',
+            content='Related content',
+            source='agira',
+            relevance_score=0.9,
+            link='/items/42/',
+            updated_at='2024-01-01',
+            status=ItemStatus.REVIEW,
+        )
+        stub_context = ExtendedRAGContext(
+            query='Test Item',
+            optimized_query=None,
+            layer_a=[],
+            layer_b=[related_item],
+            layer_c=[],
+            all_items=[related_item],
+            summary='Found 1 item',
+            stats={'total': 1},
+        )
+
+        with patch('core.views_api.build_extended_context', return_value=stub_context):
+            response = self.client.get(
+                f'/api/customgpt/items/{self.item.id}/context',
+                **self.headers
+            )
+        self.assertEqual(response.status_code, 200)
+
+        data = json.loads(response.content)
+        self.assertEqual(len(data['items']), 1)
+        self.assertEqual(data['items'][0]['object_id'], '42')
+        self.assertEqual(data['items'][0]['status'], ItemStatus.REVIEW)
+        # Same data must be reachable via the richer layer_b field too
+        self.assertEqual(data['layer_b'][0]['status'], ItemStatus.REVIEW)
+
     def test_get_item_context_not_found(self):
         """Test GET /api/customgpt/items/{id}/context with invalid item ID."""
         response = self.client.get(


### PR DESCRIPTION
Automated draft PR opened by the Claude queue worker for Agira item #898.

Model: Sonnet
Job: #74

---

## Zusammenfassung

MCP-Issue-Tools liefern jetzt konsistent eine maschinenlesbare `id`/`status`-Zuordnung, auch im RAG-Kontext-Tool, das bisher `status` verschluckte.

## Änderungen

- `core/services/rag/config.py`: `FIELD_MAPPING` um `"status": "status"` ergänzt, sodass der bereits in Weaviate indexierte Status gelesen wird.
- `core/services/rag/extended_service.py`: Der Suchergebnis-Dict und die daraus gebaute `RAGContextObject` übernehmen jetzt `status` aus den Weaviate-Properties.
- `core/services/rag/models.py`: `RAGContextObject` um das additive Feld `status: Optional[str] = None` erweitert, inklusive `to_dict()`.
- `agira_mcp/server.py`: Docstrings von `list_open_items`, `get_item` und `get_item_context` beschreiben jetzt explizit, dass `id`/`status` (bzw. `object_id`/`status`) in der Response enthalten sind, damit ein Agent das Schema schon aus der Tool-Beschreibung erkennt.
- Tests in `core/services/rag/test_extended_rag.py` und `core/test_customgpt_api.py` decken die neue `status`-Propagierung end-to-end ab (Weaviate-Property → Suchergebnis → Layer-Objekt → JSON-Response des `/context`-Endpunkts).

## Warum / Entscheidungen

- Die Analyse zeigte, dass `serialize_item` (verwendet von `list_open_items`/`get_item` über `/api/customgpt/items*`) bereits `id` und `status` als Top-Level-Felder liefert – das Problem lag nicht dort. Die eigentliche Lücke war im RAG-Kontext-Tool (`get_item_context`), dessen `RAGContextObject`-Ergebnisse `status` nie enthielten, obwohl Weaviate diesen Wert beim Indexieren von Items längst speichert (`core/services/weaviate/serializers.py`). Ein Agent, der über `get_item_context` verwandte Issues findet, musste den Status separat über weitere Tool-Aufrufe nachschlagen – genau das im Ticket beschriebene Verhalten.
- Nicht ein neues, paralleles Metadaten-Objekt eingeführt, weil bereits ein Schema-Konzept existiert (`RAGContextObject`/`serialize_item`); `status` wurde dort additiv ergänzt statt eine zusätzliche Response-Hülle zu bauen.
- Nicht `object_id` in `id` umbenannt, weil `object_id` als stabiler, typübergreifender Bezeichner (item/comment/attachment/github_issue) bereits von bestehenden Clients konsumiert wird – ein Rename hätte ohne Mehrwert bestehende Konsumenten gebrochen.
- Nicht die Statusermittlung rückwirkend aus der Datenbank nachgeladen (z. B. Join über `object_id` zur Laufzeit), weil Weaviate den Status bereits bei der Indexierung mitschreibt; ein DB-Join hätte unnötige Latenz und eine zusätzliche Fehlerquelle eingeführt.
- Nicht `to_context_text()` (die menschenlesbare Textdarstellung) angefasst, weil der MCP-Endpunkt (`/api/customgpt/items/{id}/context`) ausschließlich den strukturierten `to_dict()`-Pfad zurückgibt; die Textvariante wird nur intern für UI-Antworten verwendet und ist kein MCP-Response-Feld.
- Nicht versucht, die drei vorbestehenden, unabhängigen Testfehler (`test_layers_contain_correct_types`, `test_small_doc_included_full`, `test_ranking_by_type_priority`) sowie den fehlenden `alpha`-Schlüssel in `test_get_item_context` zu reparieren, weil sie bereits vor dieser Änderung fehlschlugen und nicht mit `id`/`status` zusammenhängen – ein Fix hätte den Scope unnötig ausgeweitet.

## Test-Hinweise

- `python manage.py test core.services.rag.test_extended_rag core.services.rag.test_rag core.test_customgpt_api --keepdb`
- Neue/erweiterte Tests: `test_search_returns_results` (Status aus Weaviate-Properties), `test_layers_propagate_status`, `test_rag_context_object_to_dict` / `..._status_defaults_to_none`, `test_get_item_context_includes_status_per_item` (End-to-End über den `/context`-Endpunkt), sowie ergänzte Status-Assertions in `test_get_item` und `test_get_project_open_items`.
- Die vier vorbestehenden Fehlschläge sind unverändert und wurden auf dem Ausgangscommit als bereits vorhanden verifiziert (nicht Teil dieser Änderung).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive optional field on RAG models and API JSON; no auth or write-path changes.
> 
> **Overview**
> **RAG context objects now carry `status` end-to-end**, so MCP agents and CustomGPT clients can read item state from related hits without extra API calls.
> 
> The pipeline maps Weaviate’s existing `status` property through search results into `RAGContextObject` and JSON (`to_dict()` / `/api/customgpt/items/{id}/context` layers). **MCP tool docstrings** for `list_open_items`, `get_item`, and `get_item_context` now state that responses include `id`/`status` or `object_id`/`status` as top-level fields.
> 
> Tests cover Weaviate mock → layer separation → serialization and a patched context endpoint asserting `status` on `items` and `layer_b`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4174542773d4099c3996314061e95a1ec99e05e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->