### PR TITLE
DetailView-Header neu strukturieren: Titel, Breadcrumb & Aktionsmenü kompakt und mobiltauglich

### DIFF
--- a/static/css/site.css
+++ b/static/css/site.css
@@ -1155,6 +1155,58 @@ a:hover {
     border-top: 1px solid var(--border-default);
 }
 
+.dropdown-header {
+    color: var(--text-muted);
+    font-size: var(--font-size-sm);
+    text-transform: uppercase;
+}
+
+/* Item DetailView header: compact title/breadcrumb + hierarchical actions */
+.item-detail-breadcrumb {
+    margin-bottom: var(--space-2);
+}
+
+.item-detail-header {
+    margin-bottom: var(--space-4);
+}
+
+.item-detail-title-block {
+    min-width: 0;
+    flex: 1 1 auto;
+}
+
+.item-detail-title {
+    margin-bottom: var(--space-1);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    max-width: 100%;
+}
+
+.item-detail-actions {
+    flex: 0 0 auto;
+}
+
+.item-actions-menu {
+    max-height: 80vh;
+    overflow-y: auto;
+}
+
+@media (max-width: 768px) {
+    .item-detail-title {
+        white-space: normal;
+        display: -webkit-box;
+        -webkit-line-clamp: 2;
+        -webkit-box-orient: vertical;
+    }
+
+    .item-actions-menu .dropdown-item,
+    .item-actions-menu .dropdown-header {
+        padding-top: var(--space-2);
+        padding-bottom: var(--space-2);
+    }
+}
+
 /* Alerts */
 .alert {
     border: 1px solid var(--border-default);

--- a/templates/item_detail.html
+++ b/templates/item_detail.html
@@ -120,86 +120,112 @@
      data-recent-status="{{ item.status }}" 
      data-recent-url="{% url 'item-detail' item.id %}"></div>
 
-<div class="page-header d-flex justify-content-between align-items-start">
-    
-        <div>
-            <h3>{{ item.title }}</h3>
-            <p class="text-muted">
-                <a href="{% url 'project-detail' item.project.id %}" class="text-decoration-none">{{ item.project.name }}</a> • {{ item.type.name }}
-            </p>
-        </div>
-   
-        <div class="btn-group" role="group" aria-label="Item Actions">
-            <a href="{% url 'project-detail' item.project.id %}" class="btn btn-outline-primary">
-                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-arrow-left" viewBox="0 0 16 16">
-                                <path fill-rule="evenodd" d="M15 8a.5.5 0 0 0-.5-.5H2.707l3.147-3.146a.5.5 0 1 0-.708-.708l-4 4a.5.5 0 0 0 0 .708l4 4a.5.5 0 0 0 .708-.708L2.707 8.5H14.5A.5.5 0 0 0 15 8z"/>
-                            </svg>
-                            Back to Project
-                        </a>
-                         <a href="{% url 'item-edit' item.id %}" class="btn btn-outline-primary">
-                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-pencil" viewBox="0 0 16 16">
-                    <path d="M12.146.146a.5.5 0 0 1 .708 0l3 3a.5.5 0 0 1 0 .708l-10 10a.5.5 0 0 1-.168.11l-5 2a.5.5 0 0 1-.65-.65l2-5a.5.5 0 0 1 .11-.168l10-10zM11.207 2.5 13.5 4.793 14.793 3.5 12.5 1.207 11.207 2.5zm1.586 3L10.5 3.207 4 9.707V10h.5a.5.5 0 0 1 .5.5v.5h.5a.5.5 0 0 1 .5.5v.5h.293l6.5-6.5zm-9.761 5.175-.106.106-1.528 3.821 3.821-1.528.106-.106A.5.5 0 0 1 5 12.5V12h-.5a.5.5 0 0 1-.5-.5V11h-.5a.5.5 0 0 1-.468-.325z"/>
-                </svg>
-                Edit
-            </a>
-            <button type="button" class="btn btn-outline-primary" data-bs-toggle="modal" data-bs-target="#moveItemModal">
-                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-arrow-left-right" viewBox="0 0 16 16">
-                    <path fill-rule="evenodd" d="M1 11.5a.5.5 0 0 0 .5.5h11.793l-3.147 3.146a.5.5 0 0 0 .708.708l4-4a.5.5 0 0 0 0-.708l-4-4a.5.5 0 0 0-.708.708L13.293 11H1.5a.5.5 0 0 0-.5.5zm14-7a.5.5 0 0 1-.5.5H2.707l3.147 3.146a.5.5 0 1 1-.708.708l-4-4a.5.5 0 0 1 0-.708l4-4a.5.5 0 1 1 .708.708L2.707 4H14.5a.5.5 0 0 1 .5.5z"/>
-                </svg>
-                Move
-            </button>
-            <button type="button" class="btn btn-outline-primary" data-bs-toggle="modal" data-bs-target="#applyBlueprintModal">
-                <i class="bi bi-file-earmark-text"></i>
-                Apply Blueprint
-            </button>
-            <a href="{% url 'item-create-blueprint' item.id %}" class="btn btn-outline-primary">
-                <i class="bi bi-clipboard-plus"></i>
-                Create Blueprint
-            </a>
-            {% if user.role == 'Agent' %}
-            <button type="button" class="btn btn-outline-success" onclick="takeOverResponsible()">
-                <i class="bi bi-person-check"></i>
-                Take over
-            </button>
-            {% if item.status != 'Closed' %}
-            <button type="button" class="btn btn-outline-primary" onclick="enqueueToClaude()">
-                <i class="bi bi-robot"></i>
-                An Claude übergeben
-            </button>
-            {% endif %}
-            {% endif %}
-            <button type="button" class="btn btn-outline-info" data-bs-toggle="modal" data-bs-target="#assignResponsibleModal">
-                <i class="bi bi-person-plus"></i>
-                Assign
-            </button>
-            <button type="button" class="btn btn-outline-secondary" onclick="sendStatusUpdate({{ item.id }})">
-                <i class="bi bi-send"></i>
-                Send status update
-            </button>
-              <button type="button" class="btn btn-outline-danger" onclick="confirmDelete()">
-                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-trash" viewBox="0 0 16 16">
-                    <path d="M5.5 5.5A.5.5 0 0 1 6 6v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5zm2.5 0a.5.5 0 0 1 .5.5v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5zm3 .5a.5.5 0 0 0-1 0v6a.5.5 0 0 0 1 0V6z"/>
-                    <path fill-rule="evenodd" d="M14.5 3a1 1 0 0 1-1 1H13v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V4h-.5a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1H6a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1h3.5a1 1 0 0 1 1 1v1zM4.118 4 4 4.059V13a1 1 0 0 0 1 1h6a1 1 0 0 0 1-1V4.059L11.882 4H4.118zM2.5 3V2h11v1h-11z"/>
-                </svg>
-                Delete
-            </button>         
-        </div>
- 
-</div>
+<!-- Hidden CSRF token for delete/other JS-driven operations -->
+{% csrf_token %}
+
 <!-- Breadcrumb -->
-<nav aria-label="breadcrumb" class="mb-3">
-    <ol class="breadcrumb">
-        {% if item %}
+<nav aria-label="breadcrumb" class="item-detail-breadcrumb">
+    <ol class="breadcrumb mb-0">
         <li class="breadcrumb-item"><a href="{% url 'project-detail' item.project.id %}">{{ item.project.name }}</a></li>
-        <li class="breadcrumb-item"><a href="{% url 'item-detail' item.id %}">{{ item.title }}</a></li>
-        <li class="breadcrumb-item active">Edit</li>
-        {% else %}
-        <li class="breadcrumb-item active">New Item</li>
-        {% endif %}
+        <li class="breadcrumb-item active" aria-current="page">Item #{{ item.id }}</li>
     </ol>
 </nav>
-<!-- Hidden CSRF token for delete operation -->
-{% csrf_token %}
+
+<div class="page-header item-detail-header d-flex justify-content-between align-items-start flex-wrap gap-2">
+    <div class="item-detail-title-block">
+        <h3 class="item-detail-title" title="{{ item.title }}">{{ item.title }}</h3>
+        <div class="item-detail-meta d-flex align-items-center flex-wrap gap-2">
+            <span class="badge bg-secondary">{{ item.get_status_display }}</span>
+            <span class="text-muted small">{{ item.type.name }}</span>
+        </div>
+    </div>
+
+    <div class="item-detail-actions d-flex align-items-center gap-2">
+        <!-- Primary actions: visible on desktop only, reachable via the Aktionen menu on mobile -->
+        <a href="{% url 'item-edit' item.id %}" class="btn btn-primary btn-sm d-none d-md-inline-flex align-items-center gap-1">
+            <i class="bi bi-pencil"></i> Edit
+        </a>
+        <button type="button" class="btn btn-outline-secondary btn-sm d-none d-md-inline-flex align-items-center gap-1" onclick="sendStatusUpdate({{ item.id }})">
+            <i class="bi bi-send"></i> Send status update
+        </button>
+
+        <!-- Overflow menu: everything else, grouped. Also the only control shown on mobile. -->
+        <div class="dropdown">
+            <button type="button" class="btn btn-outline-secondary btn-sm dropdown-toggle d-flex align-items-center gap-1" id="itemActionsMenuBtn" data-bs-toggle="dropdown" aria-expanded="false">
+                <i class="bi bi-three-dots"></i>
+                Aktionen
+            </button>
+            <ul class="dropdown-menu dropdown-menu-end item-actions-menu" aria-labelledby="itemActionsMenuBtn">
+                <!-- Mobile-only: primary actions, since no separate buttons are shown there -->
+                <li class="d-md-none">
+                    <a class="dropdown-item" href="{% url 'item-edit' item.id %}">
+                        <i class="bi bi-pencil me-2"></i>Edit
+                    </a>
+                </li>
+                <li class="d-md-none">
+                    <button type="button" class="dropdown-item" onclick="sendStatusUpdate({{ item.id }})">
+                        <i class="bi bi-send me-2"></i>Send status update
+                    </button>
+                </li>
+                <li class="d-md-none"><hr class="dropdown-divider"></li>
+
+                <li><h6 class="dropdown-header">Navigation</h6></li>
+                <li>
+                    <a class="dropdown-item" href="{% url 'project-detail' item.project.id %}">
+                        <i class="bi bi-arrow-left me-2"></i>Back to Project
+                    </a>
+                </li>
+
+                <li><hr class="dropdown-divider"></li>
+                <li><h6 class="dropdown-header">Workflow</h6></li>
+                <li>
+                    <button type="button" class="dropdown-item" data-bs-toggle="modal" data-bs-target="#moveItemModal">
+                        <i class="bi bi-arrow-left-right me-2"></i>Move
+                    </button>
+                </li>
+                {% if user.role == 'Agent' %}
+                <li>
+                    <button type="button" class="dropdown-item" onclick="takeOverResponsible()">
+                        <i class="bi bi-person-check me-2"></i>Take over
+                    </button>
+                </li>
+                {% if item.status != 'Closed' %}
+                <li>
+                    <button type="button" class="dropdown-item" onclick="enqueueToClaude()">
+                        <i class="bi bi-robot me-2"></i>An Claude übergeben
+                    </button>
+                </li>
+                {% endif %}
+                {% endif %}
+                <li>
+                    <button type="button" class="dropdown-item" data-bs-toggle="modal" data-bs-target="#assignResponsibleModal">
+                        <i class="bi bi-person-plus me-2"></i>Assign
+                    </button>
+                </li>
+
+                <li><hr class="dropdown-divider"></li>
+                <li><h6 class="dropdown-header">Blueprint</h6></li>
+                <li>
+                    <button type="button" class="dropdown-item" data-bs-toggle="modal" data-bs-target="#applyBlueprintModal">
+                        <i class="bi bi-file-earmark-text me-2"></i>Apply Blueprint
+                    </button>
+                </li>
+                <li>
+                    <a class="dropdown-item" href="{% url 'item-create-blueprint' item.id %}">
+                        <i class="bi bi-clipboard-plus me-2"></i>Create Blueprint
+                    </a>
+                </li>
+
+                <li><hr class="dropdown-divider"></li>
+                <li>
+                    <button type="button" class="dropdown-item text-danger" onclick="confirmDelete()">
+                        <i class="bi bi-trash me-2"></i>Delete
+                    </button>
+                </li>
+            </ul>
+        </div>
+    </div>
+</div>
 
 <!-- Incoming Project Warning Banner -->
 {% if item.project.name == 'Incoming' %}


### PR DESCRIPTION
Automated draft PR opened by the Claude queue worker for Agira item #995.

Model: Sonnet
Job: #171

---

## Zusammenfassung

Der Header der Item-DetailView (`templates/item_detail.html`) zeigte den Titel doppelt (Überschrift + Breadcrumb), reihte zehn gleichwertige Aktions-Buttons flach aneinander und lief auf schmalen Bildschirmen über. Der Header wurde neu strukturiert: schmaler Breadcrumb, eine Titel-Überschrift mit Ellipsis/Tooltip, ein Status-Badge, höchstens zwei primäre Aktionen und ein gruppiertes Aktionsmenü für den Rest – inklusive vollständig mobiltauglichem Verhalten.

## Änderungen

- `templates/item_detail.html`: Breadcrumb zeigt nur noch `Projekt / Item #<id>` statt den Titel ein zweites Mal auszuschreiben; die tote `{% else %}`-Zweigstelle für ein nicht existierendes Item wurde entfernt, da diese Seite immer mit einem geladenen Item gerendert wird.
- Neue Titel-Überschrift (`.item-detail-title`) mit `title`-Tooltip, Ellipsis auf Desktop und 2-zeiligem Clamp auf Mobile, direkt daneben ein Status-Badge und der Item-Typ.
- Aktionsleiste neu aufgeteilt: **Edit** und **Send status update** bleiben als primäre Buttons sichtbar (nur ab `md`-Breakpoint), alle übrigen Aktionen (Back to Project, Move, Take over, An Claude übergeben, Assign, Apply/Create Blueprint, Delete) wandern in ein gruppiertes Bootstrap-Dropdown „Aktionen" (Gruppen: Navigation, Workflow, Blueprint, Delete separat und rot abgesetzt via `text-danger`).
- Auf Mobile (`< md`) verschwinden die primären Buttons komplett; das Dropdown enthält zusätzlich Edit und Send status update, sodass „Aktionen" der einzige sichtbare Auslöser ist und alle Aktionen erreichbar bleiben.
- `static/css/site.css`: Neue Regeln für `.item-detail-header`, `.item-detail-title` (Ellipsis/Clamp), `.item-detail-breadcrumb`, `.item-actions-menu` (Scroll-Begrenzung, größere Tap-Ziele unter 768px) sowie `.dropdown-header`-Styling passend zum bestehenden dunklen Chrome-Farbschema.

## Warum / Entscheidungen

- Ein gemeinsames Bootstrap-Dropdown für Desktop-Overflow und Mobile-Menü, statt eines separaten Offcanvas/Bottom-Sheets: nicht zwei parallele Markup-Bäume, weil das Dropdown bereits dark-theme-gestylt ist, per Klick/Touch funktioniert und die Aktionsliste so nur einmal gepflegt werden muss statt in zwei Komponenten synchron gehalten zu werden.
- Primäre Aktionen (Edit, Send status update) sind zusätzlich – ausgeblendet via `d-md-none` – im Dropdown enthalten, statt sie auf Mobile als eigene Buttons neben dem Aktionen-Button zu belassen: nicht zwei sichtbare Steuerelemente auf Mobile, weil die Anforderung explizit „ein Aktionen-Button" auf Mobile verlangt und jede zusätzliche Buttonreihe wieder zum ursprünglichen Overflow-Problem führen würde.
- Kein neues Farb-Mapping für den Status-Badge (z. B. je Status eine andere Bootstrap-Farbe), sondern `badge bg-secondary` wie in den übrigen Listen-/Detailansichten (`changes.html`, `dashboard_in_progress.html`): nicht extra Farblogik einführen, weil das nicht Teil der Aufgabe ist und Konsistenz mit dem restlichen UI wichtiger ist als eine isolierte Verbesserung nur auf dieser Seite.
- Der Breadcrumb zeigt „Item #<id>" statt des Titels: nicht den Titel im Breadcrumb wiederholen, weil genau das als Redundanz in der Aufgabenstellung benannt wurde; die ID ist eindeutig und kurz genug, um auch auf schmalen Bildschirmen nicht umzubrechen.
- Keine serverseitige, datengetriebene Aktionsliste (Python-Konfigurationsobjekt pro Aktion), sondern weiterhin Django-Template-Konditionals (`{% if user.role == 'Agent' %}` etc.): nicht in `views.py` eine Aktionsstruktur einführen, weil die Sichtbarkeitsregeln (Rolle, Item-Status) bereits kompakt im Template abgebildet sind und eine zusätzliche Abstraktionsschicht für zehn Aktionen mehr Komplexität als Nutzen gebracht hätte; die eigentliche Dopplung (Desktop-Button vs. Mobile-Menüeintrag) wurde stattdessen dadurch vermieden, dass jede Aktion nur einmal im Markup steht und per CSS-Klasse (`d-md-none` / Standard) ein- bzw. ausgeblendet wird.

## Test-Hinweise

- [ ] Desktop (breit): Header zeigt Breadcrumb, Titel, Status-Badge, die Buttons „Edit" und „Send status update" sowie das „Aktionen"-Dropdown; alle Einträge im Dropdown (Back to Project, Move, Take over, An Claude übergeben, Assign, Apply/Create Blueprint, Delete) lösen die jeweils bekannte Aktion aus.
- [ ] Sehr langer Item-Titel: Überschrift wird per Ellipsis (Desktop) bzw. 2-Zeilen-Clamp (Mobile) abgeschnitten, vollständiger Titel erscheint als Tooltip; Layout bricht nicht.
- [ ] Mobile-Breite (z. B. iPhone-Breakpoint < 768px): „Edit"/„Send status update"-Buttons sind ausgeblendet, nur der „Aktionen"-Button ist sichtbar; das geöffnete Dropdown enthält alle Aktionen inklusive Edit, Send status update und Delete (rot, am Ende der Liste), keine überlaufende Button-Reihe.
- [ ] Delete löst weiterhin den bestehenden `confirm()`-Dialog aus, kein versehentliches Löschen ohne Bestätigung.
- [ ] `python manage.py check` sowie ein Rendering-Testaufruf der Item-Detail-Seite (`GET /items/<id>/`) wurden lokal ausgeführt und liefern Status 200 ohne Template-Fehler.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Template and CSS-only UI reorganization; existing onclick/modal targets are preserved with no backend or permission logic changes.
> 
> **Overview**
> Restructures the **item detail** page header so it no longer duplicates the title in the breadcrumb and no longer shows a long row of action buttons.
> 
> The breadcrumb is now **project → Item #id** (active leaf), and the header shows a single **title** with tooltip, a **status badge**, and item type. **Edit** and **Send status update** stay as primary buttons on `md+`; everything else (navigation, workflow, blueprint, delete) moves into a grouped **Aktionen** dropdown. On mobile, only that dropdown is shown, with Edit and Send status update duplicated inside via `d-md-none` entries.
> 
> `site.css` adds layout rules for the new header (title ellipsis / 2-line clamp on small screens), scrollable action menu, and **dropdown-header** styling for section labels.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4f762228383f24213134d9756e250b0d6b9548d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->