### PR TITLE
Benutzer/Settings/Abmelden als sticky Aufklappmenü unten links (aus oberer Navbar entfernen)

### DIFF
--- a/static/css/site.css
+++ b/static/css/site.css
@@ -167,7 +167,7 @@ h6, .h6 { font-size: var(--font-size-h6); }
     color: var(--chrome-accent-hover);
 }
 
-.topbar-user {
+.topbar-actions {
     display: flex;
     align-items: center;
 }
@@ -241,8 +241,8 @@ h6, .h6 { font-size: var(--font-size-h6); }
     height: calc(100vh - var(--topbar-height));
     background-color: var(--chrome-bg);
     border-right: 1px solid var(--chrome-border);
-    overflow-x: hidden;
-    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
     padding: var(--space-2) 0;
     transition: width 0.3s ease, padding 0.3s ease;
     z-index: 999;
@@ -281,6 +281,97 @@ h6, .h6 { font-size: var(--font-size-h6); }
 .sidebar-nav {
     display: flex;
     flex-direction: column;
+    flex: 1 1 auto;
+    min-height: 0;
+    overflow-x: hidden;
+    overflow-y: auto;
+}
+
+/* Sticky user menu at the foot of the left navigation (#992) */
+.sidebar-user {
+    flex: 0 0 auto;
+    position: sticky;
+    bottom: 0;
+    border-top: 1px solid var(--chrome-border);
+    background-color: var(--chrome-bg);
+}
+
+.sidebar-user-toggle {
+    display: flex;
+    align-items: center;
+    width: 100%;
+    padding: var(--space-2) var(--space-4);
+    background: transparent;
+    border: none;
+    color: var(--chrome-fg-secondary);
+    text-align: left;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.sidebar-user-toggle:hover,
+.sidebar-user-toggle[aria-expanded="true"] {
+    background-color: var(--chrome-hover-bg);
+    color: var(--chrome-fg);
+}
+
+.sidebar-user-avatar {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 26px;
+    width: 26px;
+    height: 26px;
+    margin-right: var(--space-2);
+    border-radius: 50%;
+    background-color: var(--chrome-accent);
+    color: var(--chrome-bg);
+    font-size: var(--font-size-xs);
+    font-weight: 600;
+    flex-shrink: 0;
+}
+
+.sidebar-user-name {
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-size: var(--font-size-sm);
+}
+
+.sidebar-user-chevron {
+    font-size: var(--font-size-xs);
+    color: var(--chrome-fg-muted);
+}
+
+.sidebar.collapsed .sidebar-user-toggle {
+    justify-content: center;
+    padding: var(--space-2);
+}
+
+.sidebar.collapsed .sidebar-user-avatar {
+    margin-right: 0;
+}
+
+.sidebar-user-menu {
+    min-width: 200px;
+    background-color: var(--chrome-bg);
+    border-color: var(--chrome-border);
+}
+
+.sidebar-user-menu .dropdown-item {
+    color: var(--chrome-fg-secondary);
+    font-size: var(--font-size-sm);
+}
+
+.sidebar-user-menu .dropdown-item:hover,
+.sidebar-user-menu .dropdown-item:focus {
+    background-color: var(--chrome-hover-bg);
+    color: var(--chrome-fg);
+}
+
+.sidebar-user-menu .dropdown-divider {
+    border-top-color: var(--chrome-border);
 }
 
 .sidebar-link {

--- a/templates/base.html
+++ b/templates/base.html
@@ -105,14 +105,7 @@
         {% endif %}
         
         {% if user.is_authenticated %}
-        <div class="topbar-user ms-auto">
-            <span class="text-muted me-3">{{ user.username }}</span>
-            <a href="{% url 'user-settings' %}" class="btn btn-sm btn-outline-primary me-2">
-                <i class="bi bi-gear"></i> Settings
-            </a>
-            <a href="{% url 'logout' %}" class="btn btn-sm btn-outline-secondary me-2">
-                <i class="bi bi-box-arrow-right"></i> Abmelden
-            </a>
+        <div class="topbar-actions ms-auto">
             <button type="button" class="btn btn-sm btn-outline-secondary" id="rightSidebarToggle" aria-label="Rechte Sidebar ein-/ausblenden" title="Rechte Sidebar ein-/ausblenden">
                 <i class="bi bi-layout-sidebar-inset-reverse"></i>
             </button>
@@ -266,6 +259,29 @@
                     <span class="sidebar-text">Admin</span>
                 </a>
             </nav>
+
+            {% if user.is_authenticated %}
+            <div class="sidebar-user dropup">
+                <button type="button" class="sidebar-user-toggle" id="sidebarUserToggle" data-bs-toggle="dropdown" aria-expanded="false" aria-haspopup="true">
+                    <span class="sidebar-user-avatar">{{ user.username|first|upper }}</span>
+                    <span class="sidebar-user-name sidebar-text">{{ user.username }}</span>
+                    <i class="bi bi-chevron-expand sidebar-user-chevron sidebar-text"></i>
+                </button>
+                <ul class="dropdown-menu sidebar-user-menu" aria-labelledby="sidebarUserToggle">
+                    <li>
+                        <a class="dropdown-item" href="{% url 'user-settings' %}">
+                            <i class="bi bi-gear me-2"></i>Einstellungen
+                        </a>
+                    </li>
+                    <li><hr class="dropdown-divider"></li>
+                    <li>
+                        <a class="dropdown-item" href="{% url 'logout' %}">
+                            <i class="bi bi-box-arrow-right me-2"></i>Abmelden
+                        </a>
+                    </li>
+                </ul>
+            </div>
+            {% endif %}
         </aside>
 
         <!-- Main Content -->


### PR DESCRIPTION
Automated draft PR opened by the Claude queue worker for Agira item #992.

Model: Sonnet
Job: #168

---

## Zusammenfassung

Benutzeranzeige, Einstellungen und Abmelden wandern aus der oberen Navbar in ein sticky Aufklappmenü am unteren Ende der linken Navigation – analog zum Benutzermenü in Claude Desktop.

## Änderungen

- `templates/base.html`: Aus der Topbar entfernt: Benutzername, „Settings"-Link und „Abmelden"-Link. Übrig bleibt nur noch der Umschalter für die rechte Sidebar (`topbar-actions`).
- `templates/base.html`: Am Fuß der linken Navigation (`.sidebar`) neuer Block `.sidebar-user` mit Avatar-Initiale + Benutzername als Bootstrap-`dropup`-Toggle; das Aufklappmenü enthält „Einstellungen" und „Abmelden" mit denselben URLs wie zuvor.
- `static/css/site.css`: `.sidebar` ist jetzt ein Flex-Container; die Linkliste (`.sidebar-nav`) scrollt eigenständig (`flex: 1 1 auto; overflow-y: auto`), während `.sidebar-user` als nicht schrumpfender Footer (zusätzlich mit `position: sticky; bottom: 0`) immer sichtbar bleibt. Neue Styles für Toggle, Avatar, Name und Menü-Items, inkl. Verhalten im eingeklappten Sidebar-Zustand (nur Avatar sichtbar, wie bei den übrigen Nav-Icons).
- Umbenennung `.topbar-user` → `.topbar-actions`, da die Klasse jetzt nur noch den Sidebar-Umschalter enthält.

## Warum / Entscheidungen

- Eigene JS-Logik für Öffnen/Schließen des Menüs (Klick außerhalb, Escape) wurde **nicht** selbst geschrieben, weil Bootstraps vorhandene `dropdown`/`dropup`-Komponente (bereits über `bootstrap.bundle.min.js` eingebunden) genau dieses Verhalten inklusive Tastatursteuerung und Outside-Click-Handling liefert – weniger Code, kein zusätzlicher Wartungsaufwand.
- Sichtbarkeit des User-Bereichs wurde **nicht** rein über `position: sticky` auf einem weiterhin insgesamt scrollenden `.sidebar`-Container gelöst, weil bei kurzen Navigationslisten sonst eine Lücke zwischen Menüende und User-Bereich entstünde statt eines wirklich am unteren Rand fixierten Bereichs; stattdessen scrollt nur `.sidebar-nav` und `.sidebar-user` sitzt als nicht schrumpfender Flex-Footer außerhalb davon (mit `sticky` zusätzlich als defensive Absicherung).
- Es wurde **keine** neue globale State-/Storage-Logik (z. B. „Menü offen" in localStorage) ergänzt, weil das Bootstrap-Dropdown dieses Verhalten pro Seitenaufruf bereits korrekt handhabt und zusätzlicher Zustand hier keinen Mehrwert bringt.
- Für den eingeklappten Sidebar-Zustand wurde die bestehende `.sidebar-text`-Klasse (die Name/Chevron ausblendet) wiederverwendet statt einer neuen Collapse-Regel, um konsistent mit dem restlichen Verhalten der Navigation zu bleiben.

## Test-Hinweise

- `python manage.py check` läuft ohne Fehler.
- Serverseitig gerendertes HTML (eingeloggte Session) geprüft: In der Topbar erscheinen keine Benutzer-/Settings-/Abmelden-Elemente mehr; am Ende der linken Navigation ist der neue `sidebar-user`-Block mit Avatar-Initiale, Benutzername sowie Aufklappmenü-Einträgen „Einstellungen" und „Abmelden" vorhanden.
- Eine pixelgenaue visuelle Prüfung im Browser (Screenshot) war in dieser Umgebung nicht möglich, da für den headless Chromium eine Systembibliothek (`libatk-1.0.so.0`) fehlt und kein root-Zugriff zur Nachinstallation besteht. Bitte vor dem Merge einmal manuell im Browser gegenprüfen: Sidebar scrollen (Menü bleibt sichtbar), Klick auf den User-Bereich öffnet das Aufklappmenü nach oben, Klick außerhalb/Escape schließt es, „Einstellungen" und „Abmelden" funktionieren wie zuvor, Darstellung im ein- und ausgeklappten Sidebar-Zustand.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Template and CSS-only layout change; no auth or routing changes beyond relocating existing links.
> 
> **Overview**
> Moves **account actions** (username, settings, logout) from the top navbar into a **sticky user block** at the bottom of the left sidebar, similar to Claude Desktop.
> 
> In `base.html`, the topbar for authenticated users now only keeps the right-sidebar toggle (`topbar-user` → `topbar-actions`). A new `sidebar-user` **Bootstrap dropup** shows avatar initial, username, and menu items for Einstellungen and Abmelden with the same URLs as before.
> 
> In `site.css`, the sidebar becomes a **flex column**: `sidebar-nav` scrolls independently while `sidebar-user` stays pinned as a non-shrinking footer (with sticky styling and collapsed-sidebar rules so only the avatar remains visible).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20c441d621a0e46440fce74a0e1df7b1d63f56e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->