### PR TITLE
Einheitliche Hintergrundfarbe (--bg-primary / #0b0f14) für obere Nav, linke Nav und rechte Sidebar

### DIFF
--- a/static/css/site.css
+++ b/static/css/site.css
@@ -42,8 +42,8 @@
     --color-white: #ffffff;
 
     /* Chrome Surfaces - unified background for topbar, left nav and right sidebar (#991) */
-    --chrome-bg: var(--text-primary);
-    --chrome-fg: var(--bg-primary);
+    --chrome-bg: var(--bg-primary);
+    --chrome-fg: var(--text-primary);
     --chrome-fg-secondary: color-mix(in srgb, var(--chrome-fg) 80%, var(--chrome-bg));
     --chrome-fg-muted: color-mix(in srgb, var(--chrome-fg) 60%, var(--chrome-bg));
     --chrome-border: color-mix(in srgb, var(--chrome-fg) 15%, var(--chrome-bg));


### PR DESCRIPTION
Automated draft PR opened by the Claude queue worker for Agira item #991.

Model: Sonnet
Job: #170

---

## Zusammenfassung

Korrigiert eine vertauschte CSS-Variablen-Zuweisung, durch die die obere Nav, die linke Nav und die rechte Sidebar fälschlich einen hellen statt den vorgesehenen dunklen Hintergrund (`--bg-primary`, `#0b0f14`) erhielten.

## Änderungen

- `static/css/site.css`: `--chrome-bg` zeigt jetzt auf `var(--bg-primary)` (dunkel) statt auf `var(--text-primary)` (hell); `--chrome-fg` zeigt entsprechend auf `var(--text-primary)` (hell) statt auf `var(--bg-primary)` (dunkel).

## Warum / Entscheidungen

- Die vorherige Umsetzung (#991, Commit „unify chrome background via --text-primary") hatte Hintergrund- und Vordergrundvariable exakt vertauscht: `--chrome-bg: var(--text-primary)` machte die Flächen hell/weiß, `--chrome-fg: var(--bg-primary)` machte Text/Icons dunkel auf hellem Grund — das Gegenteil der Anforderung.
- Nicht die abhängigen `--chrome-fg-secondary`, `--chrome-fg-muted`, `--chrome-border`, `--chrome-hover-bg`, `--chrome-accent*` Variablen sowie alle Verbrauchsstellen (Topbar, Sidebar-Links, Recents etc.) angepasst, weil deren `color-mix`-Formeln bereits korrekt von „chrome-bg = dunkel, chrome-fg = hell" ausgingen — nur die Basiszuweisung war invertiert. Eine Anpassung dieser Stellen wäre unnötige Churn gewesen.
- Nicht `--bg-primary` direkt an allen drei Stellen (Topbar, Sidebar, rechte Sidebar) hartkodiert, weil die bestehende `--chrome-bg`-Abstraktion aus #991 genau für diesen Zweck existiert und weiterhin zentral gepflegt werden soll.
- Keinen separaten Light-Mode-Zweig ergänzt, weil das Projekt aktuell nur ein (dunkles) Farbschema in `:root` definiert und kein `[data-theme]`/`prefers-color-scheme`-Umschalten existiert.

## Test-Hinweise

- `static/css/site.css` visuell prüfen: `--chrome-bg` löst zu `var(--bg-primary)` (`#0b0f14`) auf, `--chrome-fg` zu `var(--text-primary)` (`#f1f5f9`).
- Seite im Browser laden und obere Nav, linke Nav sowie rechte Sidebar auf einheitlichen dunklen Hintergrund ohne weiße/helle Flächen prüfen.
- Lesbarkeit von Labels, Icons sowie Active-/Hover-Zuständen (z. B. `.sidebar-link.active`, `.recents-entry.active`) auf dem dunklen Grund kontrollieren.
- Sicherstellen, dass der zentrale Content-Bereich unverändert bleibt.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Two-line CSS variable swap in static styles; no logic, auth, or data changes—visual chrome theming only.
> 
> **Overview**
> Fixes inverted **chrome** theme variables in `site.css` so the top bar, left nav, and right sidebar use the intended dark shell (`--bg-primary` / `#0b0f14`) with light foreground text instead of a light background with dark text.
> 
> The change only swaps the two root assignments: `--chrome-bg` now points to `var(--bg-primary)` and `--chrome-fg` to `var(--text-primary)`. Dependent `--chrome-*` mixes and consumers (`.topbar`, `.sidebar`, `.right-sidebar`, recents, user menu) are unchanged and pick up the corrected semantics automatically.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6c45f7db015a839f7009ce10000b090a84049d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->