### PR TITLE
Claude-Queue-Worker: leerer/uncommitteter Lauf wird als Erfolg dargestellt (PR-Body suggeriert Arbeit, Files changed = 0)

### DIFF
--- a/core/management/commands/run_claude_worker.py
+++ b/core/management/commands/run_claude_worker.py
@@ -312,8 +312,12 @@ class Command(BaseCommand):
             self.stdout.write(self.style.ERROR(f"Job #{job.pk} failed: {exc}"))
             return
 
-        # Push whatever Claude committed onto the branch. Best-effort: Claude may
-        # have pushed already, or produced no commit — neither is fatal here.
+        # Claude is told to commit its own work but may stop short of it (ran
+        # out of turns, misjudged its own completion, ...). Rescue anything
+        # left in the working tree before the next job's checkout reset would
+        # discard it, then push whatever ended up on the branch. Best-effort:
+        # Claude may already have committed and pushed, or produced nothing.
+        self._commit_uncommitted_work(repo_dir, job)
         self._push_branch(repo_dir, branch)
 
         if result.get('is_error') or result.get('returncode', 0) != 0:
@@ -335,6 +339,25 @@ class Command(BaseCommand):
             self._fail_job(job, error=error)
             self._update_pr_body(job, error=error)
             self.stdout.write(self.style.ERROR(f"Job #{job.pk} failed (no result event)"))
+            return
+
+        if self._is_empty_diff(repo_dir, bootstrap_sha):
+            # Still no diff even after the rescue-commit attempt above: this is
+            # a genuine empty run, not a bookkeeping accident. It must not look
+            # like a clean "done" — that is exactly the failure mode (an
+            # empty PR merged on the strength of an unrelated success body)
+            # this check exists to prevent.
+            error = "Kein Code committet – Claude hat keine Änderungen geliefert."
+            job.completion_uncertain = True
+            job.completion_uncertain_reason = (
+                "Leerer PR: keine Änderungen über den Start-Commit hinaus "
+                "(auch nach automatischem Rettungscommit-Versuch)."
+            )
+            self._fail_job(job, error=error)
+            self._update_pr_body(job, error=error)
+            self.stdout.write(self.style.ERROR(
+                f"Job #{job.pk} failed: no code committed (empty diff)"
+            ))
             return
 
         uncertain_reason = self._detect_completion_uncertain(
@@ -655,6 +678,45 @@ class Command(BaseCommand):
             self._git(['push', 'origin', branch], cwd=repo_dir)
         except Exception as exc:  # noqa: BLE001 — non-fatal; Claude may have pushed
             logger.warning("Post-run push of %s failed: %s", branch, exc)
+
+    def _commit_uncommitted_work(self, repo_dir, job):
+        """Auto-commit any working-tree changes Claude left uncommitted.
+
+        The prompt asks Claude to commit its own changes, but a run can edit
+        files and stop short of ``git commit`` — that work would otherwise be
+        silently discarded by the next job's ``reset --hard``/``clean -fd``.
+        Deliberately unconditional (not gated on "no commit exists yet"): a
+        run that made a partial commit and then left further edits
+        uncommitted must not lose that tail either.
+
+        ``.claude/settings.local.json`` is the worker's own trust-settings
+        file (written by ``_write_trust_settings``), never Claude's work, so
+        it is staged and then explicitly unstaged before checking whether
+        anything worth committing remains.
+
+        Best-effort: any git failure here (e.g. a bad ``repo_dir`` in tests)
+        is swallowed and treated as "nothing to rescue" rather than failing
+        the job. Returns True if a rescue commit was made.
+        """
+        try:
+            self._git(['add', '-A'], cwd=repo_dir)
+            self._git(['reset', '--', '.claude/settings.local.json'], cwd=repo_dir)
+            proc = subprocess.run(
+                ['git', 'diff', '--cached', '--quiet'], cwd=repo_dir, timeout=60,
+            )
+            if proc.returncode == 0:
+                self._git(['reset'], cwd=repo_dir)
+                return False
+
+            self._git(
+                ['commit', '-m',
+                 f"chore(#{job.item_id}): auto-commit uncommitted work from Claude run"],
+                cwd=repo_dir,
+            )
+            return True
+        except Exception as exc:  # noqa: BLE001 — best-effort rescue, must not fail the job
+            logger.warning("Auto-commit rescue failed for %s: %s", repo_dir, exc)
+            return False
 
     # ------------------------------------------------------------------ #
     # Completion-uncertain detection

--- a/core/management/commands/test_run_claude_worker.py
+++ b/core/management/commands/test_run_claude_worker.py
@@ -453,6 +453,195 @@ class CompletionUncertainTests(ClaudeWorkerTestBase):
             self.assertIsNone(reason)
 
 
+class CommitUncommittedWorkTests(ClaudeWorkerTestBase):
+    """Unit tests for _commit_uncommitted_work: rescue a Claude run's uncommitted edits."""
+
+    def _init_repo(self, tmp_path):
+        subprocess.run(['git', 'init'], cwd=tmp_path, check=True, capture_output=True)
+        subprocess.run(['git', 'config', 'user.email', 'test@example.com'], cwd=tmp_path, check=True)
+        subprocess.run(['git', 'config', 'user.name', 'Test'], cwd=tmp_path, check=True)
+        (Path(tmp_path) / 'README.md').write_text('hello\n')
+        subprocess.run(['git', 'add', '.'], cwd=tmp_path, check=True, capture_output=True)
+        subprocess.run(['git', 'commit', '-m', 'init'], cwd=tmp_path, check=True, capture_output=True)
+        subprocess.run(['git', 'commit', '--allow-empty', '-m', 'bootstrap'],
+                        cwd=tmp_path, check=True, capture_output=True)
+        return subprocess.run(
+            ['git', 'rev-parse', 'HEAD'], cwd=tmp_path, check=True,
+            capture_output=True, text=True,
+        ).stdout.strip()
+
+    def test_commits_uncommitted_changes(self):
+        with tempfile.TemporaryDirectory() as tmp_path:
+            bootstrap_sha = self._init_repo(tmp_path)
+            (Path(tmp_path) / 'feature.py').write_text('print("hi")\n')
+            job = self._job(self.project_a)
+
+            rescued = Command()._commit_uncommitted_work(tmp_path, job)
+
+            self.assertTrue(rescued)
+            self.assertFalse(Command()._is_empty_diff(tmp_path, bootstrap_sha))
+            subject = subprocess.run(
+                ['git', 'log', '-1', '--format=%s'], cwd=tmp_path,
+                capture_output=True, text=True, check=True,
+            ).stdout.strip()
+            self.assertIn('auto-commit uncommitted work', subject)
+            self.assertIn(f'#{job.item_id}', subject)
+
+    def test_ignores_claude_settings_local_json(self):
+        with tempfile.TemporaryDirectory() as tmp_path:
+            bootstrap_sha = self._init_repo(tmp_path)
+            claude_dir = Path(tmp_path) / '.claude'
+            claude_dir.mkdir()
+            (claude_dir / 'settings.local.json').write_text('{"a": 1}\n')
+            job = self._job(self.project_a)
+
+            rescued = Command()._commit_uncommitted_work(tmp_path, job)
+
+            self.assertFalse(rescued)
+            self.assertTrue(Command()._is_empty_diff(tmp_path, bootstrap_sha))
+            status = subprocess.run(
+                ['git', 'status', '--porcelain'], cwd=tmp_path,
+                capture_output=True, text=True, check=True,
+            ).stdout
+            self.assertIn('.claude', status)
+
+    def test_commits_real_change_while_excluding_settings_file(self):
+        with tempfile.TemporaryDirectory() as tmp_path:
+            self._init_repo(tmp_path)
+            claude_dir = Path(tmp_path) / '.claude'
+            claude_dir.mkdir()
+            (claude_dir / 'settings.local.json').write_text('{"a": 1}\n')
+            (Path(tmp_path) / 'feature.py').write_text('print("hi")\n')
+            job = self._job(self.project_a)
+
+            rescued = Command()._commit_uncommitted_work(tmp_path, job)
+
+            self.assertTrue(rescued)
+            changed = subprocess.run(
+                ['git', 'show', '--stat', '--format=', 'HEAD'], cwd=tmp_path,
+                capture_output=True, text=True, check=True,
+            ).stdout
+            self.assertIn('feature.py', changed)
+            self.assertNotIn('settings.local.json', changed)
+
+    def test_no_op_on_clean_tree(self):
+        with tempfile.TemporaryDirectory() as tmp_path:
+            self._init_repo(tmp_path)
+            job = self._job(self.project_a)
+
+            self.assertFalse(Command()._commit_uncommitted_work(tmp_path, job))
+
+    def test_swallows_git_errors_on_bad_repo_dir(self):
+        job = self._job(self.project_a)
+        self.assertFalse(Command()._commit_uncommitted_work('/no/such/repo', job))
+
+
+class EmptyRunHandlingTests(ClaudeWorkerTestBase):
+    """Process-level tests: a run with no committed changes must not look like success."""
+
+    def _init_repo(self, tmp_path):
+        subprocess.run(['git', 'init'], cwd=tmp_path, check=True, capture_output=True)
+        subprocess.run(['git', 'config', 'user.email', 'test@example.com'], cwd=tmp_path, check=True)
+        subprocess.run(['git', 'config', 'user.name', 'Test'], cwd=tmp_path, check=True)
+        (Path(tmp_path) / 'README.md').write_text('hello\n')
+        subprocess.run(['git', 'add', '.'], cwd=tmp_path, check=True, capture_output=True)
+        subprocess.run(['git', 'commit', '-m', 'init'], cwd=tmp_path, check=True, capture_output=True)
+        subprocess.run(['git', 'commit', '--allow-empty', '-m', 'bootstrap'],
+                        cwd=tmp_path, check=True, capture_output=True)
+        return subprocess.run(
+            ['git', 'rev-parse', 'HEAD'], cwd=tmp_path, check=True,
+            capture_output=True, text=True,
+        ).stdout.strip()
+
+    def _claimed_job(self, project, item_status=ItemStatus.WORKING):
+        item = self._item(project, status=item_status)
+        self._job(project, item=item)
+        return Command().claim_next_job()
+
+    def _run(self, job, tmp_path, bootstrap_sha, run_cli):
+        with patch.object(Command, '_prepare_checkout', return_value=tmp_path), \
+                patch.object(Command, '_create_branch_and_pr',
+                             return_value=('fix/x-1', bootstrap_sha)), \
+                patch.object(Command, '_push_branch'), \
+                patch.object(Command, '_run_cli', side_effect=run_cli):
+            Command().process_job(job, timeout=30, idle_timeout=5)
+
+    def test_true_empty_run_is_marked_failed_not_done(self):
+        with tempfile.TemporaryDirectory() as tmp_path:
+            bootstrap_sha = self._init_repo(tmp_path)
+            job = self._claimed_job(self.project_a)
+
+            self._run(job, tmp_path, bootstrap_sha, run_cli=lambda *a, **k: _ok_result(
+                result_text='Implemented everything, all good.',
+            ))
+
+            job.refresh_from_db()
+            self.assertEqual(job.status, ClaudeQueueJobStatus.FAILED)
+            self.assertIn('Kein Code committet', job.error_text)
+            self.assertTrue(job.completion_uncertain)
+            self.assertIn('Leerer PR', job.completion_uncertain_reason)
+            job.item.refresh_from_db()
+            self.assertEqual(job.item.status, ItemStatus.BACKLOG)
+
+    def test_true_empty_run_pr_body_does_not_show_success_summary(self):
+        from unittest.mock import MagicMock
+
+        with tempfile.TemporaryDirectory() as tmp_path:
+            bootstrap_sha = self._init_repo(tmp_path)
+            job = self._claimed_job(self.project_a)
+            job.pr_number = 42
+            job.save(update_fields=['pr_number'])
+            fake_service = MagicMock()
+
+            with patch('core.services.github.service.GitHubService',
+                       return_value=fake_service):
+                self._run(job, tmp_path, bootstrap_sha, run_cli=lambda *a, **k: _ok_result(
+                    result_text='Implemented everything, all good.',
+                ))
+
+            call_kwargs = fake_service.update_pr_body.call_args[1]
+            self.assertIn('Kein Code committet', call_kwargs['body'])
+            self.assertNotIn('## Claude Summary', call_kwargs['body'])
+            self.assertNotIn('Implemented everything', call_kwargs['body'])
+
+    def test_uncommitted_changes_are_rescued_and_run_still_marked_done(self):
+        def leave_uncommitted(job, repo_dir, timeout, idle_timeout, pr_body_file):
+            (Path(repo_dir) / 'feature.py').write_text('print("hi")\n')
+            return _ok_result(result_text='Implemented the fix.')
+
+        with tempfile.TemporaryDirectory() as tmp_path:
+            bootstrap_sha = self._init_repo(tmp_path)
+            job = self._claimed_job(self.project_a)
+
+            self._run(job, tmp_path, bootstrap_sha, run_cli=leave_uncommitted)
+
+            job.refresh_from_db()
+            self.assertEqual(job.status, ClaudeQueueJobStatus.DONE)
+            self.assertFalse(job.completion_uncertain)
+            log = subprocess.run(
+                ['git', 'log', '--format=%s'], cwd=tmp_path,
+                capture_output=True, text=True, check=True,
+            ).stdout
+            self.assertIn('auto-commit uncommitted work', log)
+
+    def test_settings_local_json_only_is_still_a_true_empty_run(self):
+        def leave_only_settings(job, repo_dir, timeout, idle_timeout, pr_body_file):
+            claude_dir = Path(repo_dir) / '.claude'
+            claude_dir.mkdir(parents=True, exist_ok=True)
+            (claude_dir / 'settings.local.json').write_text('{"a": 1}\n')
+            return _ok_result(result_text='Nothing to change here.')
+
+        with tempfile.TemporaryDirectory() as tmp_path:
+            bootstrap_sha = self._init_repo(tmp_path)
+            job = self._claimed_job(self.project_a)
+
+            self._run(job, tmp_path, bootstrap_sha, run_cli=leave_only_settings)
+
+            job.refresh_from_db()
+            self.assertEqual(job.status, ClaudeQueueJobStatus.FAILED)
+            self.assertIn('Kein Code committet', job.error_text)
+
+
 class StreamParsingTests(ClaudeWorkerTestBase):
     """Unit tests for _consume_stream against synthetic stream-json lines."""
 


### PR DESCRIPTION
Automated draft PR opened by the Claude queue worker for Agira item #998.

Model: Sonnet
Job: #183

---

## Zusammenfassung

Der Claude-Queue-Worker rettet jetzt uncommittete Arbeit nach einem Lauf und behandelt einen echten Leer-Lauf (kein Code committet) nicht mehr wie einen sauberen Erfolg.

## Änderungen

- `core/management/commands/run_claude_worker.py`: neue Methode `_commit_uncommitted_work` — nach dem Claude-Lauf wird `git add -A` (mit explizitem `git reset -- .claude/settings.local.json`, damit die vom Worker selbst geschriebene Trust-Settings-Datei nie mitcommittet wird) ausgeführt; bleibt etwas im Index, wird es als `chore(#<item-id>): auto-commit uncommitted work from Claude run` committet und über `_push_branch` gepusht.
- `_process_job_inner`: prüft nach diesem Rettungsversuch per `_is_empty_diff`, ob der Branch weiterhin keinen Unterschied zum Bootstrap-Commit hat. Falls ja, wird der Job über `_fail_job` auf `failed` gesetzt (Item zurück nach Backlog), `completion_uncertain`/`completion_uncertain_reason` bleiben gesetzt, und der PR-Body wird über den bestehenden Fehler-Pfad von `_update_pr_body` auf „Kein Code committet – Claude hat keine Änderungen geliefert." überschrieben statt eines Erfolgs-Summarys aus `PR_BODY_FILE`.
- `core/management/commands/test_run_claude_worker.py`: neue Testklassen `CommitUncommittedWorkTests` (Unit-Tests für die Rettungslogik inkl. Ausschluss von `.claude/settings.local.json`) und `EmptyRunHandlingTests` (Prozess-Ebene: echter Leer-Lauf → `failed` + ehrlicher PR-Body; uncommittete Änderungen → gerettet, Job bleibt `done`).

## Warum / Entscheidungen

- Die Rettung ist bewusst unbedingt (nicht daran gekoppelt, dass „noch kein Commit über den Bootstrap hinaus" existiert): nicht nur beim vollständig uncommitteten Fall retten, weil sonst ein Lauf mit Teil-Commit plus zusätzlichen uncommitteten Änderungen den zweiten Teil der Arbeit verlöre.
- Für den echten Leer-Lauf wurde `failed` statt eines neuen, dedizierten Job-Status gewählt: nicht ein neuer Status (z. B. „empty"), weil das eine Migration, neue Übergangsregeln und Anpassungen an allen Stellen erfordert hätte, die den State-Machine-Enum konsumieren, obwohl `failed` (inkl. Item-Freigabe nach Backlog) inhaltlich exakt das gewünschte Verhalten liefert: kein stiller Erfolg, sichtbare Konsequenz, Item wieder in menschlicher Triage.
- Der PR-Body für den Leer-Lauf nutzt den bestehenden Fehler-Zweig von `_update_pr_body` (`error=...`) statt eines neuen Parameters/Zweigs: nicht ein eigener `empty=True`-Pfad in `_update_pr_body`, weil der Fehler-Zweig bereits exakt das verlangte Verhalten liefert (kein Erfolgs-Summary, klare Botschaft) und ein Duplikat unnötige Komplexität und weitere Testfälle für einen praktisch identischen Textbaustein bedeutet hätte.
- Ausschluss von `.claude/settings.local.json` per `git add -A` + gezieltem `git reset --` statt einer Pathspec-Exclude-Syntax (`:!pattern`) beim `add`: nicht die Exclude-Pathspec-Variante, weil das Verhalten (Stagen + gezieltes Unstagen) mit einfachen, gut bekannten Git-Befehlen genauso zuverlässig funktioniert und keine Annahmen über Git-Versions-spezifische Pathspec-Magic braucht.
- Git-Fehler in der Rettungslogik werden verschluckt (best-effort, wie schon bei `_push_branch`): nicht ein harter Fehler/Job-Failure bei einem Git-Problem während der Rettung, weil ein fehlgeschlagener Rettungsversuch (z. B. Lock-Datei, Netzwerk) den eigentlichen Lauf nicht zusätzlich zum Scheitern bringen soll — der nachfolgende Leer-Diff-Check greift ohnehin als Auffangnetz.

## Test-Hinweise

- `./venv/bin/python manage.py test core.management.commands.test_run_claude_worker` — 64 Tests, alle grün, inkl. neuer Fälle für Rettungscommit, Ausschluss der Settings-Datei und den ehrlichen Leer-Lauf-Pfad.
- `./venv/bin/python manage.py test core.test_claude_queue_views core.test_claude_enqueue_view core.management.commands.test_run_claude_worker --noinput` — 122 Tests, alle grün (keine Regression an Queue-Views/Enqueue-Flow).
- Templates (`claude_queue_job_row.html`, `claude_queue_job_live.html`) zeigen für `failed`-Jobs bereits `error_text` prominent an (roter Alert/Badge) — dort erscheint die neue Meldung „Kein Code committet – Claude hat keine Änderungen geliefert." ohne weitere Anpassung.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes post-run job terminal state and git behavior on every successful Claude exit; misclassification could mark good runs failed or still merge empty PRs if diff checks fail silently.
> 
> **Overview**
> The Claude queue worker no longer treats a run with **zero commits** on the branch as success when Claude’s result text sounds fine. After each run it **rescues** leftover working-tree edits, then if the branch still has no diff past the bootstrap commit it marks the job **failed**, sets `completion_uncertain`, updates the PR body via the existing error path (no success summary), and returns the item to Backlog.
> 
> **Rescue commit:** `_commit_uncommitted_work` runs after Claude exits: `git add -A`, unstages `.claude/settings.local.json` (worker trust settings, not Claude’s work), and commits anything left as `chore(#item): auto-commit uncommitted work from Claude run`. Git errors are best-effort and do not fail the job.
> 
> Tests cover rescue behavior, settings exclusion, true empty runs vs rescued uncommitted work, and PR body content on failure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7a8c29187e8892dd51ec1178102409a55ed7ef8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->