### PR TITLE
Kostenaggregation auf Item-Ebene: summierte Claude-Queue-/PR-Kosten am Issue anzeigen

### DIFF
--- a/core/test_item_detail.py
+++ b/core/test_item_detail.py
@@ -5,11 +5,13 @@ from django.test import TestCase, Client
 from django.urls import reverse
 from django.contrib.auth import get_user_model
 
+from decimal import Decimal
+
 from core.models import (
-    Organisation, UserOrganisation, Project, ItemType, Item, 
-    ItemStatus, Release, ItemComment, ExternalIssueMapping, 
+    Organisation, UserOrganisation, Project, ItemType, Item,
+    ItemStatus, Release, ItemComment, ExternalIssueMapping,
     ExternalIssueKind, AttachmentRole, Attachment, AttachmentLink,
-    CommentKind, ReleaseStatus
+    CommentKind, ReleaseStatus, ClaudeQueueJob, ClaudeQueueJobModel
 )
 from core.services.activity import ActivityService
 
@@ -1034,3 +1036,107 @@ class SolutionReleaseFilteringTest(TestCase):
         # Verify releases list is empty
         releases = response.context['releases']
         self.assertEqual(len(releases), 0)
+
+
+class ItemDetailClaudeCostAggregationTest(TestCase):
+    """Test the aggregated Claude Queue cost shown on the item detail page."""
+
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username='testuser',
+            email='test@example.com',
+            password='testpass',
+            name='Test User',
+            role='Agent'
+        )
+
+        self.org = Organisation.objects.create(name='Test Org')
+        UserOrganisation.objects.create(
+            user=self.user,
+            organisation=self.org,
+            is_primary=True
+        )
+
+        self.project = Project.objects.create(name='Test Project')
+        self.project.clients.add(self.org)
+
+        self.item_type = ItemType.objects.create(key='bug', name='Bug', is_active=True)
+
+        self.item = Item.objects.create(
+            project=self.project,
+            title='Test Item',
+            type=self.item_type,
+            organisation=self.org,
+            status=ItemStatus.WORKING
+        )
+
+        self.client = Client()
+        self.client.login(username='testuser', password='testpass')
+
+    def test_no_jobs_shows_dash(self):
+        """An item without any Claude Queue jobs shows a dash, not an error."""
+        url = reverse('item-detail', args=[self.item.id])
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIsNone(response.context['claude_total_cost'])
+        self.assertContains(response, 'Claude-Kosten')
+
+    def test_multiple_jobs_are_summed(self):
+        """Costs of multiple jobs/PRs for the same item are summed, not overwritten."""
+        ClaudeQueueJob.objects.create(
+            item=self.item, project=self.project,
+            model=ClaudeQueueJobModel.SONNET,
+            total_cost_usd=Decimal('1.234567'), num_turns=5,
+        )
+        ClaudeQueueJob.objects.create(
+            item=self.item, project=self.project,
+            model=ClaudeQueueJobModel.OPUS,
+            total_cost_usd=Decimal('2.500000'), num_turns=10,
+        )
+
+        url = reverse('item-detail', args=[self.item.id])
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context['claude_total_cost'], Decimal('3.734567'))
+        self.assertContains(response, '7346')  # cost digits (locale-independent)
+
+    def test_jobs_without_cost_do_not_break_the_sum(self):
+        """A still-running job with no cost yet is treated as contributing 0."""
+        ClaudeQueueJob.objects.create(
+            item=self.item, project=self.project,
+            model=ClaudeQueueJobModel.SONNET,
+            total_cost_usd=Decimal('1.500000'), num_turns=3,
+        )
+        ClaudeQueueJob.objects.create(
+            item=self.item, project=self.project,
+            model=ClaudeQueueJobModel.SONNET,
+            total_cost_usd=None, num_turns=None,
+        )
+
+        url = reverse('item-detail', args=[self.item.id])
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context['claude_total_cost'], Decimal('1.500000'))
+
+    def test_costs_from_other_items_are_not_included(self):
+        """Aggregation is scoped to this item — no cross-item leakage."""
+        other_item = Item.objects.create(
+            project=self.project,
+            title='Other Item',
+            type=self.item_type,
+            status=ItemStatus.WORKING
+        )
+        ClaudeQueueJob.objects.create(
+            item=other_item, project=self.project,
+            model=ClaudeQueueJobModel.SONNET,
+            total_cost_usd=Decimal('9.999999'), num_turns=1,
+        )
+
+        url = reverse('item-detail', args=[self.item.id])
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIsNone(response.context['claude_total_cost'])

--- a/core/views.py
+++ b/core/views.py
@@ -1055,7 +1055,14 @@ def item_detail(request, item_id):
     
     # Get initial tab from query parameter (default: overview)
     active_tab = request.GET.get('tab', 'overview')
-    
+
+    # Sum of Claude Code's own cost estimate across all queue jobs/PRs run
+    # for this item — a single DB aggregate, not a per-row Python sum.
+    claude_queue_jobs = item.claude_queue_jobs.order_by('-created_at')
+    claude_total_cost = claude_queue_jobs.aggregate(
+        total=models.Sum('total_cost_usd')
+    )['total']
+
     context = {
         'item': item,
         'followers': followers,
@@ -1068,6 +1075,8 @@ def item_detail(request, item_id):
         'organisations': organisations,
         'active_tab': active_tab,
         'available_statuses': ItemStatus.choices,
+        'claude_queue_jobs': claude_queue_jobs,
+        'claude_total_cost': claude_total_cost,
     }
     return render(request, 'item_detail.html', context)
 

--- a/templates/item_detail.html
+++ b/templates/item_detail.html
@@ -812,10 +812,58 @@
                                 Gespeichert
                             </small>
                         </div>
-                                   
+                        <div class="mb-3">
+                            <strong>Claude-Kosten:</strong>
+                            <div>
+                                {% if claude_total_cost is not None %}
+                                    <span title="Summe der Claude-Code-Kostenschätzung (API-Listenpreis) über alle Claude-Queue-Läufe/PRs dieses Items — keine abgerechnete Zahl.">
+                                        ${{ claude_total_cost|floatformat:4 }}
+                                    </span>
+                                    <span class="text-muted small">(geschätzt, API-Listenpreis)</span>
+                                {% else %}
+                                    <span class="text-muted">—</span>
+                                {% endif %}
+                                {% if claude_queue_jobs %}
+                                    <button type="button" class="btn btn-sm btn-link p-0 ms-1" data-bs-toggle="collapse" data-bs-target="#claude-cost-breakdown">
+                                        Details
+                                    </button>
+                                {% endif %}
+                            </div>
+                            {% if claude_queue_jobs %}
+                            <div class="collapse mt-2" id="claude-cost-breakdown">
+                                <table class="table table-sm mb-0">
+                                    <thead>
+                                        <tr>
+                                            <th>Run</th>
+                                            <th>Modell</th>
+                                            <th>Turns</th>
+                                            <th>Kosten</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        {% for job in claude_queue_jobs %}
+                                        <tr>
+                                            <td>
+                                                {% if job.pr_url %}
+                                                <a href="{{ job.pr_url }}" target="_blank" rel="noopener">PR #{{ job.pr_number }}</a>
+                                                {% else %}
+                                                Job #{{ job.id }}
+                                                {% endif %}
+                                            </td>
+                                            <td>{{ job.get_model_display }}</td>
+                                            <td>{{ job.num_turns|default:"—" }}</td>
+                                            <td>{% if job.total_cost_usd is not None %}${{ job.total_cost_usd|floatformat:4 }}{% else %}—{% endif %}</td>
+                                        </tr>
+                                        {% endfor %}
+                                    </tbody>
+                                </table>
+                            </div>
+                            {% endif %}
+                        </div>
+
                     </div>
                 </div>
-                
+
                 <!-- Help Card -->
                 <div class="card">
                     <div class="card-header">


### PR DESCRIPTION
Automated draft PR opened by the Claude queue worker for Agira item #997.

Model: Sonnet
Job: #182

---

## Zusammenfassung

Am Item wird nun die Summe der Claude-Code-Kostenschätzung (`total_cost_usd`) aller zugehörigen Claude-Queue-Läufe/PRs angezeigt, inklusive aufklappbarer Aufschlüsselung je Job.

## Änderungen

- `core/views.py`: `item_detail` lädt zusätzlich `item.claude_queue_jobs` und aggregiert `total_cost_usd` per DB-`Sum(...)` in `claude_total_cost`; beide werden in den Template-Context aufgenommen.
- `templates/item_detail.html`: neuer Block „Claude-Kosten" in der „Additional Information"-Sidebar. Zeigt die Summe (`$` + 4 Nachkommastellen) mit Hinweis-Tooltip und sichtbarer Kennzeichnung „(geschätzt, API-Listenpreis)"; ohne Jobs erscheint ein „—". Ein aufklappbarer Bereich listet je Job/PR: Link zum PR (falls vorhanden) bzw. Job-ID, Modell, `num_turns` und Einzelkosten.
- `core/test_item_detail.py`: neue Testklasse `ItemDetailClaudeCostAggregationTest` deckt ab: keine Jobs → „—"/`None`; mehrere Jobs werden korrekt aufsummiert; Jobs ohne Kostenwert brechen die Summe nicht (NULL wird von SQL `SUM` übersprungen, nicht als Fehler); Kosten anderer Items fließen nicht mit ein.

## Warum / Entscheidungen

- Aggregation als DB-`Sum(...)` auf dem bestehenden `total_cost_usd`-Feld, nicht Neuberechnung aus Tokens, weil Claude Code keinen Token-Breakdown liefert und `total_cost_usd` bereits die einzige verfügbare Kostenquelle ist — eine Neuberechnung wäre technisch gar nicht möglich und würde nur Komplexität ohne Mehrwert schaffen.
- Summierung per Datenbank-Aggregat statt Python-Schleife über `item.claude_queue_jobs.all()`, weil die Akzeptanzkriterien explizit ein DB-`Sum` ohne Per-Request-Python-Summierung fordern und dies unabhängig von der Anzahl der Jobs performant bleibt.
- Anzeige in der bestehenden „Additional Information"-Karte statt eines neuen eigenen Cards/Tabs, weil die Information eine kompakte Kennzahl ist und so konsistent zum kompakteren UI (#990/#991) und dem neuen Header (#995) bleibt, statt zusätzliche visuelle Fläche zu beanspruchen.
- Aufschlüsselung je Job/PR über ein Bootstrap-`collapse` statt einer immer sichtbaren Tabelle, weil die Detailinfo für die meisten Nutzer nicht relevant ist und die Sidebar sonst bei Items mit vielen Runs unübersichtlich würde.
- Verlinkung je Zeile über `job.pr_url`/`job.pr_number` (Fallback „Job #id"), nicht über `ExternalIssueMapping`, weil die Aufgabenstellung ausdrücklich sagt, dass für die Kostensumme die Jobs genügen und `ClaudeQueueJob` bereits PR-Nummer/-URL direkt am Job führt — ein zusätzlicher Join wäre unnötig.
- Keine Aggregation auf Projekt-Ebene umgesetzt, weil das laut Anforderung „Optional / später" ist und der Scope dieses Tickets explizit die Item-Ebene ist.
- Explizite Kennzeichnung „(geschätzt, API-Listenpreis)" direkt neben dem Betrag statt nur im Tooltip, weil ein reiner Tooltip auf Touch-Geräten nicht zugänglich ist und der Hinweis laut Anforderung sichtbar sein soll, nicht nur bei Hover entdeckbar.

## Test-Hinweise

- `python manage.py test core.test_item_detail.ItemDetailClaudeCostAggregationTest` — 4 Tests, alle grün (keine Jobs, mehrere Jobs summiert, Jobs ohne Kostenwert, keine Cross-Item-Leakage).
- Manuell: Item-Detailseite eines Items mit mehreren Claude-Queue-Jobs öffnen, „Additional Information" prüfen — Summe korrekt, „Details" klappt Tabelle mit Modell/Turns/Kosten je Job auf; Item ohne Jobs zeigt „—" ohne Fehler.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only display and aggregation on existing fields; no auth or billing logic changes.
> 
> **Overview**
> The item detail page now shows **aggregated Claude Code cost estimates** for all Claude queue jobs tied to that item.
> 
> `item_detail` loads related `claude_queue_jobs` and computes `claude_total_cost` with a database `Sum` on `total_cost_usd` (not a Python loop). The **Additional Information** sidebar adds a **Claude-Kosten** block: total in USD with four decimals, labeled as estimated API list price; **—** when there are no jobs. When jobs exist, a collapsible **Details** table lists each run (PR link or job id), model, turns, and per-job cost.
> 
> New tests in `ItemDetailClaudeCostAggregationTest` cover empty totals, summing multiple jobs, NULL costs in `SUM`, and scoping so other items’ jobs are excluded.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2533ead04e44ca3d93df34724d68425d8e4dde1c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->