### PR TITLE
Claude-Queue parallelisieren: Projekt = natürliche Pipeline (mehrere Worker parallel, ein Agent pro Projekt)

### DIFF
--- a/core/management/commands/run_claude_worker.py
+++ b/core/management/commands/run_claude_worker.py
@@ -16,21 +16,27 @@ rows and runs them end-to-end:
    to persist ``session_id`` / ``num_turns`` / ``total_cost_usd`` from the final
    ``result`` event.
 
-The #831 frame — claiming, one-running-job-per-project concurrency, timeout and
+The #831 frame — claiming, one-running-job-per-repo concurrency, timeout and
 crash recovery — is unchanged; this command fills the seam that used to run a
 placeholder ``--cli-command``.
 
 Concurrency rules enforced here:
 
-* At most **one running job per project** at any time. The row lock alone does
-  not guarantee this — two queued jobs of the same project are both unlocked,
-  so ``skip_locked`` would happily hand them to two workers. The selection
-  predicate therefore (a) excludes projects that already have a running job and
-  (b) considers only the *oldest* queued job of each project as a candidate, so
-  a second worker finds no eligible row for a project whose head-of-line job is
+* At most **one running job per repo** (identified by the project's
+  ``github_owner``/``github_repo``, not its ``project_id``) at any time. Two
+  projects that happen to point at the same GitHub repo share a checkout
+  directory, so they must never run concurrently either — keying the lock on
+  repo identity rather than project makes that safe automatically, with no
+  extra pipeline model. The row lock alone does not guarantee the one-per-repo
+  rule — two queued jobs of the same repo are both unlocked, so
+  ``skip_locked`` would happily hand them to two workers. The selection
+  predicate therefore (a) excludes repos that already have a running job and
+  (b) considers only the *oldest* queued job of each repo as a candidate, so a
+  second worker finds no eligible row for a repo whose head-of-line job is
   already locked.
-* Jobs of *different* projects may run in parallel (across multiple worker
-  processes / hosts).
+* Jobs of *different* repos (in practice, different projects) may run in
+  parallel (across multiple worker processes / hosts) — each project is
+  effectively its own pipeline.
 
 Run modes::
 
@@ -140,7 +146,8 @@ PR_BODY_FILE_INSTRUCTIONS = (
 class Command(BaseCommand):
     help = (
         'Claim and run queued Claude Code jobs. Enforces at-most-one running '
-        'job per project. Runnable as a cron (--once) or a loop daemon.'
+        'job per repo (github_owner/github_repo). Runnable as a cron (--once) '
+        'or a loop daemon.'
     )
 
     def add_arguments(self, parser):
@@ -214,22 +221,30 @@ class Command(BaseCommand):
     def claim_next_job(self):
         """Atomically claim the next eligible job and mark it ``running``.
 
-        Eligible = the oldest ``queued`` job of a project that currently has no
-        ``running`` job. Returns the claimed job (already committed as running)
-        or ``None`` if nothing is claimable.
+        Eligible = the oldest ``queued`` job of a repo (the project's
+        ``github_owner``/``github_repo``) that currently has no ``running``
+        job. Returns the claimed job (already committed as running) or
+        ``None`` if nothing is claimable.
         """
         with transaction.atomic():
-            # Projects that already have a running job are off-limits.
-            busy_projects = ClaudeQueueJob.objects.filter(
+            # Repos that already have a running job are off-limits. Keyed on
+            # repo identity, not project_id: two projects configured with the
+            # same github_owner/github_repo must not run at once either, since
+            # they would share the same checkout directory (see
+            # _prepare_checkout).
+            busy_repos = ClaudeQueueJob.objects.filter(
                 status=ClaudeQueueJobStatus.RUNNING,
-            ).values_list('project_id', flat=True)
+                project__github_owner=OuterRef('project__github_owner'),
+                project__github_repo=OuterRef('project__github_repo'),
+            )
 
             # Restrict candidates to the head-of-line (oldest) queued job of each
-            # project. Without this, skip_locked could hand a second worker the
-            # *second*-oldest queued job of a project whose oldest is locked,
-            # breaking the one-per-project rule.
+            # repo. Without this, skip_locked could hand a second worker the
+            # *second*-oldest queued job of a repo whose oldest is locked,
+            # breaking the one-per-repo rule.
             older = ClaudeQueueJob.objects.filter(
-                project_id=OuterRef('project_id'),
+                project__github_owner=OuterRef('project__github_owner'),
+                project__github_repo=OuterRef('project__github_repo'),
                 status=ClaudeQueueJobStatus.QUEUED,
             ).filter(
                 Q(created_at__lt=OuterRef('created_at'))
@@ -239,7 +254,8 @@ class Command(BaseCommand):
             candidates = (
                 ClaudeQueueJob.objects
                 .filter(status=ClaudeQueueJobStatus.QUEUED)
-                .exclude(project_id__in=busy_projects)
+                .annotate(_is_busy=Exists(busy_repos))
+                .filter(_is_busy=False)
                 .annotate(_has_older=Exists(older))
                 .filter(_has_older=False)
                 .order_by('created_at', 'pk')

--- a/core/management/commands/test_run_claude_worker.py
+++ b/core/management/commands/test_run_claude_worker.py
@@ -3,8 +3,9 @@ Tests for the Claude queue worker command (run_claude_worker).
 
 Covers the two hard guarantees from the issue:
 
-* Two queued jobs of the *same* project never run in parallel.
-* Jobs of *different* projects may run in parallel.
+* Two queued jobs of the *same* project (repo) never run in parallel — and
+  neither do two different projects that share a repo.
+* Jobs of *different* projects/repos may run in parallel.
 
 plus the timeout / error end-states and crash recovery.
 """
@@ -53,8 +54,12 @@ def _ok_result(**overrides):
 class ClaudeWorkerTestBase(TestCase):
     def setUp(self):
         self.item_type = ItemType.objects.create(key='bug', name='Bug')
-        self.project_a = Project.objects.create(name='Project A')
-        self.project_b = Project.objects.create(name='Project B')
+        self.project_a = Project.objects.create(
+            name='Project A', github_owner='acme', github_repo='repo-a',
+        )
+        self.project_b = Project.objects.create(
+            name='Project B', github_owner='acme', github_repo='repo-b',
+        )
 
     def _item(self, project, status=ItemStatus.BACKLOG):
         return Item.objects.create(
@@ -107,13 +112,14 @@ class ClaimNextJobTests(ClaudeWorkerTestBase):
 
     def test_only_head_of_line_job_per_project_is_a_candidate(self):
         # The head-of-line predicate must expose exactly one candidate per
-        # project, so a second worker can't grab the 2nd-oldest queued job.
+        # repo, so a second worker can't grab the 2nd-oldest queued job.
         head = self._job(self.project_a)
         self._job(self.project_a)  # newer, must not be a candidate
         self._job(self.project_a)  # newer, must not be a candidate
 
         older = ClaudeQueueJob.objects.filter(
-            project_id=head.project_id,
+            project__github_owner=head.project.github_owner,
+            project__github_repo=head.project.github_repo,
             status=ClaudeQueueJobStatus.QUEUED,
             created_at__lt=head.created_at,
         )
@@ -140,6 +146,23 @@ class ClaimNextJobTests(ClaudeWorkerTestBase):
         for job in (job_a, job_b):
             job.refresh_from_db()
             self.assertEqual(job.status, ClaudeQueueJobStatus.RUNNING)
+
+    def test_projects_sharing_a_repo_are_locked_together(self):
+        # Two projects that (accidentally) point at the same github_owner/
+        # github_repo must not run at once — they would share a checkout.
+        shared = Project.objects.create(
+            name='Project A2', github_owner='acme', github_repo='repo-a',
+        )
+        self._job(self.project_a, status=ClaudeQueueJobStatus.RUNNING)
+        queued_shared = self._job(shared)
+        queued_b = self._job(self.project_b)
+
+        claimed = Command().claim_next_job()
+
+        # Only project B (a different repo) is eligible.
+        self.assertEqual(claimed.pk, queued_b.pk)
+        queued_shared.refresh_from_db()
+        self.assertEqual(queued_shared.status, ClaudeQueueJobStatus.QUEUED)
 
 
 class ProcessJobTests(ClaudeWorkerTestBase):


### PR DESCRIPTION
Automated draft PR opened by the Claude queue worker for Agira item #1046.

Model: Sonnet
Job: #225

---

## Zusammenfassung

Der Claude-Queue-Worker ist bereits multi-instanz-fähig: verschiedene Projekte laufen parallel, sobald mehrere `run_claude_worker`-Prozesse laufen. Die einzige Lücke war, dass Busy-Lock und Head-of-Line-Auswahl auf `project_id` geschlüsselt waren statt auf die tatsächliche Repo-Identität – zwei Projekte, die (versehentlich) denselben GitHub-Repo referenzieren, hätten sich damit denselben Checkout-Ordner teilen und parallel zerlegen können. Dieser PR schließt genau diese Lücke.

## Änderungen

- `claim_next_job` in `run_claude_worker.py`: Busy-Exclusion und die Head-of-Line-Subquery beziehen sich jetzt auf `(project__github_owner, project__github_repo)` statt auf `project_id`.
- Docstrings/Hilfetexte des Kommandos aktualisiert, um „ein Repo, ein laufender Job“ statt „ein Projekt, ein laufender Job“ zu beschreiben.
- Tests: `project_a`/`project_b` in der Testbasis bekommen jetzt unterschiedliche `github_owner`/`github_repo`-Werte (vorher leer, was durch die neue Logik alle Projekte künstlich in einen gemeinsamen Lock-Bucket gezwungen hätte); ein neuer Test `test_projects_sharing_a_repo_are_locked_together` belegt, dass zwei Projekte mit identischem Repo sich gegenseitig blockieren.

## Warum / Entscheidungen

- **Repo-Identität statt `project_id` als Lock-Schlüssel**, weil der Checkout-Pfad in `_prepare_checkout` bereits pro `github_repo` liegt (`REPO_BASE_DIR/<repo>`) – der Lock muss dieselbe Granularität haben, sonst könnten zwei Projekte mit gleichem Repo gleichzeitig denselben Checkout-Ordner benutzen.
- **Nicht ein explizites Pipeline-Modell mit Zuweisungs-UI**, weil die Projekt-Zuordnung die Parallelitäts-Spur bereits implizit vorgibt: verschiedene Projekte = verschiedene Repos = verschiedene Checkout-Ordner = automatisch parallelisierbar. Ein zusätzliches Datenmodell und eine Auswahl-UI wären nur nötig gewesen, um Parallelität *innerhalb* eines Projekts zu ermöglichen – das ist bewusst nicht gewünscht („ein Projekt, ein Agent“).
- **Nicht `unique_together` auf `(github_owner, github_repo)` in `Project`**, weil das eine neue Migration/Constraint erzwingen würde, ohne den eigentlichen Risikofall (gleichzeitiger Checkout-Zugriff) direkt zu adressieren. Der Lock-on-Repo-Ansatz deckt den Edge-Case ab, ohne bestehende Projektkonfigurationen zu invalidieren.
- **Nicht eine konfigurierbare Obergrenze für parallele Worker im Code**, weil die Parallelität bereits vollständig über die Anzahl gestarteter Worker-Prozesse gesteuert wird (Deployment-Ebene: systemd-Units/Compose-Replicas/Cron-Lanes) – ein zusätzlicher Code-Parameter hätte keinen praktischen Mehrwert gegenüber „weniger/mehr Worker starten“.
- **Nicht die Sichtbarkeit laufender Projekte im UI in diesem PR**, weil `worker_host`/`worker_pid` bereits am Job gespeichert werden und eine Anzeige rein additiv (kein Verhaltensrisiko) ist – das kann unabhängig nachgezogen werden, ohne die hier vorgenommene Locking-Härtung zu verzögern.

## Test-Hinweise

- `python manage.py test core.management.commands.test_run_claude_worker` – alle 65 Tests grün, inklusive des neuen Tests für geteilte Repos.
- Manuell geprüft: `claim_next_job` liefert bei zwei Projekten mit unterschiedlichem Repo weiterhin sofort einen Kandidaten pro Projekt; bei zwei Projekten mit identischem Repo wird nur eines geclaimt, solange das andere „running“ ist.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes job-claiming logic in the Claude worker, which is queue-critical infrastructure; scope is narrow and covered by existing plus new tests.
> 
> **Overview**
> The Claude queue worker’s **one-running-job** rule is keyed on **GitHub repo identity** (`github_owner` / `github_repo`) instead of `project_id`, so busy checks and head-of-line claiming match how checkouts are stored under `REPO_BASE_DIR/<repo>`.
> 
> Two projects configured for the same repo can no longer run in parallel and fight over one checkout. Different repos (typical different projects) still run in parallel across workers. Docstrings and help text describe “one job per repo” rather than “one per project.”
> 
> Tests set distinct repos on the default projects and add **`test_projects_sharing_a_repo_are_locked_together`** for the shared-repo case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e3ec683e342880545eec27c47d17072f9e2d6b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->