### PR TITLE
Menüpunkt "Review" unter Items für Items mit Status Review

### DIFF
--- a/core/test_item_listviews.py
+++ b/core/test_item_listviews.py
@@ -115,6 +115,15 @@ class ItemListViewTestCase(TestCase):
             organisation=self.org,
         )
         
+        self.review_item = Item.objects.create(
+            title="Review Item",
+            description="This is a review item",
+            project=self.project2,
+            type=self.feature_type,
+            status=ItemStatus.REVIEW,
+            organisation=self.org,
+        )
+
         self.ready_item = Item.objects.create(
             title="Ready Item",
             description="This is a ready item",
@@ -175,13 +184,23 @@ class ItemListViewTestCase(TestCase):
         self.assertEqual(len(items), 1)
         self.assertEqual(items[0].status, ItemStatus.TESTING)
     
+    def test_review_view_status_scope(self):
+        """Test review view only shows review items"""
+        response = self.client.get(reverse('items-review'))
+        self.assertEqual(response.status_code, 200)
+
+        items = list(response.context['table'].data)
+
+        self.assertEqual(len(items), 1)
+        self.assertEqual(items[0].status, ItemStatus.REVIEW)
+
     def test_ready_view_status_scope(self):
         """Test ready view only shows ready items"""
         response = self.client.get(reverse('items-ready'))
         self.assertEqual(response.status_code, 200)
-        
+
         items = list(response.context['table'].data)
-        
+
         self.assertEqual(len(items), 1)
         self.assertEqual(items[0].status, ItemStatus.READY_FOR_RELEASE)
     
@@ -292,6 +311,7 @@ class ItemListViewTestCase(TestCase):
             'items-backlog',
             'items-working',
             'items-testing',
+            'items-review',
             'items-ready',
         ]
         

--- a/core/urls.py
+++ b/core/urls.py
@@ -54,6 +54,7 @@ urlpatterns = [
     path('items/backlog/', views_items.ItemsBacklogView.as_view(), name='items-backlog'),
     path('items/working/', views_items.ItemsWorkingView.as_view(), name='items-working'),
     path('items/testing/', views_items.ItemsTestingView.as_view(), name='items-testing'),
+    path('items/review/', views_items.ItemsReviewView.as_view(), name='items-review'),
     path('items/ready/', views_items.ItemsReadyView.as_view(), name='items-ready'),
     path('items/assigned/', views_items.ItemsAssignedToMeView.as_view(), name='items-assigned'),
     path('items/responsible/', views_items.ItemsResponsibleForView.as_view(), name='items-responsible'),

--- a/core/views_items.py
+++ b/core/views_items.py
@@ -155,6 +155,13 @@ class ItemsTestingView(StatusItemListView):
     page_description = "Items being tested"
 
 
+class ItemsReviewView(StatusItemListView):
+    """Items Review - items marked for coordination or open questions."""
+    item_status = ItemStatus.REVIEW
+    page_title = "Items - Review"
+    page_description = "Items marked for review/coordination"
+
+
 class ItemsReadyView(StatusItemListView):
     """Items Ready for Release - items ready to be released."""
     item_status = ItemStatus.READY_FOR_RELEASE
@@ -380,6 +387,7 @@ def item_list_delete(request, item_id):
             ItemStatus.BACKLOG: ItemsBacklogView,
             ItemStatus.WORKING: ItemsWorkingView,
             ItemStatus.TESTING: ItemsTestingView,
+            ItemStatus.REVIEW: ItemsReviewView,
             ItemStatus.READY_FOR_RELEASE: ItemsReadyView,
         }
         view_class = view_class_map.get(item_status)

--- a/templates/base.html
+++ b/templates/base.html
@@ -164,6 +164,10 @@
                             <i class="bi bi-bug sidebar-icon"></i>
                             <span class="sidebar-text">Testing</span>
                         </a>
+                        <a href="{% url 'items-review' %}" class="sidebar-link sidebar-link-sub {% if request.resolver_match.url_name == 'items-review' %}active{% endif %}">
+                            <i class="bi bi-eye sidebar-icon"></i>
+                            <span class="sidebar-text">Review</span>
+                        </a>
                         <a href="{% url 'items-ready' %}" class="sidebar-link sidebar-link-sub {% if request.resolver_match.url_name == 'items-ready' %}active{% endif %}">
                             <i class="bi bi-check-circle sidebar-icon"></i>
                             <span class="sidebar-text">Ready for Release</span>


### PR DESCRIPTION
Automated draft PR opened by the Claude queue worker for Agira item #933.

Model: Sonnet
Job: #108

---

## Zusammenfassung

Für Items mit Status `Review` gibt es nun einen eigenen Menüpunkt unter „Items" in der linken Sidebar, analog zu Inbox, Backlog, Working, Testing und Ready for Release.

## Änderungen

- `core/views_items.py`: Neue View `ItemsReviewView(StatusItemListView)` mit `item_status = ItemStatus.REVIEW`, ergänzt nach dem bestehenden Muster der übrigen Status-Views. `view_class_map` in `item_list_delete` um den Review-Eintrag erweitert, damit HTMX-Löschungen aus der Review-Liste korrekt neu gerendert werden.
- `core/urls.py`: Route `items/review/` mit Namen `items-review` ergänzt, eingeordnet zwischen `items-testing` und `items-ready` (entsprechend der Reihenfolge im `ItemStatus`-Enum).
- `templates/base.html`: Sidebar-Eintrag „Review" unter „Items" ergänzt, inkl. Active-State über `request.resolver_match.url_name == 'items-review'`, identisch zum bestehenden Pattern der anderen Einträge.
- `core/test_item_listviews.py`: Testdaten und Tests um ein Review-Item ergänzt (`test_review_view_status_scope`), sowie `items-review` in `test_login_required` aufgenommen.

## Warum / Entscheidungen

- Wiederverwendung der bestehenden `StatusItemListView`-Basisklasse und des `items_list.html`-Templates statt einer eigenen Review-Implementierung, weil genau das die im Ticket geforderte generische Erweiterung ist und für alle anderen Status bereits so umgesetzt wurde.
- Nicht die Reihenfolge der Sidebar-Einträge frei gewählt, sondern Review zwischen Testing und Ready for Release platziert, weil das der Reihenfolge im `ItemStatus`-Enum (Testing → Review → ReadyForRelease) entspricht und damit den fachlichen Workflow widerspiegelt.
- Nicht die im Repo noch vorhandenen verwaisten Templates `items_planning.html` / `items_specification.html` als Vorlage genutzt, weil diese zu inzwischen entfernten Status gehören (Migration `0047_remove_planing_specification_statuses`) und nicht mehr dem aktuellen Class-Based-View-Muster entsprechen.
- Kein neues Icon-Konzept eingeführt, sondern `bi-eye` (Bootstrap Icons) gewählt, weil es sich thematisch für „Review/Begutachtung" anbietet und konsistent zu den bestehenden, thematisch passenden Icons der anderen Einträge ist.
- Keine Änderung an `mail_triggerable_choices()` oder sonstiger Statuslogik vorgenommen, weil das Ticket ausdrücklich nur die Navigationsergänzung verlangt und die fachliche Sonderbehandlung von Review (kein Mail-Trigger) bereits bewusst so besteht.

## Test-Hinweise

- `python manage.py test core.test_item_listviews.ItemListViewTestCase` — 15 Tests, alle grün (inkl. neuem `test_review_view_status_scope`).
- `python manage.py check` — keine Probleme gefunden.
- Manuell: Sidebar unter „Items" zeigt „Review" zwischen „Testing" und „Ready for Release"; Klick öffnet `/items/review/` mit ausschließlich Items im Status Review; Menüpunkt wird bei geöffneter Review-Route als aktiv hervorgehoben.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mirrors existing status list views and navigation only; no auth, data model, or workflow logic changes.
> 
> **Overview**
> Adds a dedicated **Review** item list in the sidebar and at `/items/review/`, matching the existing status-scoped lists (Inbox, Backlog, Working, Testing, Ready).
> 
> `ItemsReviewView` extends `StatusItemListView` with `ItemStatus.REVIEW`. The route is registered as `items-review` between Testing and Ready. HTMX list deletes from the Review page re-render via `ItemsReviewView` in `item_list_delete`. The sidebar gets a **Review** link (`bi-eye`) with the same active-state pattern as the other status entries.
> 
> Tests add a Review fixture, `test_review_view_status_scope`, and include `items-review` in the login-required coverage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a404e5b088d1f2682bafacaa2b5616e793e0f1f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->