### PR TITLE
#1000 🎉 „Agira über Agira" – Meilenstein-Retrospektive & dauerhaftes System-Analytics

### DIFF
--- a/core/test_system_analytics.py
+++ b/core/test_system_analytics.py
@@ -1,0 +1,122 @@
+"""
+Tests for the system analytics ("Agira über Agira") view.
+"""
+from decimal import Decimal
+
+from django.test import TestCase, Client
+from django.urls import reverse
+from django.utils import timezone
+
+from core.models import (
+    Item, Project, ItemStatus, ItemType, User, Release,
+    ClaudeQueueJob, ClaudeQueueJobStatus, ClaudeQueueJobModel,
+    ExternalIssueMapping, ExternalIssueKind,
+)
+from core.services.activity import ActivityService
+
+
+class SystemAnalyticsViewTestCase(TestCase):
+    def setUp(self):
+        self.client = Client()
+        self.user = User.objects.create_user(
+            username='testuser',
+            password='testpass123',
+            email='test@example.com',
+        )
+        self.user.active = True
+        self.user.save()
+
+        self.project = Project.objects.create(name='Test Project', description='desc')
+        self.item_type = ItemType.objects.create(key='bug', name='Bug', description='Bug type')
+
+        self.item = Item.objects.create(
+            title='Closed item with a job',
+            description='desc',
+            project=self.project,
+            type=self.item_type,
+            status=ItemStatus.CLOSED,
+        )
+        ActivityService().log_status_change(
+            item=self.item, from_status=ItemStatus.TESTING, to_status=ItemStatus.CLOSED,
+        )
+
+        job = ClaudeQueueJob.objects.create(
+            item=self.item,
+            project=self.project,
+            status=ClaudeQueueJobStatus.QUEUED,
+            model=ClaudeQueueJobModel.SONNET,
+        )
+        job.transition_to(ClaudeQueueJobStatus.RUNNING)
+        job.transition_to(ClaudeQueueJobStatus.DONE)
+        job.total_cost_usd = Decimal('1.234500')
+        job.num_turns = 12
+        job.save()
+
+        ExternalIssueMapping.objects.create(
+            item=self.item,
+            github_id=123456,
+            number=1,
+            kind=ExternalIssueKind.PR,
+            state='closed',
+            html_url='https://example.com/pr/1',
+            merged_at=timezone.now(),
+        )
+
+        self.open_item = Item.objects.create(
+            title='Still open item',
+            description='desc',
+            project=self.project,
+            type=self.item_type,
+            status=ItemStatus.WORKING,
+        )
+
+    def test_requires_authentication(self):
+        response = self.client.get(reverse('system-analytics'))
+        self.assertEqual(response.status_code, 302)
+
+    def test_renders_for_authenticated_user(self):
+        self.client.login(username='testuser', password='testpass123')
+        response = self.client.get(reverse('system-analytics'))
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'system_analytics.html')
+
+    def test_kpis_reflect_seeded_data(self):
+        self.client.login(username='testuser', password='testpass123')
+        response = self.client.get(reverse('system-analytics'))
+
+        self.assertEqual(response.context['total_items'], 2)
+        self.assertEqual(response.context['closed_items_count'], 1)
+        self.assertEqual(response.context['open_items_count'], 1)
+        self.assertEqual(response.context['cycle_time_sample_size'], 1)
+        self.assertEqual(response.context['lead_time_sample_size'], 1)
+        self.assertAlmostEqual(response.context['lead_time_coverage_pct'], 50.0)
+        self.assertEqual(response.context['items_with_jobs_count'], 1)
+        self.assertEqual(response.context['total_jobs'], 1)
+        self.assertEqual(response.context['jobs_done_ok'], 1)
+        self.assertEqual(response.context['total_cost_all_time'], Decimal('1.234500'))
+
+    def test_milestone_item_shown_when_present(self):
+        # Backfill items up to id 1000 so the milestone item can be looked up by pk.
+        Item.objects.filter(pk=1000).delete()
+        milestone_item = Item.objects.create(
+            id=1000,
+            title='The 1000th item',
+            description='desc',
+            project=self.project,
+            type=self.item_type,
+            status=ItemStatus.CLOSED,
+        )
+
+        self.client.login(username='testuser', password='testpass123')
+        response = self.client.get(reverse('system-analytics'))
+
+        self.assertTrue(response.context['milestone_reached'])
+        self.assertEqual(response.context['milestone_item'], milestone_item)
+
+    def test_top_cost_items_excludes_items_without_cost(self):
+        self.client.login(username='testuser', password='testpass123')
+        response = self.client.get(reverse('system-analytics'))
+
+        top_cost_items = response.context['top_cost_items']
+        self.assertEqual(len(top_cost_items), 1)
+        self.assertEqual(top_cost_items[0].id, self.item.id)

--- a/core/urls.py
+++ b/core/urls.py
@@ -200,7 +200,10 @@ urlpatterns = [
     # AI Jobs History URLs
     path('ai-jobs-history/', views.ai_jobs_history, name='ai-jobs-history'),
     path('ai-job-statistics/', views.ai_job_statistics, name='ai-job-statistics'),
-    
+
+    # System Analytics ("Agira über Agira") URL
+    path('system-analytics/', views.system_analytics, name='system-analytics'),
+
     # Mail Template URLs
     path('mail-templates/', views.mail_templates, name='mail-templates'),
     path('mail-templates/new/', views.mail_template_create, name='mail-template-create'),

--- a/core/views.py
+++ b/core/views.py
@@ -7646,6 +7646,311 @@ def ai_job_statistics(request):
     return render(request, 'ai_job_statistics.html', context)
 
 
+@login_required
+def system_analytics(request):
+    """"Agira über Agira": dauerhafte System-Analytics-/Retrospektive-Ansicht.
+
+    Wertet die eigenen Daten (Item, ClaudeQueueJob, Release, Activity) aus:
+    Durchsatz, Cycle-/Kigil-Lead-Time, Kosten, Autonomie/Qualität, Top-Listen
+    und ein leichtgewichtiger Meilenstein-Marker. Alles DB-seitig aggregiert
+    (Sum/Count/Avg/Max/Min + Zeit-Buckets), keine Queries pro Item.
+    """
+    import statistics
+    from collections import defaultdict
+    from datetime import timedelta
+    from django.db.models import Sum
+    from django.db.models.functions import TruncWeek, TruncMonth
+
+    MILESTONE_TARGET = 1000
+
+    today = timezone.localdate()
+
+    # ------------------------------------------------------------------
+    # Meilenstein-Kopfzeile
+    # ------------------------------------------------------------------
+    total_items = Item.objects.count()
+    first_item = Item.objects.select_related('project').order_by('created_at').first()
+    closed_items_count = Item.objects.filter(status=ItemStatus.CLOSED).count()
+    open_items_count = total_items - closed_items_count
+    completion_rate = (closed_items_count / total_items * 100) if total_items else 0
+
+    days_since_start = 0
+    avg_items_per_day = 0
+    if first_item:
+        days_since_start = max((today - first_item.created_at.date()).days + 1, 1)
+        avg_items_per_day = total_items / days_since_start
+
+    highest_item_number = Item.objects.aggregate(m=models.Max('id'))['m'] or 0
+    milestone_reached = highest_item_number >= MILESTONE_TARGET
+    milestone_item = Item.objects.select_related('project').filter(pk=MILESTONE_TARGET).first()
+    milestone_progress_pct = min(highest_item_number / MILESTONE_TARGET * 100, 100) if MILESTONE_TARGET else 0
+
+    # ------------------------------------------------------------------
+    # Closed-Zeitpunkt je Item: jüngste "-> Closed"-Aktivität, sonst
+    # updated_at als Fallback (z.B. Statusänderung ohne Activity-Log-Eintrag).
+    # Zwei Aggregat-Queries, keine Pro-Item-Lookups.
+    # ------------------------------------------------------------------
+    closed_activity_qs = (
+        Activity.objects.filter(verb='item.status_changed', summary__endswith=f'→ {ItemStatus.CLOSED}')
+        .values('target_object_id')
+        .annotate(closed_at=models.Max('created_at'))
+    )
+    closed_at_by_item_id = {int(r['target_object_id']): r['closed_at'] for r in closed_activity_qs}
+
+    closed_items_rows = list(
+        Item.objects.filter(status=ItemStatus.CLOSED).values('id', 'created_at', 'updated_at')
+    )
+    item_closed_dates = []  # (item_id, created_at, closed_at)
+    for row in closed_items_rows:
+        closed_at = closed_at_by_item_id.get(row['id'], row['updated_at'])
+        if closed_at and closed_at >= row['created_at']:
+            item_closed_dates.append((row['id'], row['created_at'], closed_at))
+
+    # ------------------------------------------------------------------
+    # Durchsatz über die Zeit: erstellt vs. geschlossen je Woche + offene-Kurve
+    # ------------------------------------------------------------------
+    created_by_week_qs = (
+        Item.objects.annotate(week=TruncWeek('created_at'))
+        .values('week').annotate(count=Count('id')).order_by('week')
+    )
+    created_by_week = {row['week'].date(): row['count'] for row in created_by_week_qs}
+
+    closed_by_week = defaultdict(int)
+    for _id, _created_at, closed_at in item_closed_dates:
+        week_start = closed_at.date() - timedelta(days=closed_at.weekday())
+        closed_by_week[week_start] += 1
+
+    week_labels, created_series, closed_series, open_series = [], [], [], []
+    if first_item:
+        week_cursor = first_item.created_at.date() - timedelta(days=first_item.created_at.weekday())
+        current_week_start = today - timedelta(days=today.weekday())
+        cumulative_open = 0
+        while week_cursor <= current_week_start:
+            created_n = created_by_week.get(week_cursor, 0)
+            closed_n = closed_by_week.get(week_cursor, 0)
+            cumulative_open += created_n - closed_n
+            week_labels.append(week_cursor.strftime('%d.%m.'))
+            created_series.append(created_n)
+            closed_series.append(closed_n)
+            open_series.append(cumulative_open)
+            week_cursor += timedelta(days=7)
+
+    # ------------------------------------------------------------------
+    # Cycle-Time (erstellt -> geschlossen) für aktuell geschlossene Items
+    # ------------------------------------------------------------------
+    cycle_days = [
+        (closed_at - created_at).total_seconds() / 86400
+        for _id, created_at, closed_at in item_closed_dates
+    ]
+    avg_cycle_days = statistics.mean(cycle_days) if cycle_days else None
+    median_cycle_days = statistics.median(cycle_days) if cycle_days else None
+
+    # ------------------------------------------------------------------
+    # Kigil-Lead-Time: Idee (created_at) -> Deployment.
+    # Deployment = früheres von (erster gemergter PR) / (Release closed_at).
+    # Nicht jedes Item hat bereits eine Deployment-Spur - lead_time_coverage_pct
+    # macht das im UI sichtbar, statt stillschweigend nur einen Teil zu zeigen.
+    # ------------------------------------------------------------------
+    pr_deploy_qs = (
+        ExternalIssueMapping.objects.filter(kind=ExternalIssueKind.PR, merged_at__isnull=False)
+        .values('item_id').annotate(first_merge=models.Min('merged_at'))
+    )
+    pr_deploy_by_item = {r['item_id']: r['first_merge'] for r in pr_deploy_qs}
+
+    release_deploy_by_item = {
+        r['id']: r['solution_release__closed_at']
+        for r in Item.objects.filter(solution_release__closed_at__isnull=False)
+        .values('id', 'solution_release__closed_at')
+    }
+
+    lead_time_rows = []  # (item_id, created_at, deploy_at, lead_days)
+    for item_id, created_at in Item.objects.values_list('id', 'created_at'):
+        candidates = [d for d in (pr_deploy_by_item.get(item_id), release_deploy_by_item.get(item_id)) if d]
+        if not candidates:
+            continue
+        deploy_at = min(candidates)
+        if deploy_at < created_at:
+            continue
+        lead_time_rows.append((item_id, created_at, deploy_at, (deploy_at - created_at).total_seconds() / 86400))
+
+    lead_days = [row[3] for row in lead_time_rows]
+    avg_lead_days = statistics.mean(lead_days) if lead_days else None
+    median_lead_days = statistics.median(lead_days) if lead_days else None
+    lead_time_coverage_pct = (len(lead_days) / total_items * 100) if total_items else 0
+
+    # ------------------------------------------------------------------
+    # Kosten über die Zeit + Modell-Mix (basiert auf ClaudeQueueJob.total_cost_usd,
+    # Claudes eigener Schätzwert - keine Neuberechnung, siehe #997)
+    # ------------------------------------------------------------------
+    total_cost_all_time = ClaudeQueueJob.objects.aggregate(total=Sum('total_cost_usd'))['total'] or Decimal('0')
+
+    cost_by_month_qs = (
+        ClaudeQueueJob.objects.annotate(month=TruncMonth('created_at'))
+        .values('month').annotate(total=Sum('total_cost_usd')).order_by('month')
+    )
+    month_labels = [row['month'].strftime('%m/%Y') for row in cost_by_month_qs]
+    month_cost_series = [float(row['total'] or 0) for row in cost_by_month_qs]
+
+    model_mix = list(
+        ClaudeQueueJob.objects.values('model')
+        .annotate(total_cost=Sum('total_cost_usd'), count=Count('id'))
+        .order_by('-total_cost')
+    )
+
+    items_with_jobs_count = Item.objects.filter(claude_queue_jobs__isnull=False).distinct().count()
+    avg_cost_per_item = (total_cost_all_time / items_with_jobs_count) if items_with_jobs_count else None
+
+    # ------------------------------------------------------------------
+    # Autonomie & Qualität
+    # ------------------------------------------------------------------
+    total_jobs = ClaudeQueueJob.objects.count()
+    autonomy_rate = (items_with_jobs_count / total_items * 100) if total_items else 0
+
+    done_jobs = ClaudeQueueJob.objects.filter(status=ClaudeQueueJobStatus.DONE)
+    jobs_done_ok = done_jobs.filter(completion_uncertain=False).count()
+    jobs_done_uncertain = done_jobs.filter(completion_uncertain=True).count()
+    jobs_failed = ClaudeQueueJob.objects.filter(status=ClaudeQueueJobStatus.FAILED).count()
+    jobs_cancelled = ClaudeQueueJob.objects.filter(status=ClaudeQueueJobStatus.CANCELLED).count()
+    jobs_in_flight = ClaudeQueueJob.objects.filter(
+        status__in=[ClaudeQueueJobStatus.QUEUED, ClaudeQueueJobStatus.RUNNING]
+    ).count()
+    success_rate = (jobs_done_ok / total_jobs * 100) if total_jobs else 0
+
+    turns_list = sorted(
+        ClaudeQueueJob.objects.filter(num_turns__isnull=False).values_list('num_turns', flat=True)
+    )
+    avg_turns = statistics.mean(turns_list) if turns_list else None
+    median_turns = statistics.median(turns_list) if turns_list else None
+
+    turns_buckets = [('1-10', 0, 10), ('11-25', 11, 25), ('26-50', 26, 50), ('51-100', 51, 100), ('100+', 101, None)]
+    turns_histogram = []
+    for label, low, high in turns_buckets:
+        if high is None:
+            count = sum(1 for t in turns_list if t >= low)
+        else:
+            count = sum(1 for t in turns_list if low <= t <= high)
+        turns_histogram.append({'label': label, 'count': count})
+
+    # ------------------------------------------------------------------
+    # Top-Listen
+    # ------------------------------------------------------------------
+    top_cost_items = list(
+        Item.objects.select_related('project')
+        .annotate(total_job_cost=Sum('claude_queue_jobs__total_cost_usd'))
+        .filter(total_job_cost__isnull=False, total_job_cost__gt=0)
+        .order_by('-total_job_cost')[:10]
+    )
+
+    top_turns_items = list(
+        Item.objects.select_related('project')
+        .annotate(
+            total_turns=Sum('claude_queue_jobs__num_turns'),
+            pr_count=Count(
+                'external_mappings',
+                filter=Q(external_mappings__kind=ExternalIssueKind.PR),
+                distinct=True,
+            ),
+        )
+        .filter(total_turns__isnull=False)
+        .order_by('-total_turns')[:10]
+    )
+
+    top_cycle_time_rows = sorted(item_closed_dates, key=lambda row: row[2] - row[1], reverse=True)[:10]
+    top_cycle_time_items = []
+    if top_cycle_time_rows:
+        items_by_id = {
+            it.id: it for it in
+            Item.objects.select_related('project').filter(id__in=[row[0] for row in top_cycle_time_rows])
+        }
+        for item_id, created_at, closed_at in top_cycle_time_rows:
+            item = items_by_id.get(item_id)
+            if item:
+                top_cycle_time_items.append({
+                    'item': item,
+                    'cycle_days': (closed_at - created_at).total_seconds() / 86400,
+                })
+
+    # ------------------------------------------------------------------
+    # Hall of Fame (leichtgewichtig)
+    # ------------------------------------------------------------------
+    oldest_open_item = (
+        Item.objects.select_related('project')
+        .exclude(status=ItemStatus.CLOSED).order_by('created_at').first()
+    )
+    most_discussed_item = (
+        Item.objects.select_related('project').annotate(comment_count=Count('comments'))
+        .filter(comment_count__gt=0).order_by('-comment_count').first()
+    )
+    fastest_lead_time_item = None
+    if lead_time_rows:
+        fastest_row = min(lead_time_rows, key=lambda row: row[3])
+        fastest_lead_time_item = {
+            'item': Item.objects.select_related('project').filter(pk=fastest_row[0]).first(),
+            'lead_days': fastest_row[3],
+        }
+
+    context = {
+        'milestone_target': MILESTONE_TARGET,
+        'milestone_reached': milestone_reached,
+        'milestone_item': milestone_item,
+        'milestone_progress_pct': milestone_progress_pct,
+        'highest_item_number': highest_item_number,
+        'total_items': total_items,
+        'first_item': first_item,
+        'closed_items_count': closed_items_count,
+        'open_items_count': open_items_count,
+        'completion_rate': completion_rate,
+        'days_since_start': days_since_start,
+        'avg_items_per_day': avg_items_per_day,
+
+        'throughput_chart_json': json.dumps({
+            'labels': week_labels,
+            'created': created_series,
+            'closed': closed_series,
+            'open': open_series,
+        }),
+
+        'avg_cycle_days': avg_cycle_days,
+        'median_cycle_days': median_cycle_days,
+        'cycle_time_sample_size': len(cycle_days),
+
+        'avg_lead_days': avg_lead_days,
+        'median_lead_days': median_lead_days,
+        'lead_time_sample_size': len(lead_days),
+        'lead_time_coverage_pct': lead_time_coverage_pct,
+
+        'total_cost_all_time': total_cost_all_time,
+        'avg_cost_per_item': avg_cost_per_item,
+        'items_with_jobs_count': items_with_jobs_count,
+        'model_mix': model_mix,
+        'cost_chart_json': json.dumps({
+            'labels': month_labels,
+            'data': month_cost_series,
+        }),
+
+        'total_jobs': total_jobs,
+        'autonomy_rate': autonomy_rate,
+        'success_rate': success_rate,
+        'jobs_done_ok': jobs_done_ok,
+        'jobs_done_uncertain': jobs_done_uncertain,
+        'jobs_failed': jobs_failed,
+        'jobs_cancelled': jobs_cancelled,
+        'jobs_in_flight': jobs_in_flight,
+        'avg_turns': avg_turns,
+        'median_turns': median_turns,
+        'turns_histogram_json': json.dumps(turns_histogram),
+
+        'top_cost_items': top_cost_items,
+        'top_turns_items': top_turns_items,
+        'top_cycle_time_items': top_cycle_time_items,
+
+        'oldest_open_item': oldest_open_item,
+        'most_discussed_item': most_discussed_item,
+        'fastest_lead_time_item': fastest_lead_time_item,
+    }
+    return render(request, 'system_analytics.html', context)
+
+
 # ============================================================================
 # Weaviate Sync Views
 # ============================================================================

--- a/templates/base.html
+++ b/templates/base.html
@@ -184,6 +184,10 @@
                     <i class="bi bi-robot sidebar-icon"></i>
                     <span class="sidebar-text">Claude Queue</span>
                 </a>
+                <a href="{% url 'system-analytics' %}" class="sidebar-link {% if request.resolver_match.url_name == 'system-analytics' %}active{% endif %}">
+                    <i class="bi bi-graph-up-arrow sidebar-icon"></i>
+                    <span class="sidebar-text">System Analytics</span>
+                </a>
                 <a href="{% url 'organisations' %}" class="sidebar-link {% if request.resolver_match.url_name == 'organisations' %}active{% endif %}">
                     <i class="bi bi-building sidebar-icon"></i>
                     <span class="sidebar-text">Organisations</span>

--- a/templates/system_analytics.html
+++ b/templates/system_analytics.html
@@ -1,0 +1,467 @@
+{% extends "base.html" %}
+
+{% block title %}System Analytics - Agira{% endblock %}
+
+{% block extra_head %}
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+{% endblock %}
+
+{% block content %}
+<div class="page-header">
+    <h1><i class="bi bi-graph-up-arrow me-2"></i>Agira über Agira</h1>
+    <p class="text-muted">System-Analytics &amp; Retrospektive &mdash; dauerhafte Kennzahlen statt Einmal-Report</p>
+</div>
+
+<!-- Milestone banner -->
+<div class="dashboard-section mb-4" style="border-color: var(--accent-primary);">
+    <div class="d-flex justify-content-between align-items-center flex-wrap gap-2">
+        <div>
+            <h2 class="dashboard-section-title mb-1">
+                <i class="bi bi-flag-fill me-2"></i>
+                {% if milestone_reached %}
+                    🎉 Meilenstein erreicht: Item #{{ milestone_target }}
+                {% else %}
+                    Auf dem Weg zu Item #{{ milestone_target }}
+                {% endif %}
+            </h2>
+            {% if first_item %}
+            <p class="text-muted mb-0">
+                Seit dem ersten Item ({{ first_item.created_at|date:"d.m.Y" }}): {{ days_since_start }} Tage,
+                {{ total_items }} Items (Ø {{ avg_items_per_day|floatformat:1 }}/Tag),
+                {{ completion_rate|floatformat:0 }}% abgeschlossen ({{ closed_items_count }}/{{ total_items }}).
+            </p>
+            {% endif %}
+        </div>
+        <div class="text-end" style="min-width: 180px;">
+            <div class="progress" style="height: 0.5rem; background-color: var(--bg-tertiary);">
+                <div class="progress-bar" role="progressbar" style="width: {{ milestone_progress_pct|floatformat:0 }}%; background-color: var(--accent-primary);"></div>
+            </div>
+            <small class="text-muted">Item-Nr. {{ highest_item_number }} / {{ milestone_target }}</small>
+        </div>
+    </div>
+    {% if milestone_item %}
+    <div class="mt-2">
+        <a href="{% url 'item-detail' milestone_item.id %}" class="text-decoration-none">
+            <i class="bi bi-bookmark-star me-1"></i>Zum Jubiläums-Item: {{ milestone_item.title }}
+        </a>
+    </div>
+    {% endif %}
+</div>
+
+<!-- KPI Tiles -->
+<div class="row g-3 mb-4">
+    <div class="col-md-3">
+        <div class="kpi-card">
+            <div class="kpi-icon"><i class="bi bi-hourglass-split"></i></div>
+            <div class="kpi-content">
+                <div class="kpi-value">{{ avg_cycle_days|floatformat:1|default:"–" }}</div>
+                <div class="kpi-label">Ø Cycle-Time (Tage), n={{ cycle_time_sample_size }}</div>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-3">
+        <div class="kpi-card kpi-card-primary">
+            <div class="kpi-icon"><i class="bi bi-rocket-takeoff"></i></div>
+            <div class="kpi-content">
+                <div class="kpi-value">{{ avg_lead_days|floatformat:1|default:"–" }}</div>
+                <div class="kpi-label">Kigil-Lead-Time Idee → Deployment (Tage)</div>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-3">
+        <div class="kpi-card">
+            <div class="kpi-icon"><i class="bi bi-currency-dollar"></i></div>
+            <div class="kpi-content">
+                <div class="kpi-value">US${{ total_cost_all_time|floatformat:2 }}</div>
+                <div class="kpi-label">Kosten gesamt (geschätzt)</div>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-3">
+        <div class="kpi-card kpi-card-success">
+            <div class="kpi-icon"><i class="bi bi-robot"></i></div>
+            <div class="kpi-content">
+                <div class="kpi-value">{{ autonomy_rate|floatformat:0 }}%</div>
+                <div class="kpi-label">Items via Claude-Queue bearbeitet</div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- Throughput -->
+<div class="row g-3 mb-4">
+    <div class="col-md-12">
+        <div class="card">
+            <div class="card-header">
+                <strong><i class="bi bi-bar-chart-steps me-1"></i>Durchsatz über die Zeit (wöchentlich seit Start)</strong>
+            </div>
+            <div class="card-body">
+                <canvas id="throughputChart" style="max-height: 300px;"></canvas>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- Cycle/Lead time detail -->
+<div class="row g-3 mb-4">
+    <div class="col-md-6">
+        <div class="card h-100">
+            <div class="card-header">
+                <strong><i class="bi bi-hourglass-split me-1"></i>Cycle-Time (Erstellung → Closed)</strong>
+            </div>
+            <div class="card-body">
+                <table class="table table-sm mb-0">
+                    <tbody>
+                        <tr><td>Durchschnitt</td><td class="text-end">{{ avg_cycle_days|floatformat:1|default:"–" }} Tage</td></tr>
+                        <tr><td>Median</td><td class="text-end">{{ median_cycle_days|floatformat:1|default:"–" }} Tage</td></tr>
+                        <tr><td>Basis</td><td class="text-end">{{ cycle_time_sample_size }} geschlossene Items</td></tr>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-6">
+        <div class="card h-100">
+            <div class="card-header">
+                <strong><i class="bi bi-rocket-takeoff me-1"></i>Kigil-Lead-Time (Idee → Deployment)</strong>
+            </div>
+            <div class="card-body">
+                <table class="table table-sm mb-0">
+                    <tbody>
+                        <tr><td>Durchschnitt</td><td class="text-end">{{ avg_lead_days|floatformat:1|default:"–" }} Tage</td></tr>
+                        <tr><td>Median</td><td class="text-end">{{ median_lead_days|floatformat:1|default:"–" }} Tage</td></tr>
+                        <tr><td>Abdeckung</td><td class="text-end">{{ lead_time_sample_size }} Items ({{ lead_time_coverage_pct|floatformat:0 }}% aller Items)</td></tr>
+                    </tbody>
+                </table>
+                <p class="text-muted small mb-0">Deployment = frühestes von: erster gemergter PR oder Abschluss des zugeordneten Release. Nur Items mit bekannter Deployment-Spur fließen ein.</p>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- Cost over time + model mix -->
+<div class="row g-3 mb-4">
+    <div class="col-md-7">
+        <div class="card h-100">
+            <div class="card-header">
+                <strong><i class="bi bi-graph-up me-1"></i>Kosten über die Zeit (je Monat, geschätzt)</strong>
+            </div>
+            <div class="card-body">
+                <canvas id="costChart" style="max-height: 280px;"></canvas>
+                <p class="text-muted small mt-2 mb-0">Basiert auf <code>total_cost_usd</code> je Claude-Queue-Job (Claudes eigene Schätzung) &mdash; keine Neuberechnung.</p>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-5">
+        <div class="card h-100">
+            <div class="card-header">
+                <strong><i class="bi bi-cpu me-1"></i>Modell-Mix</strong>
+            </div>
+            <div class="card-body p-0">
+                <div class="table-responsive">
+                    <table class="table table-hover table-sm mb-0">
+                        <thead class="table-light">
+                            <tr>
+                                <th>Modell</th>
+                                <th class="text-end">Jobs</th>
+                                <th class="text-end">Kosten (US$)</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for row in model_mix %}
+                            <tr>
+                                <td>{{ row.model|default:"–" }}</td>
+                                <td class="text-end">{{ row.count }}</td>
+                                <td class="text-end">{{ row.total_cost|floatformat:2|default:"–" }}</td>
+                            </tr>
+                            {% empty %}
+                            <tr><td colspan="3" class="text-center text-muted py-3">Keine Daten</td></tr>
+                            {% endfor %}
+                        </tbody>
+                        <tfoot>
+                            <tr>
+                                <td><strong>Ø je bearbeitetes Item</strong></td>
+                                <td class="text-end"></td>
+                                <td class="text-end"><strong>{{ avg_cost_per_item|floatformat:2|default:"–" }}</strong></td>
+                            </tr>
+                        </tfoot>
+                    </table>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- Autonomy & quality -->
+<div class="row g-3 mb-4">
+    <div class="col-md-6">
+        <div class="card h-100">
+            <div class="card-header">
+                <strong><i class="bi bi-robot me-1"></i>Autonomie &amp; Erfolgsquote</strong>
+            </div>
+            <div class="card-body">
+                <table class="table table-sm mb-0">
+                    <tbody>
+                        <tr><td>Items mit Claude-Queue-Job</td><td class="text-end">{{ items_with_jobs_count }} / {{ total_items }} ({{ autonomy_rate|floatformat:0 }}%)</td></tr>
+                        <tr><td>Jobs gesamt</td><td class="text-end">{{ total_jobs }}</td></tr>
+                        <tr><td>Erfolgreich (done, eindeutig)</td><td class="text-end">{{ jobs_done_ok }} ({{ success_rate|floatformat:0 }}%)</td></tr>
+                        <tr><td>Done, aber unsicher (#998)</td><td class="text-end">{{ jobs_done_uncertain }}</td></tr>
+                        <tr><td>Fehlgeschlagen</td><td class="text-end">{{ jobs_failed }}</td></tr>
+                        <tr><td>Abgebrochen</td><td class="text-end">{{ jobs_cancelled }}</td></tr>
+                        <tr><td>In Bearbeitung / Warteschlange</td><td class="text-end">{{ jobs_in_flight }}</td></tr>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-6">
+        <div class="card h-100">
+            <div class="card-header">
+                <strong><i class="bi bi-arrow-left-right me-1"></i>Verteilung <code>num_turns</code> (Kostentreiber)</strong>
+            </div>
+            <div class="card-body">
+                <p class="mb-2">Ø {{ avg_turns|floatformat:1|default:"–" }} &middot; Median {{ median_turns|floatformat:0|default:"–" }}</p>
+                <canvas id="turnsChart" style="max-height: 220px;"></canvas>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- Top lists -->
+<div class="row g-3 mb-4">
+    <div class="col-md-4">
+        <div class="card h-100">
+            <div class="card-header">
+                <strong><i class="bi bi-currency-dollar me-1"></i>Teuerste Items</strong>
+            </div>
+            <div class="card-body p-0">
+                <div class="table-responsive">
+                    <table class="table table-hover table-sm mb-0">
+                        <thead class="table-light"><tr><th>Item</th><th class="text-end">US$</th></tr></thead>
+                        <tbody>
+                            {% for item in top_cost_items %}
+                            <tr>
+                                <td><a href="{% url 'item-detail' item.id %}">#{{ item.id }} {{ item.title|truncatechars:40 }}</a></td>
+                                <td class="text-end">{{ item.total_job_cost|floatformat:2 }}</td>
+                            </tr>
+                            {% empty %}
+                            <tr><td colspan="2" class="text-center text-muted py-3">Keine Daten</td></tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-4">
+        <div class="card h-100">
+            <div class="card-header">
+                <strong><i class="bi bi-hourglass-split me-1"></i>Längste Cycle-Time</strong>
+            </div>
+            <div class="card-body p-0">
+                <div class="table-responsive">
+                    <table class="table table-hover table-sm mb-0">
+                        <thead class="table-light"><tr><th>Item</th><th class="text-end">Tage</th></tr></thead>
+                        <tbody>
+                            {% for row in top_cycle_time_items %}
+                            <tr>
+                                <td><a href="{% url 'item-detail' row.item.id %}">#{{ row.item.id }} {{ row.item.title|truncatechars:40 }}</a></td>
+                                <td class="text-end">{{ row.cycle_days|floatformat:1 }}</td>
+                            </tr>
+                            {% empty %}
+                            <tr><td colspan="2" class="text-center text-muted py-3">Keine Daten</td></tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-4">
+        <div class="card h-100">
+            <div class="card-header">
+                <strong><i class="bi bi-arrow-repeat me-1"></i>Meiste PRs / Turns</strong>
+            </div>
+            <div class="card-body p-0">
+                <div class="table-responsive">
+                    <table class="table table-hover table-sm mb-0">
+                        <thead class="table-light"><tr><th>Item</th><th class="text-end">PRs</th><th class="text-end">Turns</th></tr></thead>
+                        <tbody>
+                            {% for item in top_turns_items %}
+                            <tr>
+                                <td><a href="{% url 'item-detail' item.id %}">#{{ item.id }} {{ item.title|truncatechars:30 }}</a></td>
+                                <td class="text-end">{{ item.pr_count }}</td>
+                                <td class="text-end">{{ item.total_turns }}</td>
+                            </tr>
+                            {% empty %}
+                            <tr><td colspan="3" class="text-center text-muted py-3">Keine Daten</td></tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- Hall of Fame -->
+<div class="dashboard-section mb-4">
+    <div class="dashboard-section-header">
+        <h2 class="dashboard-section-title"><i class="bi bi-trophy me-2"></i>Hall of Fame</h2>
+    </div>
+    <div class="row g-3">
+        {% if first_item %}
+        <div class="col-md-3">
+            <div class="kpi-card">
+                <div class="kpi-icon"><i class="bi bi-flag"></i></div>
+                <div class="kpi-content">
+                    <div class="kpi-label">Der Anfang</div>
+                    <a href="{% url 'item-detail' first_item.id %}">#{{ first_item.id }} {{ first_item.title|truncatechars:30 }}</a>
+                    <div class="text-muted small">{{ first_item.created_at|date:"d.m.Y" }}</div>
+                </div>
+            </div>
+        </div>
+        {% endif %}
+        {% if oldest_open_item %}
+        <div class="col-md-3">
+            <div class="kpi-card">
+                <div class="kpi-icon"><i class="bi bi-hourglass"></i></div>
+                <div class="kpi-content">
+                    <div class="kpi-label">Ältestes offenes Item</div>
+                    <a href="{% url 'item-detail' oldest_open_item.id %}">#{{ oldest_open_item.id }} {{ oldest_open_item.title|truncatechars:30 }}</a>
+                    <div class="text-muted small">seit {{ oldest_open_item.created_at|date:"d.m.Y" }}</div>
+                </div>
+            </div>
+        </div>
+        {% endif %}
+        {% if most_discussed_item %}
+        <div class="col-md-3">
+            <div class="kpi-card">
+                <div class="kpi-icon"><i class="bi bi-chat-dots"></i></div>
+                <div class="kpi-content">
+                    <div class="kpi-label">Meistdiskutiert</div>
+                    <a href="{% url 'item-detail' most_discussed_item.id %}">#{{ most_discussed_item.id }} {{ most_discussed_item.title|truncatechars:30 }}</a>
+                    <div class="text-muted small">{{ most_discussed_item.comment_count }} Kommentare</div>
+                </div>
+            </div>
+        </div>
+        {% endif %}
+        {% if fastest_lead_time_item and fastest_lead_time_item.item %}
+        <div class="col-md-3">
+            <div class="kpi-card kpi-card-success">
+                <div class="kpi-icon"><i class="bi bi-lightning-charge"></i></div>
+                <div class="kpi-content">
+                    <div class="kpi-label">Schnellste Idee → Deployment</div>
+                    <a href="{% url 'item-detail' fastest_lead_time_item.item.id %}">#{{ fastest_lead_time_item.item.id }} {{ fastest_lead_time_item.item.title|truncatechars:30 }}</a>
+                    <div class="text-muted small">{{ fastest_lead_time_item.lead_days|floatformat:1 }} Tage</div>
+                </div>
+            </div>
+        </div>
+        {% endif %}
+    </div>
+</div>
+{% endblock %}
+
+{% block extra_js %}
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    const throughputCtx = document.getElementById('throughputChart');
+    if (throughputCtx) {
+        const data = {{ throughput_chart_json|safe }};
+        new Chart(throughputCtx, {
+            type: 'bar',
+            data: {
+                labels: data.labels,
+                datasets: [
+                    {
+                        label: 'Erstellt',
+                        data: data.created,
+                        backgroundColor: 'rgba(99, 102, 241, 0.6)',
+                        order: 2,
+                    },
+                    {
+                        label: 'Geschlossen',
+                        data: data.closed,
+                        backgroundColor: 'rgba(34, 197, 94, 0.6)',
+                        order: 2,
+                    },
+                    {
+                        type: 'line',
+                        label: 'Offen (kumuliert)',
+                        data: data.open,
+                        borderColor: 'rgba(220, 53, 69, 0.9)',
+                        backgroundColor: 'rgba(220, 53, 69, 0.1)',
+                        tension: 0.3,
+                        yAxisID: 'y1',
+                        order: 1,
+                    },
+                ]
+            },
+            options: {
+                responsive: true,
+                maintainAspectRatio: true,
+                interaction: { mode: 'index', intersect: false },
+                plugins: { legend: { position: 'bottom' } },
+                scales: {
+                    y: { beginAtZero: true, title: { display: true, text: 'Items / Woche' } },
+                    y1: {
+                        beginAtZero: true,
+                        position: 'right',
+                        grid: { drawOnChartArea: false },
+                        title: { display: true, text: 'Offen (kumuliert)' },
+                    },
+                }
+            }
+        });
+    }
+
+    const costCtx = document.getElementById('costChart');
+    if (costCtx) {
+        const data = {{ cost_chart_json|safe }};
+        new Chart(costCtx, {
+            type: 'bar',
+            data: {
+                labels: data.labels,
+                datasets: [{
+                    label: 'Kosten (US$)',
+                    data: data.data,
+                    backgroundColor: 'rgba(13, 202, 240, 0.6)',
+                    borderColor: 'rgba(13, 202, 240, 1)',
+                    borderWidth: 1,
+                }]
+            },
+            options: {
+                responsive: true,
+                maintainAspectRatio: true,
+                plugins: { legend: { display: false } },
+                scales: { y: { beginAtZero: true } }
+            }
+        });
+    }
+
+    const turnsCtx = document.getElementById('turnsChart');
+    if (turnsCtx) {
+        const histogram = {{ turns_histogram_json|safe }};
+        new Chart(turnsCtx, {
+            type: 'bar',
+            data: {
+                labels: histogram.map(b => b.label),
+                datasets: [{
+                    label: 'Jobs',
+                    data: histogram.map(b => b.count),
+                    backgroundColor: 'rgba(255, 193, 7, 0.6)',
+                    borderColor: 'rgba(255, 193, 7, 1)',
+                    borderWidth: 1,
+                }]
+            },
+            options: {
+                responsive: true,
+                maintainAspectRatio: true,
+                plugins: { legend: { display: false } },
+                scales: { y: { beginAtZero: true, ticks: { precision: 0 } } }
+            }
+        });
+    }
+});
+</script>
+{% endblock %}


### PR DESCRIPTION
Automated draft PR opened by the Claude queue worker for Agira item #1000.

Model: Sonnet
Job: #185

---

## Zusammenfassung

Zum 1000. Issue richtet Agira seine eigenen Werkzeuge auf sich selbst: ein dauerhafter System-Analytics-View unter „System Analytics" in der Sidebar wertet Item-, ClaudeQueueJob-, Release- und Activity-Daten aus und macht Durchsatz, Cycle-/Kigil-Lead-Time, Kosten und Autonomie/Qualität laufend sichtbar — statt eines einmaligen Reports.

## Änderungen

- Neue View `system_analytics` (`core/views.py`) unter `/system-analytics/`, ausschließlich DB-seitige Aggregationen (`Sum`/`Count`/`Avg`/`Max`/`Min`, `TruncWeek`/`TruncMonth`), keine Pro-Item-Queries:
  - **Meilenstein-Kopfzeile**: Item-Anzahl, Tage seit dem ersten Item, Ø Items/Tag, Abschlussquote, Fortschrittsbalken bis Item #1000 und Link auf das Jubiläums-Item, falls vorhanden.
  - **Durchsatz**: erstellte vs. geschlossene Items je Woche seit dem ersten Item plus kumulierte Offen-Kurve.
  - **Cycle-Time**: Erstellung → Closed, aus dem jüngsten `item.status_changed`-Aktivitätseintrag pro Item (Fallback: `updated_at`, falls kein Aktivitätslog vorhanden).
  - **Kigil-Lead-Time** (Idee → Deployment): frühestes von erstem gemergtem PR (`ExternalIssueMapping.merged_at`) oder Abschluss des zugeordneten Release (`Release.closed_at`); Abdeckung wird explizit ausgewiesen, da nicht jedes Item bereits eine Deployment-Spur hat.
  - **Kosten über die Zeit + Modell-Mix**: Summe `total_cost_usd` je Monat, Aufteilung Sonnet/Opus, Ø Kosten je bearbeitetes Item — baut auf #997 auf, keine Neuberechnung.
  - **Autonomie & Qualität**: Anteil via Claude-Queue bearbeiteter Items, Erfolgs-/Unsicher-/Fehler-/Abbruchquote der Jobs (Anknüpfung an #998), Verteilung von `num_turns` als Histogramm.
  - **Top-Listen**: teuerste Items, längste Cycle-Time, meiste PRs/Turns.
  - **Hall of Fame**: erstes Item, ältestes noch offenes Item, meistdiskutiertes Item, schnellste Idee-→-Deployment.
- Neues Template `templates/system_analytics.html`, konsistent mit dem bestehenden Dashboard-/AI-Job-Statistics-Layout (KPI-Cards, ruhige Chart.js-Diagramme, Bootstrap-Tabellen).
- Neuer Sidebar-Eintrag „System Analytics" in `templates/base.html`, neben Claude Queue.
- Neue URL-Route `system-analytics` in `core/urls.py`.
- Tests in `core/test_system_analytics.py`: Login-Pflicht, Rendering, KPI-Korrektheit anhand von Fixture-Daten, Meilenstein-Erkennung, Top-Listen-Filterung.

## Warum / Entscheidungen

- **Release.closed_at + PR merged_at statt nur Change.executed_at** für die Kigil-Lead-Time: In den vorhandenen Daten haben deutlich mehr Items einen zugeordneten Release mit `closed_at` bzw. eine gemergte PR als einen `Change` mit `executed_at` — die gewählte Quelle liefert die höhere Abdeckung, ohne ein neues Tracking-Feld einzuführen.
- **Nicht ausschließlich Change/Release als Deployment-Signal, sondern zusätzlich PR-Merge**, weil ein Großteil der Items über den Claude-Queue-Workflow direkt per Pull-Request-Merge „ausgeliefert" wird, ganz ohne formalen Change-/Release-Prozess; ohne PR-Merge als Signal bliebe die Kennzahl für diese Items leer.
- **Cycle-Time aus dem Activity-Log statt einem neuen `closed_at`-Feld auf Item**: Ein neues Datenbankfeld hätte eine Migration und rückwirkendes Befüllen erfordert; die Statusänderungs-Aktivität existiert bereits durchgängig und liefert den Zeitpunkt praktisch verlustfrei. Nur für die Minderheit ohne passenden Aktivitätseintrag greift der Fallback auf `updated_at`.
- **Wöchentliche statt tägliche Buckets für den Durchsatz**: Bei rund 5 Items/Tag wäre eine Tagesansicht zu verrauscht, um Trends erkennbar zu machen; Wochen-Buckets ergeben über die bisherige Projektlaufzeit eine überschaubare, lesbare Anzahl an Datenpunkten.
- **Kein neues Aggregat-/Snapshot-Modell, keine Zwischenspeicherung**: Alle Kennzahlen werden bei jedem Aufruf frisch aus den bestehenden Tabellen berechnet. Das hält den View einfach und immer aktuell; bei den heutigen Datenmengen (~1000 Items) ist das performant genug, ein Caching wäre verfrühte Optimierung für ein Problem, das noch nicht existiert.
- **Hall of Fame bewusst schlank** (vier Kacheln: erstes Item, ältestes offenes Item, meistdiskutiertes Item, schnellste Lieferung) statt eines eigenen Kurationsmechanismus, weil der Fokus des Features auf dauerhaft nützlichen Kennzahlen liegt und nicht auf einem einmaligen Zeremoniell-Rückblick.
- **Sidebar-Eintrag auf oberster Ebene neben „Claude Queue"** statt unter „AI/KI" einsortiert, weil der View sich auf das gesamte System bezieht (Items, Releases, Activities) und nicht nur auf KI-Kennzahlen wie die bestehende „AI Job Statistics"-Seite.

## Test-Hinweise

- `python manage.py test core.test_system_analytics` — 5 neue Tests (Auth-Pflicht, Rendering, KPI-Berechnung, Meilenstein-Erkennung, Top-Kosten-Filterung), alle grün.
- `python manage.py check` — keine neuen Probleme.
- Bestehende Suiten (`core.test_claude_queue_views`, `core.test_item_detail`) laufen unverändert weiter; die dort beobachteten Fehlschläge bestehen bereits auf `main` und sind nicht durch diese Änderung verursacht (verifiziert per `git stash`).
- Manuell per Django-Shell gerendert (`RequestFactory` + `system_analytics`-View) gegen die lokale Entwicklungsdatenbank — Status 200, Charts und Tabellen befüllt.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New read-heavy analytics endpoint over core tables; no auth or data-model changes, but request cost could grow with dataset size since metrics are computed on each page load without caching.
> 
> **Overview**
> Adds a **login-protected** `/system-analytics/` page and a **System Analytics** sidebar link for ongoing retrospectives on Agira’s own data (items, Claude queue jobs, activities, PR/release signals)—not a one-off report.
> 
> The new `system_analytics` view aggregates in the database: milestone progress toward item #1000, weekly throughput (created vs closed + cumulative open), cycle time from status-change activity (with `updated_at` fallback), **Kigil lead time** from earliest PR merge or solution release close, Claude job costs and model mix, autonomy/success/turns metrics, top lists, and a small Hall of Fame. Chart JSON is passed to a new `system_analytics.html` template (Chart.js, aligned with existing dashboard/AI statistics styling).
> 
> `core/test_system_analytics.py` covers auth, rendering, KPI fixtures, milestone item #1000, and top-cost filtering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0665a0281e8f303094d1199eadabee478756f37a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->