### PR TITLE
Projekt-Ebene: Kosten je Monat/Jahr summiert anzeigen (Text + Diagramm)

### DIFF
--- a/core/test_project_costs.py
+++ b/core/test_project_costs.py
@@ -1,0 +1,109 @@
+"""
+Tests for the Project Detail "Kosten" tab: Claude-Queue-Kosten je Monat/Jahr (#1003).
+"""
+from decimal import Decimal
+
+from django.test import TestCase, Client
+from django.urls import reverse
+from django.utils import timezone
+
+from core.models import (
+    Item, Project, ItemStatus, ItemType, User,
+    ClaudeQueueJob, ClaudeQueueJobModel,
+)
+
+
+class ProjectCostsTabTest(TestCase):
+    """Test the project-scoped, month/year-grouped Claude Queue cost tab."""
+
+    def setUp(self):
+        self.client = Client()
+
+        self.user = User.objects.create_user(
+            username='testuser',
+            password='testpass123',
+            email='test@example.com',
+        )
+        self.user.name = 'Test User'
+        self.user.active = True
+        self.user.save()
+        self.client.login(username='testuser', password='testpass123')
+
+        self.project = Project.objects.create(name='Test Project')
+        self.item_type = ItemType.objects.create(key='bug', name='Bug', is_active=True)
+        self.item = Item.objects.create(
+            project=self.project,
+            title='Test Item',
+            type=self.item_type,
+            status=ItemStatus.WORKING,
+        )
+
+    def _job(self, cost, created_at=None, item=None):
+        job = ClaudeQueueJob.objects.create(
+            item=item or self.item,
+            project=self.project,
+            model=ClaudeQueueJobModel.SONNET,
+            total_cost_usd=cost,
+        )
+        if created_at is not None:
+            ClaudeQueueJob.objects.filter(pk=job.pk).update(created_at=created_at)
+        return job
+
+    def test_no_jobs_shows_empty_state(self):
+        response = self.client.get(reverse('project-costs-tab', args=[self.project.id]))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context['cost_by_month'], [])
+        self.assertEqual(response.context['total_cost'], Decimal('0'))
+        self.assertContains(response, 'noch keine Claude-Queue-Kosten')
+
+    def test_jobs_grouped_by_month_and_sorted_chronologically(self):
+        self._job(Decimal('1.000000'), created_at=timezone.datetime(2026, 7, 15, tzinfo=timezone.get_current_timezone()))
+        self._job(Decimal('2.000000'), created_at=timezone.datetime(2026, 7, 20, tzinfo=timezone.get_current_timezone()))
+        self._job(Decimal('4.000000'), created_at=timezone.datetime(2026, 8, 1, tzinfo=timezone.get_current_timezone()))
+
+        response = self.client.get(reverse('project-costs-tab', args=[self.project.id]))
+
+        self.assertEqual(response.status_code, 200)
+        rows = response.context['cost_by_month']
+        self.assertEqual([r['label'] for r in rows], ['07/2026', '08/2026'])
+        self.assertEqual(rows[0]['total'], Decimal('3.000000'))
+        self.assertEqual(rows[0]['count'], 2)
+        self.assertEqual(rows[1]['total'], Decimal('4.000000'))
+        self.assertEqual(response.context['total_cost'], Decimal('7.000000'))
+        self.assertEqual(response.context['total_jobs'], 3)
+
+    def test_jobs_without_cost_do_not_break_the_sum(self):
+        self._job(Decimal('1.500000'), created_at=timezone.datetime(2026, 7, 15, tzinfo=timezone.get_current_timezone()))
+        self._job(None, created_at=timezone.datetime(2026, 7, 20, tzinfo=timezone.get_current_timezone()))
+
+        response = self.client.get(reverse('project-costs-tab', args=[self.project.id]))
+
+        self.assertEqual(response.status_code, 200)
+        rows = response.context['cost_by_month']
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]['total'], Decimal('1.500000'))
+        self.assertEqual(rows[0]['count'], 2)
+
+    def test_costs_from_other_projects_are_not_included(self):
+        other_project = Project.objects.create(name='Other Project')
+        other_item = Item.objects.create(
+            project=other_project,
+            title='Other Item',
+            type=self.item_type,
+            status=ItemStatus.WORKING,
+        )
+        self._job(Decimal('9.999999'), item=other_item)
+
+        response = self.client.get(reverse('project-costs-tab', args=[self.project.id]))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context['cost_by_month'], [])
+        self.assertEqual(response.context['total_cost'], Decimal('0'))
+
+    def test_project_detail_page_includes_costs_tab(self):
+        response = self.client.get(reverse('project-detail', args=[self.project.id]))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'Kosten')
+        self.assertContains(response, reverse('project-costs-tab', args=[self.project.id]))

--- a/core/urls.py
+++ b/core/urls.py
@@ -44,6 +44,7 @@ urlpatterns = [
     path('releases/<int:release_id>/create-change/', views.release_create_change, name='release-create-change'),
     path('projects/<int:id>/items/tab/', views.project_items_tab, name='project-items-tab'),
     path('projects/<int:id>/attachments/tab/', views.project_attachments_tab, name='project-attachments-tab'),
+    path('projects/<int:id>/costs/tab/', views.project_costs_tab, name='project-costs-tab'),
     path('projects/<int:id>/upload-attachment/', views.project_upload_attachment, name='project-upload-attachment'),
     path('projects/attachments/<int:attachment_id>/delete/', views.project_delete_attachment, name='project-delete-attachment'),
     path('projects/attachments/<int:attachment_id>/view/', views.project_view_attachment, name='project-view-attachment'),

--- a/core/views.py
+++ b/core/views.py
@@ -5852,7 +5852,54 @@ def project_attachments_tab(request, id):
 
 
 @login_required
+def project_costs_tab(request, id):
+    """Return the project costs tab: Claude-Queue-Kosten je Monat/Jahr (#1003).
 
+    Summiert total_cost_usd (Claudes eigene Schätzung, siehe #997) aller
+    ClaudeQueueJobs der Items dieses Projekts, gruppiert nach Monat der
+    Job-Erstellung (created_at - das einzige durchgängig verlässliche Datum).
+    DB-seitig aggregiert, keine Pro-Job-Berechnung in Python.
+    """
+    from django.db.models.functions import TruncMonth
+
+    project = get_object_or_404(Project, id=id)
+
+    cost_by_month_qs = (
+        ClaudeQueueJob.objects.filter(item__project=project)
+        .annotate(month=TruncMonth('created_at'))
+        .values('month')
+        .annotate(total=models.Sum('total_cost_usd'), n=Count('id'))
+        .order_by('month')
+    )
+    cost_by_month = [
+        {
+            'label': row['month'].strftime('%m/%Y'),
+            'total': row['total'] or Decimal('0'),
+            'count': row['n'],
+            'avg': (row['total'] / row['n']) if row['total'] and row['n'] else None,
+        }
+        for row in cost_by_month_qs
+    ]
+
+    total_cost = sum((row['total'] for row in cost_by_month), Decimal('0'))
+    total_jobs = sum(row['count'] for row in cost_by_month)
+
+    cost_chart_json = json.dumps({
+        'labels': [row['label'] for row in cost_by_month],
+        'data': [float(row['total']) for row in cost_by_month],
+    })
+
+    context = {
+        'project': project,
+        'cost_by_month': cost_by_month,
+        'total_cost': total_cost,
+        'total_jobs': total_jobs,
+        'cost_chart_json': cost_chart_json,
+    }
+    return render(request, 'partials/project_costs_tab.html', context)
+
+
+@login_required
 @require_POST
 def project_upload_attachment(request, id):
     """Upload an attachment to a project."""

--- a/templates/partials/project_costs_tab.html
+++ b/templates/partials/project_costs_tab.html
@@ -1,0 +1,79 @@
+{% load agira_filters %}
+<div class="card">
+    <div class="card-header">
+        <h5 class="mb-0">Claude-Queue-Kosten je Monat</h5>
+    </div>
+    <div class="card-body">
+        {% if cost_by_month %}
+        <div class="mb-4">
+            <canvas id="projectCostChart" style="max-height: 280px;"></canvas>
+        </div>
+
+        <div class="table-responsive">
+            <table class="table table-hover table-sm mb-0">
+                <thead class="table-light">
+                    <tr>
+                        <th>Monat/Jahr</th>
+                        <th class="text-end">Jobs</th>
+                        <th class="text-end">Summe (US$)</th>
+                        <th class="text-end">Ø je Job (US$)</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for row in cost_by_month %}
+                    <tr>
+                        <td>{{ row.label }}</td>
+                        <td class="text-end">{{ row.count }}</td>
+                        <td class="text-end">${{ row.total|floatformat:4 }}</td>
+                        <td class="text-end">{% if row.avg is not None %}${{ row.avg|floatformat:4 }}{% else %}&mdash;{% endif %}</td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+                <tfoot>
+                    <tr>
+                        <td><strong>Gesamt</strong></td>
+                        <td class="text-end"><strong>{{ total_jobs }}</strong></td>
+                        <td class="text-end"><strong>${{ total_cost|floatformat:4 }}</strong></td>
+                        <td class="text-end"></td>
+                    </tr>
+                </tfoot>
+            </table>
+        </div>
+        <p class="text-muted small mt-2 mb-0">
+            Basiert auf <code>total_cost_usd</code> je Claude-Queue-Job (Claudes eigene Kostenschätzung, API-Listenpreis)
+            &mdash; keine Neuberechnung. Gruppierung nach Erstellungsdatum (<code>created_at</code>) des Jobs.
+        </p>
+
+        <script>
+        (function() {
+            const ctx = document.getElementById('projectCostChart');
+            if (!ctx) return;
+            const data = {{ cost_chart_json|safe }};
+            new Chart(ctx, {
+                type: 'bar',
+                data: {
+                    labels: data.labels,
+                    datasets: [{
+                        label: 'Kosten (US$, geschätzt)',
+                        data: data.data,
+                        backgroundColor: 'rgba(13, 202, 240, 0.6)',
+                        borderColor: 'rgba(13, 202, 240, 1)',
+                        borderWidth: 1,
+                    }]
+                },
+                options: {
+                    responsive: true,
+                    maintainAspectRatio: true,
+                    plugins: { legend: { display: false } },
+                    scales: { y: { beginAtZero: true } }
+                }
+            });
+        })();
+        </script>
+        {% else %}
+        <div class="alert alert-info mb-0">
+            Für dieses Projekt liegen noch keine Claude-Queue-Kosten vor.
+        </div>
+        {% endif %}
+    </div>
+</div>

--- a/templates/project_detail.html
+++ b/templates/project_detail.html
@@ -4,6 +4,7 @@
 {% block title %}{{ project.name }} - Agira{% endblock %}
 
 {% block extra_head %}
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 <!-- Markdown Viewer Styles -->
 <style>
 .markdown-viewer {
@@ -193,6 +194,11 @@
             <li class="nav-item" role="presentation">
                 <button class="nav-link" id="attachments-tab" data-bs-toggle="tab" data-bs-target="#project-attachments" type="button" role="tab" aria-controls="project-attachments">
                     Attachments <span class="badge bg-secondary">{{ attachments_count }}</span>
+                </button>
+            </li>
+            <li class="nav-item" role="presentation">
+                <button class="nav-link" id="costs-tab" data-bs-toggle="tab" data-bs-target="#project-costs" type="button" role="tab" aria-controls="project-costs">
+                    Kosten
                 </button>
             </li>
         </ul>
@@ -405,6 +411,19 @@
                     </div>
                 </div>
             </div>
+
+            <!-- Costs Tab -->
+            <div class="tab-pane fade" id="project-costs" role="tabpanel" aria-labelledby="costs-tab"
+                 hx-get="{% url 'project-costs-tab' project.id %}"
+                 hx-trigger="load once"
+                 hx-swap="innerHTML">
+                <!-- Content will be loaded via HTMX -->
+                <div class="text-center py-4">
+                    <div class="spinner-border text-primary" role="status">
+                        <span class="visually-hidden">Loading...</span>
+                    </div>
+                </div>
+            </div>
         </div>
     </div>
 
@@ -576,7 +595,7 @@ function applyItemsFiltersFromStorage(event) {
     const storageKey = 'projectDetail.activeTab.{{ project.id|escapejs }}';
     
     // List of valid tab IDs for this view
-    const validTabIds = ['items-tab', 'nodes-tab', 'releases-tab', 'clients-tab', 'attachments-tab'];
+    const validTabIds = ['items-tab', 'nodes-tab', 'releases-tab', 'clients-tab', 'attachments-tab', 'costs-tab'];
     
     // Restore active tab on page load
     function restoreActiveTab() {


### PR DESCRIPTION
Automated draft PR opened by the Claude queue worker for Agira item #1003.

Model: Sonnet
Job: #189

---

## Zusammenfassung

- Neuer Tab "Kosten" im Projekt-DetailView zeigt die Claude-Queue-Kosten des Projekts, gruppiert nach Monat/Jahr, als Tabelle und als Balkendiagramm.
- Die Aggregation läuft DB-seitig über `ClaudeQueueJob.total_cost_usd`, gescoped auf die Items des jeweiligen Projekts.

## Änderungen

- `core/views.py`: neue View `project_costs_tab` — summiert `total_cost_usd` und zählt Jobs je Monat via `TruncMonth('created_at')` + `Sum`/`Count`, chronologisch sortiert; liefert zusätzlich Gesamtsumme, Gesamt-Jobanzahl und JSON-Daten fürs Diagramm.
- `core/urls.py`: neue Route `projects/<id>/costs/tab/` (`project-costs-tab`) für den per HTMX lazy geladenen Tab-Inhalt.
- `templates/project_detail.html`: neuer Tab-Button "Kosten" + Tab-Pane (HTMX `load once`, gleiches Muster wie Items-/Attachments-Tab), Chart.js-Script im `extra_head`-Block ergänzt, Tab-ID in die Persistenz-Liste (`validTabIds`) aufgenommen.
- `templates/partials/project_costs_tab.html`: neues Partial mit Tabelle (Monat/Jahr, Jobs, Summe, Ø je Job, Fußzeile mit Gesamtsumme), Balkendiagramm (Chart.js) und Leerzustand für Projekte ohne Jobs; Kennzeichnung als "geschätzt, API-Listenpreis".
- `core/test_project_costs.py`: neue Tests für Gruppierung/Sortierung, Nullkosten-Jobs, Projekt-Scoping und Einbindung des Tabs in die Detailseite.

## Warum / Entscheidungen

- Zeitbasis ist ausschließlich `created_at`, wie in der Vorgabe verlangt — nicht `started_at`/`finished_at`, weil diese nicht bei jedem Job zuverlässig gesetzt sind.
- Die Aggregation erfolgt als eigener, gescopeter HTMX-Tab-Endpunkt statt Erweiterung des Haupt-`project_detail`-Views, weil das Projekt bereits mehrere Tabs nach diesem Lazy-Load-Muster lädt (Items, Attachments) und so die initiale Seitenlast nicht durch eine zusätzliche Aggregat-Query wächst, wenn der Tab nie geöffnet wird.
- Nicht die system-weite #1000-Analytics-Seite um einen Projektfilter erweitert, weil die Anforderung explizit Projekt-Scope im Projekt-DetailView verlangt und die #1000-Seite bewusst system-weit bleiben soll.
- Nicht `total_cost_usd` neu berechnet oder auf Item-Ebene (#997) erneut aggregiert, sondern direkt über `ClaudeQueueJob.objects.filter(item__project=...)` summiert, weil das dieselbe Kostenquelle wie #997/#1000 ist und eine Neuberechnung eine zusätzliche, potenziell abweichende Fehlerquelle wäre.
- Chart.js wird als externes Script im `extra_head`-Block der vollen Projektseite geladen (nicht als `<script src>` im HTMX-Partial selbst), weil verlässlich nur inline `<script>`-Blöcke in geswapptem HTMX-Content ausgeführt werden; das Diagramm-Setup selbst liegt als Inline-Script im Partial.

## Test-Hinweise

- `python manage.py test core.test_project_costs` — neue Tests: leerer Zustand, Monatsgruppierung/-sortierung, Jobs ohne Kosten, Projekt-Scoping, Tab-Einbindung in der Detailseite.
- `python manage.py test core.test_item_detail.ItemDetailClaudeCostAggregationTest` — bestehende #997-Tests weiterhin grün, keine Regression an der Item-Ebene.
- Manuell: Projekt-DetailView öffnen → Tab "Kosten" → Tabelle und Balkendiagramm prüfen; Projekt ohne Claude-Queue-Jobs zeigt Leerzustand ohne Fehler.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only reporting UI and a scoped aggregate query; no changes to billing, auth, or job processing.
> 
> **Overview**
> Adds a **Kosten** tab on project detail that shows Claude queue spend for that project only, grouped by month/year (`created_at`), as a table and bar chart.
> 
> A new lazy-loaded HTMX endpoint `project_costs_tab` aggregates `ClaudeQueueJob.total_cost_usd` in the database (`TruncMonth`, `Sum`, `Count`) for jobs on the project’s items—no per-job Python rollups. The partial renders month labels, job counts, sums, averages, totals, and an empty state; Chart.js is loaded on the main project page while chart setup runs inline in the swapped partial.
> 
> `project_detail.html` gains the tab button, pane, and `costs-tab` in tab persistence. **`core/test_project_costs.py`** covers empty state, grouping/sorting, null costs, cross-project isolation, and tab wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e005aeb509d15426f763c7dcd9b3a0e4bff7b0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->