### PR TITLE
Erweiterung MCP Server "Agira-Tools legen kein parent_id-Feld offen"

### DIFF
--- a/agira_mcp/server.py
+++ b/agira_mcp/server.py
@@ -171,6 +171,7 @@ def create_item(
     solution_description: str = "",
     status: str | None = None,
     intern: bool = False,
+    parent_id: int | None = None,
 ) -> dict:
     """
     Create a new item (issue) in a project.
@@ -178,6 +179,10 @@ def create_item(
     The connecting user is recorded as the item's ``responsible`` (the user
     must have the Agira "Agent" role). ``title`` and ``type_id`` are required.
     Use ``list_projects`` / project details to find valid ``type_id`` values.
+
+    ``parent_id`` optionally sets the parent item (e.g. an Epic) the new item
+    belongs to. Leave it unset to create the item without a parent. The
+    parent must exist and must not itself be Closed.
     """
     payload: dict = {
         "title": title,
@@ -189,6 +194,8 @@ def create_item(
     }
     if status is not None:
         payload["status"] = status
+    if parent_id is not None:
+        payload["parent_id"] = parent_id
     return _client().create_item(project_id, payload, user_token=_user_token())
 
 
@@ -200,8 +207,18 @@ def update_item(
     solution_description: str | None = None,
     status: str | None = None,
     intern: bool | None = None,
+    parent_id: int | None = None,
+    clear_parent: bool = False,
 ) -> dict:
-    """Update fields of an existing item (partial update). Only set what changes."""
+    """
+    Update fields of an existing item (partial update). Only set what changes.
+
+    ``parent_id`` sets or changes the item's parent (e.g. an Epic). Leave it
+    unset to leave the current parent unchanged. To remove an existing parent
+    relationship, pass ``clear_parent=True`` (``parent_id`` is ignored in that
+    case). The parent must exist, must not be Closed, and cannot be the item
+    itself.
+    """
     payload = {
         k: v
         for k, v in {
@@ -213,6 +230,10 @@ def update_item(
         }.items()
         if v is not None
     }
+    if clear_parent:
+        payload["parent_id"] = None
+    elif parent_id is not None:
+        payload["parent_id"] = parent_id
     return _client().update_item(item_id, payload, user_token=_user_token())
 
 

--- a/core/models.py
+++ b/core/models.py
@@ -662,8 +662,12 @@ class Item(models.Model):
         super().clean()
         errors = {}
 
+        # An item cannot be its own parent
+        if self.parent_id is not None and self.parent_id == self.id:
+            errors['parent'] = _('Cannot set item as its own parent.')
+
         # Parent status must not be closed
-        if self.parent and self.parent.status == ItemStatus.CLOSED:
+        elif self.parent and self.parent.status == ItemStatus.CLOSED:
             errors['parent'] = _('Cannot set a closed item as parent.')
 
         # Solution release must be in same project

--- a/core/test_customgpt_api.py
+++ b/core/test_customgpt_api.py
@@ -351,12 +351,179 @@ class CustomGPTItemsAPITest(TestCase):
             **self.headers
         )
         self.assertEqual(response.status_code, 200)
-        
+
         data = json.loads(response.content)
         # Should only return open item, not closed
         self.assertEqual(len(data), 1)
         self.assertEqual(data[0]['id'], self.open_item.id)
         self.assertEqual(data[0]['status'], ItemStatus.WORKING)
+
+    def test_create_item_with_parent_id(self):
+        """Test POST .../items sets the parent when parent_id is given."""
+        create_data = {
+            'title': 'Child Item',
+            'type_id': self.item_type.id,
+            'parent_id': self.open_item.id,
+        }
+        response = self.client.post(
+            f'/api/customgpt/projects/{self.project.id}/items',
+            data=json.dumps(create_data),
+            content_type='application/json',
+            **self.headers
+        )
+        self.assertEqual(response.status_code, 201)
+
+        data = json.loads(response.content)
+        self.assertEqual(data['parent_id'], self.open_item.id)
+
+        item = Item.objects.get(id=data['id'])
+        self.assertEqual(item.parent_id, self.open_item.id)
+
+    def test_create_item_without_parent_id(self):
+        """Test POST .../items leaves parent unset when parent_id is omitted."""
+        create_data = {
+            'title': 'No Parent Item',
+            'type_id': self.item_type.id,
+        }
+        response = self.client.post(
+            f'/api/customgpt/projects/{self.project.id}/items',
+            data=json.dumps(create_data),
+            content_type='application/json',
+            **self.headers
+        )
+        self.assertEqual(response.status_code, 201)
+
+        data = json.loads(response.content)
+        self.assertIsNone(data['parent_id'])
+
+    def test_create_item_with_null_parent_id(self):
+        """Test POST .../items with parent_id explicitly null creates without a parent."""
+        create_data = {
+            'title': 'Null Parent Item',
+            'type_id': self.item_type.id,
+            'parent_id': None,
+        }
+        response = self.client.post(
+            f'/api/customgpt/projects/{self.project.id}/items',
+            data=json.dumps(create_data),
+            content_type='application/json',
+            **self.headers
+        )
+        self.assertEqual(response.status_code, 201)
+
+        data = json.loads(response.content)
+        self.assertIsNone(data['parent_id'])
+
+    def test_create_item_with_invalid_parent_id(self):
+        """Test POST .../items rejects a non-existent parent_id."""
+        create_data = {
+            'title': 'Bad Parent Item',
+            'type_id': self.item_type.id,
+            'parent_id': 999999,
+        }
+        response = self.client.post(
+            f'/api/customgpt/projects/{self.project.id}/items',
+            data=json.dumps(create_data),
+            content_type='application/json',
+            **self.headers
+        )
+        self.assertEqual(response.status_code, 400)
+
+    def test_update_item_sets_parent(self):
+        """Test PATCH .../items/{id} sets the parent when parent_id is given."""
+        update_data = {'parent_id': self.open_item.id}
+        response = self.client.patch(
+            f'/api/customgpt/items/{self.closed_item.id}',
+            data=json.dumps(update_data),
+            content_type='application/json',
+            **self.headers
+        )
+        self.assertEqual(response.status_code, 200)
+
+        data = json.loads(response.content)
+        self.assertEqual(data['parent_id'], self.open_item.id)
+
+    def test_update_item_changes_parent(self):
+        """Test PATCH .../items/{id} changes an existing parent to a new one."""
+        other_item = Item.objects.create(
+            project=self.project,
+            type=self.item_type,
+            title='Other Item',
+            status=ItemStatus.WORKING,
+        )
+        self.closed_item.parent = self.open_item
+        self.closed_item.save()
+
+        update_data = {'parent_id': other_item.id}
+        response = self.client.patch(
+            f'/api/customgpt/items/{self.closed_item.id}',
+            data=json.dumps(update_data),
+            content_type='application/json',
+            **self.headers
+        )
+        self.assertEqual(response.status_code, 200)
+
+        data = json.loads(response.content)
+        self.assertEqual(data['parent_id'], other_item.id)
+
+    def test_update_item_removes_parent_with_null(self):
+        """Test PATCH .../items/{id} removes the parent when parent_id is null."""
+        self.closed_item.parent = self.open_item
+        self.closed_item.save()
+
+        update_data = {'parent_id': None}
+        response = self.client.patch(
+            f'/api/customgpt/items/{self.closed_item.id}',
+            data=json.dumps(update_data),
+            content_type='application/json',
+            **self.headers
+        )
+        self.assertEqual(response.status_code, 200)
+
+        data = json.loads(response.content)
+        self.assertIsNone(data['parent_id'])
+
+    def test_update_item_without_parent_id_leaves_parent_unchanged(self):
+        """Test PATCH .../items/{id} without parent_id does not touch the parent."""
+        self.closed_item.parent = self.open_item
+        self.closed_item.save()
+
+        update_data = {'title': 'Renamed, parent untouched'}
+        response = self.client.patch(
+            f'/api/customgpt/items/{self.closed_item.id}',
+            data=json.dumps(update_data),
+            content_type='application/json',
+            **self.headers
+        )
+        self.assertEqual(response.status_code, 200)
+
+        data = json.loads(response.content)
+        self.assertEqual(data['parent_id'], self.open_item.id)
+
+    def test_update_item_with_invalid_parent_id(self):
+        """Test PATCH .../items/{id} rejects a non-existent parent_id."""
+        update_data = {'parent_id': 999999}
+        response = self.client.patch(
+            f'/api/customgpt/items/{self.open_item.id}',
+            data=json.dumps(update_data),
+            content_type='application/json',
+            **self.headers
+        )
+        self.assertEqual(response.status_code, 400)
+
+    def test_update_item_rejects_self_reference(self):
+        """Test PATCH .../items/{id} rejects an item as its own parent."""
+        update_data = {'parent_id': self.open_item.id}
+        response = self.client.patch(
+            f'/api/customgpt/items/{self.open_item.id}',
+            data=json.dumps(update_data),
+            content_type='application/json',
+            **self.headers
+        )
+        self.assertEqual(response.status_code, 400)
+
+        self.open_item.refresh_from_db()
+        self.assertIsNone(self.open_item.parent)
 
 
 class CustomGPTItemContextAPITest(TestCase):

--- a/core/views_api.py
+++ b/core/views_api.py
@@ -392,7 +392,16 @@ def api_item_update_put(request, item_id):
                 item.assigned_to = None
             # For simplicity, we don't validate user existence here
             # The model's clean() method will handle validation
-        
+
+        if 'parent_id' in data:
+            if data['parent_id']:
+                try:
+                    item.parent = Item.objects.get(id=data['parent_id'])
+                except Item.DoesNotExist:
+                    return JsonResponse({'error': 'Invalid parent_id'}, status=400)
+            else:
+                item.parent = None
+
         # Validate and save
         try:
             item.full_clean()
@@ -471,6 +480,14 @@ def api_project_create_item(request, project_id):
         except ItemType.DoesNotExist:
             return JsonResponse({'error': 'Invalid type_id'}, status=400)
 
+        # Resolve the parent item, if given
+        parent = None
+        if data.get('parent_id'):
+            try:
+                parent = Item.objects.get(id=data['parent_id'])
+            except Item.DoesNotExist:
+                return JsonResponse({'error': 'Invalid parent_id'}, status=400)
+
         # Resolve the acting MCP user and use them as `responsible`.
         # `responsible` requires the Agent role (see Item.clean); we guard
         # explicitly here so the caller gets a clear message instead of a
@@ -494,6 +511,7 @@ def api_project_create_item(request, project_id):
             status=data.get('status', ItemStatus.INBOX),
             intern=data.get('intern', False),
             responsible=responsible,
+            parent=parent,
         )
         
         # Validate and save


### PR DESCRIPTION
Automated draft PR opened by the Claude queue worker for Agira item #939.

Model: Sonnet
Job: #111

---

## Zusammenfassung

Die MCP-Schreibtools `create_item` und `update_item` unterstützen jetzt ein optionales `parent_id`-Feld, sodass eine Parent-Beziehung direkt über MCP gesetzt, geändert oder entfernt werden kann, ohne dass anschließend manuell in der Agira-Oberfläche nachgebessert werden muss.

## Änderungen

- `core/views_api.py`: `POST /api/customgpt/projects/{id}/items` und `PATCH/PUT /api/customgpt/items/{id}` akzeptieren jetzt optional `parent_id`. Beim Erstellen wird ein gültiges `parent_id` direkt gesetzt, beim Fehlen bleibt das Item ohne Parent. Beim Aktualisieren gilt: Feld fehlt → Parent bleibt unverändert; Feld ist `null`/leer → Parent wird entfernt; Feld enthält eine gültige ID → Parent wird gesetzt/geändert. Eine ungültige `parent_id` liefert `400 Invalid parent_id`.
- `core/models.py`: `Item.clean()` lehnt jetzt zusätzlich Self-Reference ab (`parent_id == id`). Dieselbe Methode prüfte bereits, dass geschlossene Items nicht als Parent gesetzt werden dürfen; beide Regeln greifen dadurch automatisch überall dort, wo `full_clean()` aufgerufen wird – inklusive der neuen MCP-Schreibpfade.
- `agira_mcp/server.py`: `create_item` bekommt ein optionales `parent_id: int | None`. `update_item` bekommt `parent_id: int | None` zum Setzen/Ändern sowie `clear_parent: bool` zum expliziten Entfernen der Parent-Beziehung. Beide Tool-Docstrings beschreiben das neue Verhalten inklusive der geltenden fachlichen Regeln (kein geschlossener Parent, keine Self-Reference).
- `core/test_customgpt_api.py`: neue Tests für Create mit/ohne/`null` `parent_id`, Update setzt/ändert/entfernt Parent, Update ohne `parent_id` lässt Parent unverändert, sowie Fehlerfälle für ungültige `parent_id` und Self-Reference.

## Warum / Entscheidungen

- Self-Reference-Prüfung in `Item.clean()` statt einer MCP-spezifischen Sonderprüfung, weil die REST-Schreibpfade (`views_api.py`) bereits `full_clean()` aufrufen und die bestehende Self-Reference-Prüfung bisher nur isoliert im HTMX-Endpoint `item_update_parent` existierte. Eine zentrale Model-Regel vermeidet doppelte, potenziell abweichende Validierungslogik nur für MCP.
- `update_item` bekommt einen zusätzlichen `clear_parent`-Parameter statt ausschließlich `parent_id=None` als "entfernen"-Signal, weil der MCP-Argument-Layer (FastMCP/pydantic) fehlende Parameter beim Tool-Aufruf immer mit ihrem deklarierten Default auffüllt – ein weggelassenes `parent_id` und ein explizit auf `null` gesetztes `parent_id` sind auf Python-Ebene nicht unterscheidbar. Auf REST-Ebene (`views_api.py`) funktioniert die von der Aufgabe geforderte Tri-State-Semantik (fehlt/`null`/Wert) dagegen korrekt, da dort das rohe JSON-Dict ausgewertet wird.
- Nicht die volle REST-Payload-Semantik 1:1 in die MCP-Tool-Signatur übernommen (z. B. per `**kwargs`-Trick oder Sentinel-Objekt), weil das die Tool-Schemas für Agenten unnötig verkomplizieren würde; ein expliziter Boolean-Flag ist für ein LLM eindeutiger interpretierbar als ein Sentinel-Wert.
- Keine Prüfung auf Projekt-Zugehörigkeit oder Zyklen für `parent`, weil laut bestehenden Tests (`test_item_update_parent_allows_different_project`, `test_item_update_parent_allows_item_with_parent`) projekt-übergreifende und mehrstufige Parent-Beziehungen bewusst erlaubt sind (Issues #352, #306) – MCP übernimmt exakt dieselben fachlichen Regeln, nicht mehr und nicht weniger.

## Test-Hinweise

- `python manage.py test core.test_customgpt_api` – neue und bestehende Tests für die CustomGPT-API grün (ein einzelner, vorbestehender und von dieser Änderung unabhängiger RAG-Kontext-Test schlägt bereits auf `main` fehl).
- Manuell geprüft: `create_item` mit/ohne/`null` `parent_id`, `update_item` setzt/ändert/entfernt Parent via `clear_parent`, sowie Fehlerfälle (ungültige ID, Self-Reference, geschlossener Parent) über die REST-Endpunkte.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped item hierarchy writes with existing model validation and new API tests; no auth or payment changes.
> 
> **Overview**
> MCP and the CustomGPT REST API can now set, change, or clear an item’s **parent** (e.g. Epic) when creating or updating issues, so agents no longer need a manual UI fix after the fact.
> 
> **REST** (`views_api.py`): `POST .../items` accepts optional `parent_id`; `PATCH/PUT .../items/{id}` treats missing `parent_id` as unchanged, `null` as remove parent, and a valid ID as set/change. Invalid IDs return `400`.
> 
> **MCP** (`agira_mcp/server.py`): `create_item` adds optional `parent_id`; `update_item` adds `parent_id` plus `clear_parent=True` to drop a parent (MCP can’t distinguish “omit” from `null` on optional args).
> 
> **Validation** (`Item.clean`): rejects an item as its own parent; closed-parent checks still apply via `full_clean()` on these paths.
> 
> **Tests**: broad CustomGPT API coverage for parent create/update, null semantics, invalid IDs, and self-reference.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80b186068d9fa33f392ad4ea48e2e47e8e0bb805. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->