### PR TITLE
Analytics-Feinschliff (#1000): „Verworfene Issues" als Effizienzsignal ausweisen + Autonomie-Kennzahl richtig einordnen

### DIFF
--- a/templates/system_analytics.html
+++ b/templates/system_analytics.html
@@ -33,9 +33,9 @@
             {% endif %}
             <p class="text-muted mb-0 mt-1">
                 <strong>{{ total_items }}</strong> umgesetzt &middot;
-                <strong>{{ discarded_items_count }}</strong> bewusst verworfen &middot;
+                <strong>{{ discarded_items_count }}</strong> vor Umsetzung verworfen &middot;
                 <strong>{{ highest_item_number }}</strong> Nummern vergeben
-                <i class="bi bi-info-circle ms-1" title="&quot;Verworfen&quot; = Item-Nummern, die vergeben, aber nie umgesetzt wurden (bewusst gelöscht/verworfen) - kein offener Bestand." data-bs-toggle="tooltip"></i>
+                <i class="bi bi-info-circle ms-1" title="Effizienzsignal, kein Ausschuss: in Agira bearbeitet, dann bewusst verworfen (unsinnig / nicht zu Ende gedacht / anderweitig gelöst) - bevor eine KI-Umsetzung angestoßen wurde. Kein offener Bestand, keine Fehlschläge, kein entstandener Aufwand." data-bs-toggle="tooltip"></i>
             </p>
         </div>
         <div class="text-end" style="min-width: 180px;">


### PR DESCRIPTION
Automated draft PR opened by the Claude queue worker for Agira item #1002.

Model: Sonnet
Job: #187

---

## Zusammenfassung

Die im Ticket beschriebenen zwei Unschärfen im Analytics-View (verworfene Issues als Effizienzsignal, Autonomie-Kennzahl-Kontextualisierung) waren bereits vollständig über PR #716 umgesetzt und in `main` gemergt. Dieser Branch schärft ergänzend die Tooltip-Formulierung der „Verworfen"-Kennzahl, damit die im Ticket als Kern bezeichnete Aussage — keine KI-Umsetzung, also kein entstandener Aufwand — auch textlich explizit sichtbar wird.

## Änderungen

- Label im Meilenstein-Banner von „bewusst verworfen" auf „vor Umsetzung verworfen" präzisiert, näher an der im Ticket vorgeschlagenen Formulierung.
- Tooltip der „Verworfen"-Kennzahl erweitert: benennt jetzt explizit, dass verworfene Issues zwar in Agira bearbeitet wurden, aber vor jeder KI-Umsetzung ausgeschieden sind, und grenzt sie ausdrücklich von „offenem Bestand" und „Fehlschlägen" ab.
- Alle übrigen Bestandteile (Berechnung `discarded_items_count` aus ID-Höchststand minus Item-Anzahl, Umbenennung der Claude-Queue-Kennzahl samt Copilot-Hinweis, Zeit-Marker „ab Juli: Claude Code" im Durchsatz-Chart) waren bereits vorhanden und unverändert korrekt.

## Warum / Entscheidungen

- Nicht die gesamte Umsetzung erneut geschrieben, weil die Kernlogik (Berechnung, Kachel-Umbenennung, Chart-Marker) bereits in PR #716 korrekt implementiert und durch Tests abgedeckt war — eine Neuimplementierung hätte unnötige Duplikate erzeugt.
- Nicht bei der bisherigen Tooltip-Formulierung „kein offener Bestand" belassen, weil sie die im Ticket explizit als Kern hervorgehobene Botschaft „keine KI-Umsetzung, kein Aufwand" nicht transportierte — ohne diesen Satz bleibt der Effizienzgewinn implizit statt sichtbar.
- Nicht den Zahlenwert oder die Berechnungslogik angefasst, weil `discarded_items_count = höchste Item-Nr. − Item-Anzahl` bereits korrekt und getestet ist; das Ticket verlangt eine Einordnungs-/Framing-Korrektur, keine Rechenänderung.
- Nicht zusätzlich eine separate KPI-Kachel für „Verworfen" ergänzt, weil die Zahl im Meilenstein-Banner bereits prominent und mit Tooltip ausgewiesen ist und eine zusätzliche Kachel die gleiche Information redundant duplizieren würde.

## Test-Hinweise

- `python manage.py test core.test_system_analytics` — alle 6 Tests grün, inkl. `test_discarded_items_count_reflects_gap_between_highest_id_and_total`.
- Manuell: `/system-analytics` aufrufen, Tooltip auf dem Info-Icon neben „vor Umsetzung verworfen" im Meilenstein-Banner prüfen — Text muss die Copilot/KI-Umsetzung-Abgrenzung enthalten.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only changes in a template tooltip and label; no backend, calculations, or security impact.
> 
> **Overview**
> Sharpens how **discarded item numbers** are framed in the System Analytics milestone banner—text only; counts and `discarded_items_count` logic are unchanged.
> 
> The inline label moves from **„bewusst verworfen“** to **„vor Umsetzung verworfen“**, aligning with the ticket’s wording that these IDs were dropped before implementation.
> 
> The info-icon **tooltip** now states explicitly that this is an **efficiency signal** (worked in Agira, then discarded before any KI/Claude implementation), and distinguishes it from open backlog, failures, and incurred automation cost.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 616cfd535410c04fcc336a75d3967a2f0cc9dd8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->