### PR TITLE
Analytics-Feinschliff (#1000): „Verworfene Issues" ausweisen + Autonomie-Kennzahl richtig einordnen

### DIFF
--- a/core/test_system_analytics.py
+++ b/core/test_system_analytics.py
@@ -113,6 +113,31 @@ class SystemAnalyticsViewTestCase(TestCase):
         self.assertTrue(response.context['milestone_reached'])
         self.assertEqual(response.context['milestone_item'], milestone_item)
 
+    def test_discarded_items_count_reflects_gap_between_highest_id_and_total(self):
+        self.client.login(username='testuser', password='testpass123')
+        baseline = self.client.get(reverse('system-analytics'))
+        baseline_highest = baseline.context['highest_item_number']
+        baseline_total = baseline.context['total_items']
+
+        # Backfill an item far above the current highest id, leaving a gap of
+        # never-created ids below it - those represent issues that were
+        # assigned a number but deliberately discarded, not "open" work.
+        new_id = baseline_highest + 500
+        Item.objects.create(
+            id=new_id,
+            title='Item after a gap of discarded issue numbers',
+            description='desc',
+            project=self.project,
+            type=self.item_type,
+            status=ItemStatus.CLOSED,
+        )
+
+        response = self.client.get(reverse('system-analytics'))
+
+        self.assertEqual(response.context['highest_item_number'], new_id)
+        self.assertEqual(response.context['total_items'], baseline_total + 1)
+        self.assertEqual(response.context['discarded_items_count'], new_id - (baseline_total + 1))
+
     def test_top_cost_items_excludes_items_without_cost(self):
         self.client.login(username='testuser', password='testpass123')
         response = self.client.get(reverse('system-analytics'))

--- a/core/views.py
+++ b/core/views.py
@@ -7657,11 +7657,14 @@ def system_analytics(request):
     """
     import statistics
     from collections import defaultdict
-    from datetime import timedelta
+    from datetime import date, timedelta
     from django.db.models import Sum
     from django.db.models.functions import TruncWeek, TruncMonth
 
     MILESTONE_TARGET = 1000
+    # Seit Anfang Juli 2026 läuft die autonome Umsetzung über die (zählbare)
+    # Claude-Queue statt über GitHub Copilot (nicht zählbar) - siehe #1002.
+    CLAUDE_QUEUE_CUTOVER_DATE = date(2026, 7, 1)
 
     today = timezone.localdate()
 
@@ -7684,6 +7687,9 @@ def system_analytics(request):
     milestone_reached = highest_item_number >= MILESTONE_TARGET
     milestone_item = Item.objects.select_related('project').filter(pk=MILESTONE_TARGET).first()
     milestone_progress_pct = min(highest_item_number / MILESTONE_TARGET * 100, 100) if MILESTONE_TARGET else 0
+    # Lücke zwischen höchster vergebener Item-Nr. und tatsächlich existierenden
+    # Items = bewusst verworfene/gelöschte Issues, nicht "offen" (#1002).
+    discarded_items_count = max(highest_item_number - total_items, 0)
 
     # ------------------------------------------------------------------
     # Closed-Zeitpunkt je Item: jüngste "-> Closed"-Aktivität, sonst
@@ -7721,6 +7727,7 @@ def system_analytics(request):
         closed_by_week[week_start] += 1
 
     week_labels, created_series, closed_series, open_series = [], [], [], []
+    claude_queue_marker_index = None
     if first_item:
         week_cursor = first_item.created_at.date() - timedelta(days=first_item.created_at.weekday())
         current_week_start = today - timedelta(days=today.weekday())
@@ -7733,6 +7740,8 @@ def system_analytics(request):
             created_series.append(created_n)
             closed_series.append(closed_n)
             open_series.append(cumulative_open)
+            if claude_queue_marker_index is None and week_cursor >= CLAUDE_QUEUE_CUTOVER_DATE:
+                claude_queue_marker_index = len(week_labels) - 1
             week_cursor += timedelta(days=7)
 
     # ------------------------------------------------------------------
@@ -7801,10 +7810,12 @@ def system_analytics(request):
     avg_cost_per_item = (total_cost_all_time / items_with_jobs_count) if items_with_jobs_count else None
 
     # ------------------------------------------------------------------
-    # Autonomie & Qualität
+    # Claude-Queue-Anteil & Qualität. Das ist der messbare Anteil, KEIN
+    # Autonomiegrad: bis Anfang Juli 2026 lief die autonome Umsetzung über
+    # GitHub Copilot (eigene Anbindung, nicht in dieser Queue erfasst) - siehe #1002.
     # ------------------------------------------------------------------
     total_jobs = ClaudeQueueJob.objects.count()
-    autonomy_rate = (items_with_jobs_count / total_items * 100) if total_items else 0
+    claude_queue_share_pct = (items_with_jobs_count / total_items * 100) if total_items else 0
 
     done_jobs = ClaudeQueueJob.objects.filter(status=ClaudeQueueJobStatus.DONE)
     jobs_done_ok = done_jobs.filter(completion_uncertain=False).count()
@@ -7895,6 +7906,7 @@ def system_analytics(request):
         'milestone_item': milestone_item,
         'milestone_progress_pct': milestone_progress_pct,
         'highest_item_number': highest_item_number,
+        'discarded_items_count': discarded_items_count,
         'total_items': total_items,
         'first_item': first_item,
         'closed_items_count': closed_items_count,
@@ -7908,6 +7920,7 @@ def system_analytics(request):
             'created': created_series,
             'closed': closed_series,
             'open': open_series,
+            'claude_queue_marker_index': claude_queue_marker_index,
         }),
 
         'avg_cycle_days': avg_cycle_days,
@@ -7929,7 +7942,7 @@ def system_analytics(request):
         }),
 
         'total_jobs': total_jobs,
-        'autonomy_rate': autonomy_rate,
+        'claude_queue_share_pct': claude_queue_share_pct,
         'success_rate': success_rate,
         'jobs_done_ok': jobs_done_ok,
         'jobs_done_uncertain': jobs_done_uncertain,

--- a/templates/system_analytics.html
+++ b/templates/system_analytics.html
@@ -31,6 +31,12 @@
                 {{ completion_rate|floatformat:0 }}% abgeschlossen ({{ closed_items_count }}/{{ total_items }}).
             </p>
             {% endif %}
+            <p class="text-muted mb-0 mt-1">
+                <strong>{{ total_items }}</strong> umgesetzt &middot;
+                <strong>{{ discarded_items_count }}</strong> bewusst verworfen &middot;
+                <strong>{{ highest_item_number }}</strong> Nummern vergeben
+                <i class="bi bi-info-circle ms-1" title="&quot;Verworfen&quot; = Item-Nummern, die vergeben, aber nie umgesetzt wurden (bewusst gelöscht/verworfen) - kein offener Bestand." data-bs-toggle="tooltip"></i>
+            </p>
         </div>
         <div class="text-end" style="min-width: 180px;">
             <div class="progress" style="height: 0.5rem; background-color: var(--bg-tertiary);">
@@ -81,8 +87,11 @@
         <div class="kpi-card kpi-card-success">
             <div class="kpi-icon"><i class="bi bi-robot"></i></div>
             <div class="kpi-content">
-                <div class="kpi-value">{{ autonomy_rate|floatformat:0 }}%</div>
-                <div class="kpi-label">Items via Claude-Queue bearbeitet</div>
+                <div class="kpi-value">{{ claude_queue_share_pct|floatformat:0 }}%</div>
+                <div class="kpi-label">
+                    über die (zählbare) Claude-Queue
+                    <i class="bi bi-info-circle ms-1" title="Kein Autonomiegrad, sondern nur der messbare Anteil: vor Juli 2026 lief die autonome Umsetzung über GitHub Copilot (eigene Anbindung, nicht in dieser Queue erfasst)." data-bs-toggle="tooltip"></i>
+                </div>
             </div>
         </div>
     </div>
@@ -197,12 +206,12 @@
     <div class="col-md-6">
         <div class="card h-100">
             <div class="card-header">
-                <strong><i class="bi bi-robot me-1"></i>Autonomie &amp; Erfolgsquote</strong>
+                <strong><i class="bi bi-robot me-1"></i>Claude-Queue-Anteil &amp; Erfolgsquote</strong>
             </div>
             <div class="card-body">
                 <table class="table table-sm mb-0">
                     <tbody>
-                        <tr><td>Items mit Claude-Queue-Job</td><td class="text-end">{{ items_with_jobs_count }} / {{ total_items }} ({{ autonomy_rate|floatformat:0 }}%)</td></tr>
+                        <tr><td>Items mit Claude-Queue-Job (zählbar)</td><td class="text-end">{{ items_with_jobs_count }} / {{ total_items }} ({{ claude_queue_share_pct|floatformat:0 }}%)</td></tr>
                         <tr><td>Jobs gesamt</td><td class="text-end">{{ total_jobs }}</td></tr>
                         <tr><td>Erfolgreich (done, eindeutig)</td><td class="text-end">{{ jobs_done_ok }} ({{ success_rate|floatformat:0 }}%)</td></tr>
                         <tr><td>Done, aber unsicher (#998)</td><td class="text-end">{{ jobs_done_uncertain }}</td></tr>
@@ -211,6 +220,7 @@
                         <tr><td>In Bearbeitung / Warteschlange</td><td class="text-end">{{ jobs_in_flight }}</td></tr>
                     </tbody>
                 </table>
+                <p class="text-muted small mb-0">Misst nur den zählbaren Claude-Queue-Anteil, nicht den Autonomiegrad: vor Juli 2026 lief die autonome Umsetzung über GitHub Copilot (eigene Anbindung, hier nicht erfasst); seither fast ausschließlich über Claude Code.</p>
             </div>
         </div>
     </div>
@@ -368,6 +378,32 @@ document.addEventListener('DOMContentLoaded', function() {
     const throughputCtx = document.getElementById('throughputChart');
     if (throughputCtx) {
         const data = {{ throughput_chart_json|safe }};
+        // Zeigt den Werkzeugwechsel autonomer Umsetzung sichtbar: vor Juli 2026
+        // GitHub Copilot (nicht in dieser Queue erfasst), danach Claude Code (#1002).
+        const claudeQueueMarkerPlugin = {
+            id: 'claudeQueueMarker',
+            afterDraw(chart) {
+                const idx = data.claude_queue_marker_index;
+                if (idx === null || idx === undefined) return;
+                const xScale = chart.scales.x;
+                const { ctx, chartArea } = chart;
+                const xPos = xScale.getPixelForValue(idx);
+                ctx.save();
+                ctx.beginPath();
+                ctx.setLineDash([6, 4]);
+                ctx.strokeStyle = 'rgba(255, 193, 7, 0.9)';
+                ctx.lineWidth = 2;
+                ctx.moveTo(xPos, chartArea.top);
+                ctx.lineTo(xPos, chartArea.bottom);
+                ctx.stroke();
+                ctx.setLineDash([]);
+                ctx.fillStyle = 'rgba(255, 193, 7, 0.9)';
+                ctx.font = '11px sans-serif';
+                ctx.textAlign = 'left';
+                ctx.fillText('ab Juli: Claude Code', xPos + 4, chartArea.top + 12);
+                ctx.restore();
+            }
+        };
         new Chart(throughputCtx, {
             type: 'bar',
             data: {
@@ -397,6 +433,7 @@ document.addEventListener('DOMContentLoaded', function() {
                     },
                 ]
             },
+            plugins: [claudeQueueMarkerPlugin],
             options: {
                 responsive: true,
                 maintainAspectRatio: true,


### PR DESCRIPTION
Automated draft PR opened by the Claude queue worker for Agira item #1002.

Model: Sonnet
Job: #186

---

## Zusammenfassung

Das #1000-Analytics-View ("Agira über Agira") enthielt zwei missverständliche Kennzahlen: den scheinbaren Widerspruch zwischen Item-Nr. 1000 und ~890 tatsächlichen Items, sowie eine Claude-Queue-Kennzahl, die leicht als Autonomiegrad missverstanden werden konnte. Beide Kennzahlen sind jetzt korrekt beschriftet und erklärt.

## Änderungen

- Neue Kennzahl `discarded_items_count` (höchste vergebene Item-Nr. minus tatsächliche Item-Anzahl) im Meilenstein-Banner: "890 umgesetzt · ~110 bewusst verworfen · 1000 Nummern vergeben", inkl. Tooltip, der klarstellt, dass es sich um verworfene/gelöschte Nummern handelt, nicht um offenen Bestand.
- Die Kachel "Items via Claude-Queue bearbeitet" heißt jetzt "über die (zählbare) Claude-Queue" mit Tooltip: kein Autonomiegrad, sondern nur der messbare Anteil — vor Juli 2026 lief die autonome Umsetzung über GitHub Copilot (eigene Anbindung, nicht in dieser Queue erfasst).
- Die Detailkarte "Autonomie & Erfolgsquote" heißt jetzt "Claude-Queue-Anteil & Erfolgsquote" mit erläuterndem Text zur Copilot-Phase vor Juli 2026.
- Durchsatz-Chart erhält einen gestrichelten Zeit-Marker "ab Juli: Claude Code", der den Werkzeugwechsel sichtbar macht.
- Backend-Variable `autonomy_rate` in `claude_queue_share_pct` umbenannt, um die tatsächliche Bedeutung im Code widerzuspiegeln.
- Test für `discarded_items_count` ergänzt.

## Warum / Entscheidungen

- Nicht als "offene Items" ausgewiesen, weil das den Eindruck von Rückstand statt bewusster Entscheidung erwecken würde; stattdessen explizit "verworfen" benannt, wie im Auftrag gefordert.
- Nicht die Variable `autonomy_rate` beibehalten und nur das Label im Template geändert, weil der irreführende Name sonst im Code weiterlebt und die nächste Änderung wieder denselben Fehlschluss nahelegt.
- Nicht `chartjs-plugin-annotation` nachgezogen, weil dafür ein zusätzliches Skript/CDN-Include nötig gewesen wäre; ein kleines inline Chart.js-Plugin (afterDraw-Hook) reicht für eine einzelne gestrichelte Linie mit Label und vermeidet die zusätzliche Abhängigkeit.
- Nicht den Cutover-Zeitpunkt als weitere Kontext-/Konfigurationsvariable exponiert, weil "Anfang Juli 2026" ein einmaliger historischer Fixpunkt ist, kein sich änderndes Betriebsparameter.

## Test-Hinweise

- `python manage.py test core.test_system_analytics` — alle 6 Tests (inkl. neuem Test für `discarded_items_count`) grün.
- Manuell: `/system-analytics/` aufrufen, Banner-Zeile "X umgesetzt · Y verworfen · Z Nummern vergeben" sowie Tooltip prüfen; KPI-Kachel- und Detailkarten-Beschriftung samt Tooltip zur Claude-Queue prüfen; Durchsatz-Chart auf den gestrichelten "ab Juli: Claude Code"-Marker prüfen.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics presentation and naming only; no auth, payments, or core item workflow changes.
> 
> **Overview**
> **System analytics** now separates *umgesetzt*, *bewusst verworfen*, and *Nummern vergeben* via `discarded_items_count` (max id minus total items), with UI tooltips so gaps are not read as open backlog.
> 
> The Claude-queue KPI is reframed: `autonomy_rate` becomes `claude_queue_share_pct`, labels stress *zählbar* queue share (not full autonomy), and copy notes pre–July 2026 GitHub Copilot work outside the queue.
> 
> The throughput chart adds a dashed **ab Juli: Claude Code** marker at `CLAUDE_QUEUE_CUTOVER_DATE` (2026-07-01) via a small inline Chart.js plugin.
> 
> A regression test asserts `discarded_items_count` when item ids jump above existing totals.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de57296c3f6b9262ec95bbed5ec86d7b995f8db4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->