### PR TITLE
UI-Dichte reduzieren: kompakteres, engeres Layout (Claude-Desktop-Anmutung)

### DIFF
--- a/static/css/site.css
+++ b/static/css/site.css
@@ -42,20 +42,56 @@
     --color-white: #ffffff;
     
     /* Layout Constants */
-    --topbar-height: 60px;
+    --topbar-height: 52px;
     --sidebar-width: 260px;
     --sidebar-collapsed-width: 70px;
     --right-sidebar-width: 350px;
-    --footer-height: 50px;
+    --footer-height: 42px;
+
+    /* Typography Scale - compact, Claude Desktop-inspired density */
+    --font-size-base: 0.9375rem;   /* 15px */
+    --font-size-sm: 0.8125rem;     /* 13px */
+    --font-size-xs: 0.75rem;       /* 12px */
+    --font-size-lg: 1rem;          /* 16px */
+    --line-height-base: 1.45;
+
+    --font-size-h1: 1.625rem;      /* 26px */
+    --font-size-h2: 1.375rem;      /* 22px */
+    --font-size-h3: 1.1875rem;     /* 19px */
+    --font-size-h4: 1.0625rem;     /* 17px */
+    --font-size-h5: 0.9375rem;     /* 15px */
+    --font-size-h6: 0.8125rem;     /* 13px */
+
+    /* Spacing Scale - reduced density for nav, cards, lists, forms */
+    --space-1: 0.25rem;
+    --space-2: 0.5rem;
+    --space-3: 0.75rem;
+    --space-4: 1rem;
+    --space-5: 1.25rem;
+    --space-6: 1.5rem;
+
+    /* Bootstrap overrides (Bootstrap reads these via its own CSS custom properties) */
+    --bs-body-font-size: var(--font-size-base);
+    --bs-body-line-height: var(--line-height-base);
 }
 
 body {
     background-color: var(--bg-primary);
     color: var(--text-primary);
     font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+    font-size: var(--font-size-base);
+    line-height: var(--line-height-base);
     margin: 0;
     padding: 0;
 }
+
+/* Heading scale - kept harmonious via shared variables, not one-off values */
+h1, .h1 { font-size: var(--font-size-h1); }
+h2, .h2 { font-size: var(--font-size-h2); }
+h3, .h3 { font-size: var(--font-size-h3); }
+h4, .h4 { font-size: var(--font-size-h4); }
+h5, .h5 { font-size: var(--font-size-h5); }
+h6, .h6 { font-size: var(--font-size-h6); }
 
 /* Topbar */
 .topbar {
@@ -68,25 +104,25 @@ body {
     border-bottom: 1px solid var(--border-color);
     display: flex;
     align-items: center;
-    padding: 0 1.5rem;
+    padding: 0 var(--space-4);
     z-index: 1000;
-    gap: 1rem;
+    gap: var(--space-3);
 }
 
 .sidebar-toggle {
     background: transparent;
     border: none;
     color: var(--text-primary);
-    font-size: 1.5rem;
+    font-size: 1.25rem;
     cursor: pointer;
-    padding: 0.5rem;
+    padding: var(--space-2);
     border-radius: 0.375rem;
     transition: all 0.2s ease;
     display: flex;
     align-items: center;
     justify-content: center;
-    width: 40px;
-    height: 40px;
+    width: 34px;
+    height: 34px;
 }
 
 .sidebar-toggle:hover {
@@ -97,7 +133,7 @@ body {
 .topbar-brand a {
     color: var(--accent-primary);
     font-weight: 600;
-    font-size: 1.5rem;
+    font-size: var(--font-size-h4);
     text-decoration: none;
 }
 
@@ -181,14 +217,14 @@ body {
     border-right: 1px solid var(--border-color);
     overflow-x: hidden;
     overflow-y: auto;
-    padding: 1rem 0;
+    padding: var(--space-2) 0;
     transition: width 0.3s ease, padding 0.3s ease;
     z-index: 999;
 }
 
 .sidebar.collapsed {
     width: var(--sidebar-collapsed-width);
-    padding: 1rem 0;
+    padding: var(--space-2) 0;
 }
 
 .sidebar.collapsed .sidebar-text {
@@ -209,11 +245,11 @@ body {
 
 .sidebar.collapsed .sidebar-link {
     justify-content: center;
-    padding: 0.75rem;
+    padding: var(--space-2);
 }
 
 .sidebar.collapsed .sidebar-link-sub {
-    padding-left: 0.75rem;
+    padding-left: var(--space-2);
 }
 
 .sidebar-nav {
@@ -224,7 +260,7 @@ body {
 .sidebar-link {
     display: flex;
     align-items: center;
-    padding: 0.875rem 1.25rem;
+    padding: var(--space-2) var(--space-4);
     color: var(--text-secondary);
     text-decoration: none;
     transition: all 0.2s ease;
@@ -246,14 +282,14 @@ body {
 }
 
 .sidebar-link-sub {
-    padding-left: 3rem;
-    font-size: 0.9rem;
+    padding-left: 2.5rem;
+    font-size: var(--font-size-sm);
 }
 
 .sidebar-icon {
-    min-width: 24px;
-    margin-right: 0.875rem;
-    font-size: 1.125rem;
+    min-width: 22px;
+    margin-right: var(--space-2);
+    font-size: 1rem;
     transition: margin 0.3s ease;
 }
 
@@ -262,20 +298,20 @@ body {
 }
 
 .sidebar-text {
-    font-size: 0.95rem;
+    font-size: var(--font-size-base);
     white-space: nowrap;
     transition: opacity 0.2s ease, width 0.2s ease;
 }
 
 /* Sidebar Section Headers */
 .sidebar-section {
-    margin-top: 0.5rem;
+    margin-top: var(--space-1);
 }
 
 .sidebar-section-header {
     display: flex;
     align-items: center;
-    padding: 0.75rem 1.25rem;
+    padding: var(--space-2) var(--space-4);
     cursor: pointer;
     text-decoration: none;
     transition: all 0.2s ease;
@@ -287,14 +323,14 @@ body {
 }
 
 .sidebar-section-chevron {
-    font-size: 0.875rem;
+    font-size: var(--font-size-sm);
     color: var(--text-muted);
-    margin-right: 0.5rem;
+    margin-right: var(--space-2);
     transition: transform 0.2s ease, opacity 0.3s ease;
 }
 
 .sidebar-section-title {
-    font-size: 0.75rem;
+    font-size: var(--font-size-xs);
     font-weight: 600;
     text-transform: uppercase;
     color: var(--text-muted);
@@ -307,7 +343,7 @@ body {
 .main-content {
     margin-left: var(--sidebar-width);
     flex: 1;
-    padding: 2rem;
+    padding: var(--space-5);
     min-height: calc(100vh - var(--topbar-height) - var(--footer-height));
     transition: margin-left 0.3s ease, margin-right 0.3s ease;
 }
@@ -326,7 +362,7 @@ body {
     background-color: var(--bg-secondary);
     border-left: 1px solid var(--border-color);
     overflow-y: auto;
-    padding: 1rem 0;
+    padding: var(--space-2) 0;
     z-index: 998;
 }
 
@@ -371,10 +407,35 @@ body {
     color: var(--text-primary);
 }
 
+.card-body {
+    padding: var(--space-4);
+}
+
 .card-header {
+    padding: var(--space-2) var(--space-4);
     background-color: var(--bg-tertiary);
     border-bottom: 1px solid var(--border-color);
     color: var(--text-primary);
+}
+
+.card-footer {
+    padding: var(--space-2) var(--space-4);
+}
+
+/* Lists & Forms */
+.list-group-item {
+    padding: var(--space-2) var(--space-3);
+}
+
+.form-label {
+    margin-bottom: var(--space-1);
+    font-size: var(--font-size-sm);
+}
+
+.modal-header,
+.modal-body,
+.modal-footer {
+    padding: var(--space-3) var(--space-4);
 }
 
 .btn-primary {
@@ -415,13 +476,13 @@ a:hover {
 
 /* Page Header */
 .page-header {
-    margin-bottom: 2rem;
+    margin-bottom: var(--space-5);
 }
 
 .page-header h1 {
-    font-size: 2rem;
+    font-size: var(--font-size-h2);
     font-weight: 600;
-    margin-bottom: 0.5rem;
+    margin-bottom: var(--space-1);
     color: var(--text-primary);
 }
 
@@ -433,18 +494,18 @@ a:hover {
 .container-main {
     max-width: 1400px;
     margin: 0 auto;
-    padding: 2rem 1rem;
+    padding: var(--space-5) var(--space-4);
 }
 
 .welcome-section {
     text-align: center;
-    padding: 3rem 1rem;
+    padding: var(--space-6) var(--space-4);
 }
 
 .welcome-section h1 {
-    font-size: 3rem;
+    font-size: 2.25rem;
     font-weight: 700;
-    margin-bottom: 1rem;
+    margin-bottom: var(--space-3);
     background: linear-gradient(135deg, var(--accent-primary), var(--accent-secondary));
     -webkit-background-clip: text;
     -webkit-text-fill-color: transparent;
@@ -452,7 +513,7 @@ a:hover {
 }
 
 .welcome-section p {
-    font-size: 1.25rem;
+    font-size: var(--font-size-lg);
     color: var(--text-secondary);
     max-width: 600px;
     margin: 0 auto;
@@ -461,12 +522,12 @@ a:hover {
 .feature-grid {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-    gap: 1.5rem;
-    margin-top: 3rem;
+    gap: var(--space-4);
+    margin-top: var(--space-6);
 }
 
 .feature-card {
-    padding: 2rem;
+    padding: var(--space-5);
     text-align: center;
     transition: transform 0.2s;
 }
@@ -476,8 +537,8 @@ a:hover {
 }
 
 .feature-icon {
-    font-size: 3rem;
-    margin-bottom: 1rem;
+    font-size: 2.25rem;
+    margin-bottom: var(--space-3);
     color: var(--accent-primary);
 }
 
@@ -485,8 +546,8 @@ a:hover {
 .detail-layout {
     display: grid;
     grid-template-columns: 2fr 1fr;
-    gap: 1.5rem;
-    margin-bottom: 2rem;
+    gap: var(--space-4);
+    margin-bottom: var(--space-5);
 }
 
 .detail-main {
@@ -596,21 +657,21 @@ a:hover {
     background-color: var(--bg-secondary);
     border: 1px solid var(--border-color);
     border-radius: 0.375rem;
-    padding: 1.25rem;
-    margin-bottom: 1rem;
+    padding: var(--space-4);
+    margin-bottom: var(--space-3);
 }
 
 .project-info-label {
-    font-size: 0.875rem;
+    font-size: var(--font-size-sm);
     color: var(--text-muted);
     font-weight: 600;
     text-transform: uppercase;
     letter-spacing: 0.05em;
-    margin-bottom: 0.5rem;
+    margin-bottom: var(--space-2);
 }
 
 .project-info-value {
-    font-size: 1rem;
+    font-size: var(--font-size-base);
     color: var(--text-primary);
 }
 
@@ -618,7 +679,7 @@ a:hover {
 .breadcrumb {
     background-color: transparent;
     padding: 0;
-    margin-bottom: 1rem;
+    margin-bottom: var(--space-3);
 }
 
 .breadcrumb-item {
@@ -654,10 +715,10 @@ a:hover {
     background-color: var(--bg-secondary);
     border: 1px solid var(--border-color);
     border-radius: 0.5rem;
-    padding: 1.25rem;
+    padding: var(--space-4);
     display: flex;
     align-items: center;
-    gap: 1rem;
+    gap: var(--space-3);
     transition: all 0.2s ease;
     height: 100%;
 }
@@ -680,7 +741,7 @@ a:hover {
 }
 
 .kpi-icon {
-    font-size: 2rem;
+    font-size: 1.75rem;
     color: var(--accent-primary);
     flex-shrink: 0;
 }
@@ -698,15 +759,15 @@ a:hover {
 }
 
 .kpi-value {
-    font-size: 1.75rem;
+    font-size: var(--font-size-h2);
     font-weight: 700;
     color: var(--text-primary);
     line-height: 1;
-    margin-bottom: 0.25rem;
+    margin-bottom: var(--space-1);
 }
 
 .kpi-label {
-    font-size: 0.875rem;
+    font-size: var(--font-size-sm);
     color: var(--text-secondary);
     font-weight: 500;
 }
@@ -715,18 +776,18 @@ a:hover {
     background-color: var(--bg-secondary);
     border: 1px solid var(--border-color);
     border-radius: 0.5rem;
-    padding: 1.5rem;
+    padding: var(--space-4);
 }
 
 .dashboard-section-header {
     display: flex;
     justify-content: space-between;
     align-items: center;
-    margin-bottom: 1.5rem;
+    margin-bottom: var(--space-4);
 }
 
 .dashboard-section-title {
-    font-size: 1.25rem;
+    font-size: var(--font-size-h4);
     font-weight: 600;
     color: var(--text-primary);
     margin: 0;
@@ -736,13 +797,13 @@ a:hover {
 .activity-stream {
     display: flex;
     flex-direction: column;
-    gap: 0.75rem;
+    gap: var(--space-2);
 }
 
 .activity-item {
     display: flex;
-    gap: 1rem;
-    padding: 1rem;
+    gap: var(--space-3);
+    padding: var(--space-3);
     background-color: var(--bg-primary);
     border: 1px solid var(--border-color);
     border-radius: 0.375rem;
@@ -1109,7 +1170,7 @@ a:hover {
 .upload-drop-zone {
     border: 2px dashed var(--border-default);
     border-radius: 0.5rem;
-    padding: 2rem;
+    padding: var(--space-5);
     text-align: center;
     background-color: var(--bg-surface);
     transition: all 0.3s ease;
@@ -1128,9 +1189,9 @@ a:hover {
 }
 
 .upload-drop-zone-icon {
-    font-size: 3rem;
+    font-size: 2.25rem;
     color: var(--text-muted);
-    margin-bottom: 1rem;
+    margin-bottom: var(--space-3);
 }
 
 .upload-drop-zone.drag-over .upload-drop-zone-icon {
@@ -1161,7 +1222,7 @@ a:hover {
     background-color: var(--bg-surface);
     border: 1px solid var(--border-default);
     border-radius: 0.375rem;
-    padding: 1rem;
+    padding: var(--space-3);
 }
 
 .upload-filename {
@@ -1179,24 +1240,24 @@ a:hover {
 }
 
 .recents-section {
-    margin-bottom: 1.5rem;
+    margin-bottom: var(--space-4);
 }
 
 .recents-section + .recents-section {
     border-top: 1px solid var(--border-color);
-    padding-top: 1rem;
+    padding-top: var(--space-3);
 }
 
 .recents-section-header {
     display: flex;
     justify-content: space-between;
     align-items: center;
-    padding: 0.75rem 1.25rem 0.5rem;
-    margin-bottom: 0.25rem;
+    padding: var(--space-2) var(--space-4) var(--space-1);
+    margin-bottom: var(--space-1);
 }
 
 .recents-section-title {
-    font-size: 0.75rem;
+    font-size: var(--font-size-xs);
     font-weight: 700;
     text-transform: uppercase;
     color: var(--text-muted);
@@ -1222,7 +1283,7 @@ a:hover {
     display: flex;
     align-items: center;
     justify-content: space-between;
-    padding: 0.65rem 1rem;
+    padding: var(--space-2) var(--space-4);
     color: var(--text-secondary);
     text-decoration: none;
     transition: all 0.15s cubic-bezier(0.4, 0, 0.2, 1);
@@ -1351,10 +1412,10 @@ a:hover {
 }
 
 .recents-clear {
-    padding: 0.75rem 1.25rem;
+    padding: var(--space-3) var(--space-4);
     text-align: center;
     border-top: 1px solid var(--border-color);
-    margin-top: 0.5rem;
+    margin-top: var(--space-2);
 }
 
 .recents-clear .btn {
@@ -1371,10 +1432,10 @@ a:hover {
 }
 
 .recents-empty {
-    padding: 2rem 1.25rem;
+    padding: var(--space-5) var(--space-4);
     text-align: center;
     color: var(--text-muted);
-    font-size: 0.875rem;
+    font-size: var(--font-size-sm);
     font-style: italic;
     opacity: 0.7;
 }
@@ -1398,12 +1459,12 @@ a:hover {
 .footer-content {
     display: flex;
     align-items: center;
-    gap: 0.75rem;
-    font-size: 0.875rem;
+    gap: var(--space-2);
+    font-size: var(--font-size-sm);
     color: var(--text-secondary);
     flex-wrap: wrap;
     justify-content: center;
-    padding: 0 1rem;
+    padding: 0 var(--space-4);
 }
 
 .footer-content a {
@@ -1425,11 +1486,11 @@ a:hover {
 
  .kanban-board {
         display: flex;
-        gap: 1rem;
+        gap: var(--space-3);
         overflow-x: auto;
-        padding-bottom: 1rem;
+        padding-bottom: var(--space-3);
     }
-    
+
     .kanban-column {
         flex: 1;
         min-width: 250px;
@@ -1440,46 +1501,46 @@ a:hover {
         display: flex;
         flex-direction: column;
     }
-    
+
     .kanban-column-header {
-        padding: 1rem;
+        padding: var(--space-3);
         background: var(--bg-tertiary);
         border-radius: 8px 8px 0 0;
         border-bottom: 2px solid var(--border-color);
     }
-    
+
     .kanban-column-title {
         font-weight: 600;
-        font-size: 0.9rem;
+        font-size: var(--font-size-sm);
         margin: 0;
         display: flex;
         align-items: center;
         justify-content: space-between;
         color: var(--text-primary);
     }
-    
+
     .kanban-column-count {
         background: var(--bg-primary);
         color: var(--text-muted);
-        padding: 0.25rem 0.5rem;
+        padding: 0.2rem 0.5rem;
         border-radius: 12px;
-        font-size: 0.85rem;
+        font-size: var(--font-size-xs);
         font-weight: 500;
     }
-    
+
     .kanban-column-body {
-        padding: 0.5rem;
+        padding: var(--space-2);
         flex-grow: 1;
         overflow-y: auto;
         min-height: 100px;
     }
-    
+
     .kanban-card {
         background: var(--bg-primary);
         border: 1px solid var(--border-color);
         border-radius: 6px;
-        padding: 0.75rem;
-        margin-bottom: 0.5rem;
+        padding: var(--space-2);
+        margin-bottom: var(--space-2);
         cursor: move;
         transition: box-shadow 0.2s, transform 0.2s, border-color 0.2s;
     }
@@ -1497,35 +1558,35 @@ a:hover {
     
     .kanban-card-title {
         font-weight: 600;
-        font-size: 0.9rem;
-        margin-bottom: 0.5rem;
+        font-size: var(--font-size-sm);
+        margin-bottom: var(--space-2);
         color: var(--text-primary);
         line-height: 1.3;
     }
-    
+
     .kanban-card-meta {
         display: flex;
         flex-direction: column;
         gap: 0.4rem;
-        font-size: 0.8rem;
+        font-size: var(--font-size-xs);
         color: var(--text-secondary);
     }
-    
+
     .kanban-card-meta-row {
         display: flex;
         align-items: center;
         gap: 0.3rem;
     }
-    
+
     .kanban-card-meta-row i {
         width: 14px;
-        font-size: 0.75rem;
+        font-size: var(--font-size-xs);
         color: var(--text-muted);
     }
-    
+
     .kanban-card-actions {
-        margin-top: 0.5rem;
-        padding-top: 0.5rem;
+        margin-top: var(--space-2);
+        padding-top: var(--space-2);
         border-top: 1px solid var(--border-color);
         display: flex;
         justify-content: space-between;

--- a/templates/base.html
+++ b/templates/base.html
@@ -14,7 +14,7 @@
     
     <!-- Custom CSS -->
     {% load static %}
-    <link rel="stylesheet" href="{% static 'css/site.css?v=1.1' %}">
+    <link rel="stylesheet" href="{% static 'css/site.css?v=1.2' %}">
     <link rel="manifest" href="{% static 'manifest.webmanifest' %}">
     <meta name="theme-color" content="#0d6efd">
     <link rel="icon" type="image/png" href="{% static 'icons/favicon-32.png' %}" sizes="32x32">


### PR DESCRIPTION
Automated draft PR opened by the Claude queue worker for Agira item #990.

Model: Sonnet
Job: #166

---

## Zusammenfassung

Die Dichte des gesamten UI wurde reduziert: kleinere Basis-/Überschriften-Schriftgrößen und engere Abstände in Navigation, Sidebars, Cards, Listen, Formularen und Dashboard-Komponenten – umgesetzt über eine zentrale Typografie- und Spacing-Skala als CSS-Custom-Properties, angelehnt an die Anmutung von Claude Desktop.

## Änderungen

- `static/css/site.css`: zentrale Skalen in `:root` ergänzt (`--font-size-base/sm/xs/lg`, `--font-size-h1`–`h6`, `--space-1`–`6`) sowie `--bs-body-font-size` / `--bs-body-line-height` überschrieben, damit Bootstraps eigene Regeln die kompaktere Skala übernehmen.
- Globale `h1`–`h6`/`.h1`–`.h6`-Regeln auf die neue Heading-Skala umgestellt.
- Topbar (Höhe, Padding, Icon-/Brand-Schriftgröße), linke Sidebar (Link-, Section- und Icon-Abstände), rechte Sidebar (Padding) sowie `--topbar-height`/`--footer-height` verkleinert.
- `.card-body`, `.card-header`, `.card-footer`, `.list-group-item`, `.form-label`, `.modal-header/-body/-footer` erhalten kompaktere Paddings/Margins über die neue Skala (bisher ungestylt bzw. mit Bootstrap-Defaults).
- Dashboard-/KPI-Cards, Activity-Stream, Project-Info-Card, Breadcrumbs, Recents/Pinned-Liste, Kanban-Board und Upload-Dropzone auf die Spacing-Variablen umgestellt statt einzelner rem-Werte.
- Cache-Busting-Version des Stylesheets in `templates/base.html` erhöht (`?v=1.2`), damit Browser die aktualisierten Styles laden.

## Warum / Entscheidungen

- Zentrale CSS-Variablen statt verstreuter Einzelwerte, damit künftige Anpassungen an einer Stelle erfolgen und Schrift-/Abstandsgrößen konsistent bleiben (Vorgabe aus dem Issue).
- Nicht die Bootstrap-SASS-Variablen (`$font-size-base`, `$spacer` etc.) angepasst und neu kompiliert, weil Bootstrap per CDN als fertiges `bootstrap.min.css` eingebunden ist und keine Build-Pipeline zum Neukompilieren existiert; stattdessen werden Bootstraps eigene Laufzeit-CSS-Custom-Properties (`--bs-body-font-size`, `--bs-body-line-height`) sowie gezielte Overrides für Bootstrap-Komponenten (Card, Modal, List-Group, Form-Label) genutzt, die nach dem Bootstrap-Link geladen werden.
- Nicht die komplette Bootstrap-Spacing-Utility-Skala (`.mb-3`, `.p-2` usw.) global überschrieben, weil diese Klassen quer durch die gesamte Anwendung für sehr unterschiedliche Zwecke verwendet werden; eine pauschale Änderung hätte ein unüberschaubar großes, schwer zu testendes Risiko für Regressionen an Stellen erzeugt, die nicht Teil dieses Issues sind (Navigation, Sidebars, Cards, Listen, Formulare).
- Nicht die Sidebar-/Rightsidebar-Breiten (`--sidebar-width`, `--right-sidebar-width`) verändert, weil das Issue ausdrücklich nur Schriftgrößen/Abstände (Dichte), nicht die horizontale Layout-Breite adressiert; eine Breitenänderung hätte zusätzliche, hier nicht angeforderte Layout-Verschiebungen ausgelöst.
- Nicht am Farbschema oder am Benutzermenü gearbeitet, da beides laut Issue-Beschreibung explizit in separaten Tickets behandelt wird.
- Kein separates Light-Mode-Theme ergänzt: Die Anwendung setzt `data-bs-theme="dark"` aktuell fest in allen Basistemplates (`base.html`, `login.html`, `logged_out.html`, `embed/base.html`) – ein Light-Mode existiert im Code nicht. Die neuen Variablen sind themenunabhängig definiert, sodass ein später ergänzter Light-Mode dieselbe Dichte-Skala übernehmen kann, ohne dass hier zusätzliche Attrappen-Regeln für einen nicht existierenden Modus eingeführt werden mussten.

## Test-Hinweise

- `python manage.py check` läuft ohne Fehler.
- CSS auf Klammernbalance und Syntax geprüft; Django-Dev-Server lokal gestartet und die Startseite erfolgreich mit dem aktualisierten Stylesheet ausgeliefert (HTTP 200, HTML enthält u. a. `sidebar-link`- und `kpi-card`-Klassen).
- Ein visueller Vorher/Nachher-Screenshot im Browser war in dieser Sandbox nicht möglich, da für Headless-Chromium benötigte Systembibliotheken (`libatk-1.0.so.0` u. a.) fehlen und kein Root-/Sudo-Zugriff zur Installation besteht. Empfehlung: Seite lokal bzw. in einer Umgebung mit Browser-Zugriff auf Desktop-Breite (≥1440px) gegenprüfen, insbesondere Sidebar-Navigation, Dashboard-Karten und ein Formular.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only CSS with no backend or auth changes; main risk is uneven density where Bootstrap utilities still use default spacing.
> 
> **Overview**
> Introduces a **central typography and spacing scale** in `site.css` (`:root`) and applies it across the shell and common UI patterns for a denser, Claude Desktop–style layout.
> 
> **`:root`** adds `--font-size-*`, `--line-height-base`, `--space-1`–`6`, lowers `--topbar-height` (60→52px) and `--footer-height` (50→42px), and sets `--bs-body-font-size` / `--bs-body-line-height` so Bootstrap’s body text follows the new scale. Global `h1`–`h6` rules map headings to the same variables.
> 
> **Layout chrome** (topbar, sidebars, main content padding, footer) and **components** (cards, list groups, form labels, modals, KPI/dashboard blocks, recents, kanban, upload zones) replace scattered `rem` values with the spacing/font variables and slightly smaller icons where touched.
> 
> `templates/base.html` bumps the stylesheet cache buster from `?v=1.1` to `?v=1.2`. Bootstrap utility spacing classes (e.g. `.mb-3`) are **not** globally overridden.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0750c137369fa794be760b48566796a0a064973. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->