### PR TITLE
Einheitliche Hintergrundfarbe (--text-primary) für obere Nav, linke Nav und rechte Sidebar

### DIFF
--- a/static/css/site.css
+++ b/static/css/site.css
@@ -40,7 +40,17 @@
     
     /* Utility Colors */
     --color-white: #ffffff;
-    
+
+    /* Chrome Surfaces - unified background for topbar, left nav and right sidebar (#991) */
+    --chrome-bg: var(--text-primary);
+    --chrome-fg: var(--bg-primary);
+    --chrome-fg-secondary: color-mix(in srgb, var(--chrome-fg) 80%, var(--chrome-bg));
+    --chrome-fg-muted: color-mix(in srgb, var(--chrome-fg) 60%, var(--chrome-bg));
+    --chrome-border: color-mix(in srgb, var(--chrome-fg) 15%, var(--chrome-bg));
+    --chrome-hover-bg: color-mix(in srgb, var(--chrome-fg) 8%, var(--chrome-bg));
+    --chrome-accent: color-mix(in srgb, var(--accent-primary) 65%, var(--chrome-fg));
+    --chrome-accent-hover: color-mix(in srgb, var(--accent-secondary) 65%, var(--chrome-fg));
+
     /* Layout Constants */
     --topbar-height: 52px;
     --sidebar-width: 260px;
@@ -100,8 +110,8 @@ h6, .h6 { font-size: var(--font-size-h6); }
     left: 0;
     right: 0;
     height: var(--topbar-height);
-    background-color: var(--bg-secondary);
-    border-bottom: 1px solid var(--border-color);
+    background-color: var(--chrome-bg);
+    border-bottom: 1px solid var(--chrome-border);
     display: flex;
     align-items: center;
     padding: 0 var(--space-4);
@@ -109,10 +119,26 @@ h6, .h6 { font-size: var(--font-size-h6); }
     gap: var(--space-3);
 }
 
+.topbar .btn-outline-primary {
+    --bs-btn-color: var(--chrome-fg);
+    --bs-btn-border-color: var(--chrome-border);
+    --bs-btn-hover-color: var(--chrome-fg);
+    --bs-btn-hover-bg: var(--chrome-hover-bg);
+    --bs-btn-hover-border-color: var(--chrome-border);
+}
+
+.topbar .btn-outline-secondary {
+    --bs-btn-color: var(--chrome-fg-secondary);
+    --bs-btn-border-color: var(--chrome-border);
+    --bs-btn-hover-color: var(--chrome-fg);
+    --bs-btn-hover-bg: var(--chrome-hover-bg);
+    --bs-btn-hover-border-color: var(--chrome-border);
+}
+
 .sidebar-toggle {
     background: transparent;
     border: none;
-    color: var(--text-primary);
+    color: var(--chrome-fg);
     font-size: 1.25rem;
     cursor: pointer;
     padding: var(--space-2);
@@ -126,19 +152,19 @@ h6, .h6 { font-size: var(--font-size-h6); }
 }
 
 .sidebar-toggle:hover {
-    background-color: var(--bg-tertiary);
+    background-color: var(--chrome-hover-bg);
     color: var(--accent-primary);
 }
 
 .topbar-brand a {
-    color: var(--accent-primary);
+    color: var(--chrome-accent);
     font-weight: 600;
     font-size: var(--font-size-h4);
     text-decoration: none;
 }
 
 .topbar-brand a:hover {
-    color: var(--accent-secondary);
+    color: var(--chrome-accent-hover);
 }
 
 .topbar-user {
@@ -170,8 +196,8 @@ h6, .h6 { font-size: var(--font-size-h6); }
 }
 
 .topbar-search .btn-outline-secondary {
-    border-color: var(--border-color);
-    color: var(--text-secondary);
+    border-color: var(--chrome-border);
+    color: var(--chrome-fg-secondary);
 }
 
 .topbar-search .btn-outline-secondary:hover {
@@ -182,7 +208,7 @@ h6, .h6 { font-size: var(--font-size-h6); }
 
 /* Topbar GitHub Issues Status */
 .topbar-github-issues {
-    color: var(--text-secondary);
+    color: var(--chrome-fg-secondary);
     padding: 0.5rem 0.75rem;
     border-radius: 0.375rem;
     transition: all 0.2s ease;
@@ -190,8 +216,8 @@ h6, .h6 { font-size: var(--font-size-h6); }
 }
 
 .topbar-github-issues:hover {
-    background-color: var(--bg-tertiary);
-    color: var(--text-primary);
+    background-color: var(--chrome-hover-bg);
+    color: var(--chrome-fg);
 }
 
 .topbar-github-issues .badge {
@@ -213,8 +239,8 @@ h6, .h6 { font-size: var(--font-size-h6); }
     top: var(--topbar-height);
     width: var(--sidebar-width);
     height: calc(100vh - var(--topbar-height));
-    background-color: var(--bg-secondary);
-    border-right: 1px solid var(--border-color);
+    background-color: var(--chrome-bg);
+    border-right: 1px solid var(--chrome-border);
     overflow-x: hidden;
     overflow-y: auto;
     padding: var(--space-2) 0;
@@ -261,7 +287,7 @@ h6, .h6 { font-size: var(--font-size-h6); }
     display: flex;
     align-items: center;
     padding: var(--space-2) var(--space-4);
-    color: var(--text-secondary);
+    color: var(--chrome-fg-secondary);
     text-decoration: none;
     transition: all 0.2s ease;
     position: relative;
@@ -269,14 +295,14 @@ h6, .h6 { font-size: var(--font-size-h6); }
 }
 
 .sidebar-link:hover {
-    background-color: var(--bg-tertiary);
-    color: var(--text-primary);
+    background-color: var(--chrome-hover-bg);
+    color: var(--chrome-fg);
     border-left-color: var(--accent-primary);
 }
 
 .sidebar-link.active {
     background-color: rgba(99, 102, 241, 0.12);
-    color: var(--accent-primary);
+    color: var(--chrome-accent);
     border-left-color: var(--accent-primary);
     font-weight: 500;
 }
@@ -319,12 +345,12 @@ h6, .h6 { font-size: var(--font-size-h6); }
 }
 
 .sidebar-section-header:hover {
-    background-color: var(--bg-tertiary);
+    background-color: var(--chrome-hover-bg);
 }
 
 .sidebar-section-chevron {
     font-size: var(--font-size-sm);
-    color: var(--text-muted);
+    color: var(--chrome-fg-muted);
     margin-right: var(--space-2);
     transition: transform 0.2s ease, opacity 0.3s ease;
 }
@@ -333,7 +359,7 @@ h6, .h6 { font-size: var(--font-size-h6); }
     font-size: var(--font-size-xs);
     font-weight: 600;
     text-transform: uppercase;
-    color: var(--text-muted);
+    color: var(--chrome-fg-muted);
     letter-spacing: 0.05em;
     white-space: nowrap;
     transition: opacity 0.2s ease, width 0.2s ease;
@@ -359,8 +385,8 @@ h6, .h6 { font-size: var(--font-size-h6); }
     top: var(--topbar-height);
     width: var(--right-sidebar-width);
     height: calc(100vh - var(--topbar-height));
-    background-color: var(--bg-secondary);
-    border-left: 1px solid var(--border-color);
+    background-color: var(--chrome-bg);
+    border-left: 1px solid var(--chrome-border);
     overflow-y: auto;
     padding: var(--space-2) 0;
     z-index: 998;
@@ -1244,7 +1270,7 @@ a:hover {
 }
 
 .recents-section + .recents-section {
-    border-top: 1px solid var(--border-color);
+    border-top: 1px solid var(--chrome-border);
     padding-top: var(--space-3);
 }
 
@@ -1260,15 +1286,15 @@ a:hover {
     font-size: var(--font-size-xs);
     font-weight: 700;
     text-transform: uppercase;
-    color: var(--text-muted);
+    color: var(--chrome-fg-muted);
     letter-spacing: 0.08em;
 }
 
 .recents-section-count {
     font-size: 0.7rem;
     font-weight: 600;
-    color: var(--text-muted);
-    background-color: var(--bg-tertiary);
+    color: var(--chrome-fg-muted);
+    background-color: var(--chrome-hover-bg);
     padding: 0.15rem 0.5rem;
     border-radius: 0.75rem;
 }
@@ -1284,7 +1310,7 @@ a:hover {
     align-items: center;
     justify-content: space-between;
     padding: var(--space-2) var(--space-4);
-    color: var(--text-secondary);
+    color: var(--chrome-fg-secondary);
     text-decoration: none;
     transition: all 0.15s cubic-bezier(0.4, 0, 0.2, 1);
     position: relative;
@@ -1295,15 +1321,15 @@ a:hover {
 }
 
 .recents-entry:hover {
-    background-color: var(--bg-tertiary);
-    color: var(--text-primary);
+    background-color: var(--chrome-hover-bg);
+    color: var(--chrome-fg);
     border-left-color: var(--accent-primary);
     text-decoration: none;
 }
 
 .recents-entry.active {
     background-color: rgba(99, 102, 241, 0.15);
-    color: var(--accent-primary);
+    color: var(--chrome-accent);
     border-left-color: var(--accent-primary);
     font-weight: 500;
 }
@@ -1349,12 +1375,12 @@ a:hover {
 }
 
 .recents-entry-type {
-    color: var(--text-muted);
+    color: var(--chrome-fg-muted);
     font-weight: 500;
 }
 
 .recents-entry-status {
-    color: var(--accent-primary);
+    color: var(--chrome-accent);
     font-weight: 500;
     opacity: 0.8;
     min-width: 80px;
@@ -1391,7 +1417,7 @@ a:hover {
 
 .recents-action:hover {
     text-decoration: none;
-    background-color: var(--bg-tertiary);
+    background-color: var(--chrome-hover-bg);
     transform: scale(1.1);
 }
 
@@ -1408,13 +1434,13 @@ a:hover {
 }
 
 .recents-entry:hover .recents-action.text-muted:hover {
-    color: var(--text-secondary);
+    color: var(--chrome-fg-secondary);
 }
 
 .recents-clear {
     padding: var(--space-3) var(--space-4);
     text-align: center;
-    border-top: 1px solid var(--border-color);
+    border-top: 1px solid var(--chrome-border);
     margin-top: var(--space-2);
 }
 
@@ -1434,10 +1460,17 @@ a:hover {
 .recents-empty {
     padding: var(--space-5) var(--space-4);
     text-align: center;
-    color: var(--text-muted);
+    color: var(--chrome-fg-muted);
     font-size: var(--font-size-sm);
     font-style: italic;
     opacity: 0.7;
+}
+
+/* Scoped .text-muted override so text stays legible on the chrome surfaces above */
+.topbar .text-muted,
+.sidebar .text-muted,
+.right-sidebar .text-muted {
+    color: var(--chrome-fg-muted) !important;
 }
 
 /* Footer */


### PR DESCRIPTION
Automated draft PR opened by the Claude queue worker for Agira item #991.

Model: Sonnet
Job: #167

---

## Zusammenfassung

Obere Navigation, linke Navigation und rechte Sidebar nutzen jetzt überall dieselbe Hintergrundfarbe (`var(--text-primary)`), sodass die drei Chrome-Bereiche als ein zusammenhängender, einheitlicher Rahmen um den Content wirken. Die Vordergrundfarben (Text, Icons, Borders, Hover-/Active-Zustände) in diesen Bereichen wurden zentral angepasst, damit sie auf dem hellen Hintergrund gut lesbar bleiben.

## Änderungen

- Neue zentrale CSS-Variablen in `static/css/site.css` (`:root`): `--chrome-bg` (= `var(--text-primary)`), `--chrome-fg`, `--chrome-fg-secondary`, `--chrome-fg-muted`, `--chrome-border`, `--chrome-hover-bg`, `--chrome-accent`, `--chrome-accent-hover`. Alle bis auf `--chrome-bg`/`--chrome-fg` werden per `color-mix()` aus der bestehenden Palette abgeleitet, statt neue Hex-Werte zu hardcoden.
- `.topbar`, `.sidebar`, `.right-sidebar`: `background-color` und Border-Farbe auf `--chrome-bg` / `--chrome-border` umgestellt.
- Vordergrund in diesen Bereichen umgestellt auf die neuen Chrome-Variablen: `.sidebar-toggle`, `.sidebar-link`, `.sidebar-section-title`, `.sidebar-section-chevron`, `.topbar-github-issues`, `.topbar-search .btn-outline-secondary`, `.topbar-brand a`, `.sidebar-link.active`, sowie die komplette Recents/Pinned-Liste der rechten Sidebar (`.recents-*`).
- Bootstrap-Outline-Buttons innerhalb der Topbar (`Settings`, `Abmelden`, Sidebar-Toggle-Button) über `.topbar .btn-outline-primary` / `.btn-outline-secondary` (Bootstrap-CSS-Variablen `--bs-btn-*`) an die Chrome-Farben angeglichen.
- Generisches `.text-muted` bleibt für den restlichen (dunklen) Content-Hintergrund unverändert, wird aber gezielt für `.topbar`, `.sidebar`, `.right-sidebar` überschrieben, damit z. B. der Benutzername in der Topbar lesbar bleibt.
- Der zentrale Content-Bereich (`.main-content`, `.card`, etc.) bleibt unverändert bei `--bg-primary`/`--bg-secondary`.

## Warum / Entscheidungen

- **`color-mix()` statt fixer Hex-Werte für die abgeleiteten Chrome-Variablen**, weil die Aufgabe explizit "keine hartkodierten Farbwerte je Bereich" fordert und die Kontrastfarben so automatisch mitziehen, falls `--text-primary`/`--bg-primary` sich künftig ändern.
- **Nicht per-Element-Hardcoding von `--bg-secondary`/`--text-secondary` beibehalten**, weil diese Variablen für den dunklen Content-Hintergrund optimiert sind; auf dem jetzt hellen Chrome-Hintergrund wären Text und Icons kaum lesbar gewesen (z. B. `--text-secondary` auf `--text-primary` ergibt praktisch keinen Kontrast).
- **Eigene `--chrome-accent`/`--chrome-accent-hover` statt Wiederverwendung von `--accent-primary`/`--accent-secondary` für Active-Texte**, weil die reinen Akzentfarben auf dem hellen Chrome-Hintergrund nur ca. 4:1 bzw. 3,9:1 Kontrast liefern (AA-Grenzwert 4,5:1 für normalen Text knapp verfehlt). Die abgedunkelten Varianten (per `color-mix` mit `--chrome-fg`) erreichen ca. 7:1 und bleiben trotzdem eindeutig als Indigo-Akzent erkennbar. Hintergrund-Tints für Active-Zustände (`rgba(99, 102, 241, ...)`) und dünne Border-Akzente bleiben unverändert, da sie als Fläche/Linie nur die 3:1-Anforderung für Nicht-Text-UI-Elemente erfüllen müssen.
- **`--chrome-fg-muted` auf 60 % statt ursprünglich 55 % Mischanteil gesetzt**, weil 55 % rechnerisch nur ~4,17:1 Kontrast ergab (knapp unter AA für die kleinen, fett gesetzten Section-Titel); 60 % liefert ~5,4:1 mit Sicherheitsmarge.
- **Suchfeld (`.topbar-search .form-control`) bewusst nicht verändert**, weil es bereits ein eigenständiges, in sich stimmiges Element mit eigenem dunklen Hintergrund (`--bg-tertiary`) und hellem Text ist – dieser Kontrast ändert sich durch den helleren Chrome-Hintergrund ringsherum nicht.
- **Kein `data-bs-theme="light"` auf den Chrome-Containern**, weil Bootstraps `--bs-primary`/`--bs-secondary` (Basis für Outline-Buttons) themenunabhängig fixe Markenfarben sind – die Theme-Umschaltung hätte das Kontrastproblem der Outline-Buttons nicht gelöst. Stattdessen wurden die betroffenen Buttons gezielt über `--bs-btn-*`-Variablen auf die Chrome-Farben gemappt.
- **Kein separates Light-Theme im Projekt vorhanden** (die App fährt aktuell ausschließlich das dunkle Graphite/Indigo-Farbschema, `data-bs-theme="dark"` ist global gesetzt) – die Lösung ist über semantische Variablen umgesetzt, sodass ein späteres Light-Theme automatisch konsistente Chrome-Farben bekäme, ohne dass diese Regeln angepasst werden müssten.

## Test-Hinweise

- `python manage.py check` läuft ohne Fehler.
- CSS auf Balance von Klammern/Selektoren geprüft (kein Syntaxfehler).
- Kontrastverhältnisse rechnerisch verifiziert (WCAG-Luminanzformel): `--chrome-fg` auf `--chrome-bg` ≈ 17,5:1, `--chrome-fg-secondary` ≈ 10:1, `--chrome-fg-muted` ≈ 5,4:1, `--chrome-accent`/`--chrome-accent-hover` ≈ 7:1 bzw. 6,9:1 – alle über dem AA-Grenzwert von 4,5:1 für normalen Text.
- Manuell im Browser prüfen: Topbar, linke Navigation und rechte Sidebar zeigen denselben hellen Hintergrund; Icons/Labels/aktive Einträge in Sidebar und Recents-Liste sowie Settings-/Abmelden-Buttons in der Topbar sind gut lesbar; Content-Bereich bleibt unverändert dunkel.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only visual theming in site.css with no logic, API, or data changes; main regression risk is contrast or missed selectors in chrome areas.
> 
> **Overview**
> Topbar, left nav, and right sidebar now share one **chrome** surface: background `--chrome-bg` (`var(--text-primary)`), with borders, text, hover, and accent colors derived via `color-mix()` instead of per-area `--bg-secondary` / `--text-*` tokens.
> 
> New `:root` variables (`--chrome-fg`, `--chrome-fg-secondary`, `--chrome-fg-muted`, `--chrome-border`, `--chrome-hover-bg`, `--chrome-accent`, `--chrome-accent-hover`) drive links, toggles, sidebar nav, GitHub issues chip, search outline button, and the recents/pinned list in the right sidebar. **Topbar** outline primary/secondary buttons are remapped through Bootstrap `--bs-btn-*` overrides.
> 
> `.text-muted` inside `.topbar`, `.sidebar`, and `.right-sidebar` is overridden so muted labels stay readable on the light chrome. Main content, cards, footer, and the topbar search field (still on `--bg-tertiary`) are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7f769708fdbc7666bf3ec6effba3b15ca3fd64e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->