### PR TITLE
Claude-Queue-Listview via HTMX selbst-aktualisieren (neue/entfernte Jobs + Kacheln), ohne Reload

### DIFF
--- a/core/test_claude_queue_views.py
+++ b/core/test_claude_queue_views.py
@@ -159,6 +159,51 @@ class ClaudeQueueViewsTestCase(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, 'Fix the auth bug')
 
+    # ---- list auto-refresh (container-level polling) --------------------
+
+    def test_list_kpis_carry_polling_attributes(self):
+        self.client.login(username='testuser', password='testpass123')
+        response = self.client.get(reverse('claude-queue-jobs'))
+        self.assertContains(response, 'id="claude-queue-kpis"')
+        self.assertContains(response, 'hx-trigger="every 5s"')
+
+    def test_list_table_carries_oob_attribute_not_its_own_poll(self):
+        self.client.login(username='testuser', password='testpass123')
+        response = self.client.get(reverse('claude-queue-jobs'))
+        self.assertContains(response, 'id="claude-queue-table"')
+        self.assertContains(response, 'hx-swap-oob="true"')
+
+    def test_list_rows_do_not_carry_their_own_polling(self):
+        self.client.login(username='testuser', password='testpass123')
+        job = self._running_job()
+        response = self.client.get(reverse('claude-queue-jobs'))
+        # The container already polls every 5s; a per-row hx-get would poll
+        # the same data a second time.
+        self.assertNotContains(response, reverse('claude-queue-job-row', args=[job.id]))
+
+    def test_list_htmx_request_returns_kpis_and_table_fragment_only(self):
+        self.client.login(username='testuser', password='testpass123')
+        self._running_job()
+        response = self.client.get(reverse('claude-queue-jobs'), HTTP_HX_REQUEST='true')
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'id="claude-queue-kpis"')
+        self.assertContains(response, 'id="claude-queue-table"')
+        self.assertContains(response, 'Fix the auth bug')
+        # No full page chrome on a poll response.
+        self.assertNotContains(response, '<h1>Claude Queue</h1>')
+        self.assertNotContains(response, 'id="queueChart"')
+
+    def test_list_poll_url_preserves_active_filters(self):
+        self.client.login(username='testuser', password='testpass123')
+        self._running_job()
+        response = self.client.get(
+            reverse('claude-queue-jobs'),
+            {'project': self.project.id, 'status': ClaudeQueueJobStatus.RUNNING},
+        )
+        content = response.content.decode()
+        self.assertIn(f'project={self.project.id}', content)
+        self.assertIn(f'status={ClaudeQueueJobStatus.RUNNING}', content)
+
     # ---- row partial (list polling) -----------------------------------
 
     def test_row_active_job_has_polling_attributes(self):

--- a/core/views.py
+++ b/core/views.py
@@ -832,7 +832,13 @@ def _claude_queue_dashboard_context():
 
 @login_required
 def claude_queue_jobs(request):
-    """List view of all Claude queue jobs with project/status filters."""
+    """List view of all Claude queue jobs with project/status filters.
+
+    The dashboard tiles and job table are wrapped in a self-polling HTMX
+    fragment (partials/claude_queue_list.html) so new/finished jobs and the
+    KPI counters stay current without a manual reload. On an HTMX poll only
+    that fragment is re-rendered instead of the full page.
+    """
     jobs = ClaudeQueueJob.objects.select_related(
         'item', 'project'
     ).order_by('-created_at')
@@ -860,6 +866,8 @@ def claude_queue_jobs(request):
         'selected_status': status_filter,
     }
     context.update(_claude_queue_dashboard_context())
+    if request.headers.get('HX-Request'):
+        return render(request, 'partials/claude_queue_list.html', context)
     return render(request, 'claude_queue_jobs.html', context)
 
 

--- a/templates/claude_queue_jobs.html
+++ b/templates/claude_queue_jobs.html
@@ -16,49 +16,7 @@
     </div>
 </div>
 
-<!-- Mini Dashboard -->
-<div class="row g-3 mb-3">
-    <div class="col-md-3 col-6">
-        <div class="kpi-card">
-            <div class="kpi-icon"><i class="bi bi-list-check"></i></div>
-            <div class="kpi-content">
-                <div class="kpi-value">{{ queue_total_jobs }}</div>
-                <div class="kpi-label">Jobs</div>
-            </div>
-        </div>
-    </div>
-    <div class="col-md-3 col-6">
-        <div class="kpi-card">
-            <div class="kpi-icon"><i class="bi bi-stopwatch"></i></div>
-            <div class="kpi-content">
-                <div class="kpi-value">{{ queue_avg_duration_display|default:"–" }}</div>
-                <div class="kpi-label">Ø Dauer</div>
-            </div>
-        </div>
-    </div>
-    <div class="col-md-3 col-6">
-        <div class="kpi-card">
-            <div class="kpi-icon"><i class="bi bi-currency-dollar"></i></div>
-            <div class="kpi-content">
-                <div class="kpi-value">
-                    {% if queue_avg_cost is not None %}US${{ queue_avg_cost|floatformat:2 }}{% else %}–{% endif %}
-                </div>
-                <div class="kpi-label">Ø Kosten</div>
-            </div>
-        </div>
-    </div>
-    <div class="col-md-3 col-6">
-        <div class="kpi-card">
-            <div class="kpi-icon"><i class="bi bi-arrow-repeat"></i></div>
-            <div class="kpi-content">
-                <div class="kpi-value">
-                    {% if queue_avg_turns is not None %}{{ queue_avg_turns|floatformat:0 }}{% else %}–{% endif %}
-                </div>
-                <div class="kpi-label">Ø Turns</div>
-            </div>
-        </div>
-    </div>
-</div>
+{% include 'partials/claude_queue_kpis.html' %}
 
 <div class="row g-3 mb-4">
     <div class="col-12">
@@ -104,71 +62,7 @@
     </form>
 </div>
 
-<!-- Jobs Table -->
-<div class="card">
-    <div class="card-body p-0">
-        <div class="table-responsive">
-            <table class="table table-hover mb-0">
-                <thead>
-                    <tr>
-                        <th>#</th>
-                        <th>Item</th>
-                        <th>Project</th>
-                        <th>Status</th>
-                        <th>Current step</th>
-                        <th>PR</th>
-                        <th>Turns / Cost</th>
-                        <th>Created</th>
-                        <th>Actions</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    {% for job in jobs %}
-                    {% include 'partials/claude_queue_job_row.html' %}
-                    {% empty %}
-                    <tr>
-                        <td colspan="9" class="text-center text-muted py-4">No queue jobs found.</td>
-                    </tr>
-                    {% endfor %}
-                </tbody>
-            </table>
-        </div>
-
-        <!-- Pagination Controls -->
-        {% if page_obj.has_other_pages %}
-        <nav aria-label="Page navigation" class="mt-3 pb-3 px-3">
-            <ul class="pagination justify-content-center">
-                {% if page_obj.has_previous %}
-                <li class="page-item">
-                    <a class="page-link" href="?page=1{% if selected_project %}&project={{ selected_project }}{% endif %}{% if selected_status %}&status={{ selected_status }}{% endif %}">First</a>
-                </li>
-                <li class="page-item">
-                    <a class="page-link" href="?page={{ page_obj.previous_page_number }}{% if selected_project %}&project={{ selected_project }}{% endif %}{% if selected_status %}&status={{ selected_status }}{% endif %}">Previous</a>
-                </li>
-                {% endif %}
-
-                <li class="page-item active">
-                    <span class="page-link">
-                        Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}
-                    </span>
-                </li>
-
-                {% if page_obj.has_next %}
-                <li class="page-item">
-                    <a class="page-link" href="?page={{ page_obj.next_page_number }}{% if selected_project %}&project={{ selected_project }}{% endif %}{% if selected_status %}&status={{ selected_status }}{% endif %}">Next</a>
-                </li>
-                <li class="page-item">
-                    <a class="page-link" href="?page={{ page_obj.paginator.num_pages }}{% if selected_project %}&project={{ selected_project }}{% endif %}{% if selected_status %}&status={{ selected_status }}{% endif %}">Last</a>
-                </li>
-                {% endif %}
-            </ul>
-            <div class="text-center text-muted">
-                <small>Showing {{ page_obj.start_index }} to {{ page_obj.end_index }} of {{ page_obj.paginator.count }} jobs</small>
-            </div>
-        </nav>
-        {% endif %}
-    </div>
-</div>
+{% include 'partials/claude_queue_table.html' %}
 {% endblock %}
 
 {% block extra_js %}

--- a/templates/partials/claude_queue_job_row.html
+++ b/templates/partials/claude_queue_job_row.html
@@ -3,12 +3,14 @@
 One table row for a ClaudeQueueJob. While the job is still active it carries
 HTMX polling attributes and refreshes itself every few seconds; once it reaches
 a terminal state the swapped-in row omits those attributes and polling stops.
-Expects `job` and `active_statuses` in context.
+Expects `job` and `active_statuses` in context. Pass `disable_row_polling=True`
+when the row is embedded in a container that already polls itself (the
+/claude-queue/ list) to avoid polling the same data twice.
 {% endcomment %}
 <tr id="cqj-row-{{ job.id }}"
     style="cursor: pointer;"
     onclick="window.location='{% url 'claude-queue-job-detail' job.id %}'"
-    {% if job.status in active_statuses %}
+    {% if job.status in active_statuses and not disable_row_polling %}
     hx-get="{% url 'claude-queue-job-row' job.id %}"
     hx-trigger="every 5s"
     hx-swap="outerHTML"

--- a/templates/partials/claude_queue_kpis.html
+++ b/templates/partials/claude_queue_kpis.html
@@ -1,0 +1,54 @@
+{% comment %}
+Mini dashboard KPI tiles for the /claude-queue/ list page. This is the element
+that actually polls: it fetches claude-queue-jobs on an interval and swaps
+itself, while the accompanying table partial (claude_queue_table.html) rides
+along as an out-of-band swap in the same response — one poll updates both,
+so the KPIs and the job list never fall out of sync with each other.
+Expects the queue_* dashboard vars in context, see _claude_queue_dashboard_context().
+{% endcomment %}
+<div id="claude-queue-kpis"
+     class="row g-3 mb-3"
+     hx-get="{% url 'claude-queue-jobs' %}?{{ request.GET.urlencode }}"
+     hx-trigger="every 5s"
+     hx-swap="outerHTML">
+    <div class="col-md-3 col-6">
+        <div class="kpi-card">
+            <div class="kpi-icon"><i class="bi bi-list-check"></i></div>
+            <div class="kpi-content">
+                <div class="kpi-value">{{ queue_total_jobs }}</div>
+                <div class="kpi-label">Jobs</div>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-3 col-6">
+        <div class="kpi-card">
+            <div class="kpi-icon"><i class="bi bi-stopwatch"></i></div>
+            <div class="kpi-content">
+                <div class="kpi-value">{{ queue_avg_duration_display|default:"–" }}</div>
+                <div class="kpi-label">Ø Dauer</div>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-3 col-6">
+        <div class="kpi-card">
+            <div class="kpi-icon"><i class="bi bi-currency-dollar"></i></div>
+            <div class="kpi-content">
+                <div class="kpi-value">
+                    {% if queue_avg_cost is not None %}US${{ queue_avg_cost|floatformat:2 }}{% else %}–{% endif %}
+                </div>
+                <div class="kpi-label">Ø Kosten</div>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-3 col-6">
+        <div class="kpi-card">
+            <div class="kpi-icon"><i class="bi bi-arrow-repeat"></i></div>
+            <div class="kpi-content">
+                <div class="kpi-value">
+                    {% if queue_avg_turns is not None %}{{ queue_avg_turns|floatformat:0 }}{% else %}–{% endif %}
+                </div>
+                <div class="kpi-label">Ø Turns</div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/templates/partials/claude_queue_list.html
+++ b/templates/partials/claude_queue_list.html
@@ -1,0 +1,10 @@
+{% comment %}
+Combined HTMX poll response for the /claude-queue/ list page: the KPI tiles
+(the in-band swap target) plus the jobs table (an out-of-band swap into its
+own slot further down the page). Returned by claude_queue_jobs() on an
+HX-Request so a single poll refreshes both without duplicating markup.
+Not used for the initial full-page render — claude_queue_jobs.html includes
+the two partials directly at their respective positions in the layout.
+{% endcomment %}
+{% include 'partials/claude_queue_kpis.html' %}
+{% include 'partials/claude_queue_table.html' %}

--- a/templates/partials/claude_queue_table.html
+++ b/templates/partials/claude_queue_table.html
@@ -1,0 +1,74 @@
+{% comment %}
+Jobs table + pagination for the /claude-queue/ list page. Carries no polling
+attributes of its own — it is swapped in-place as an out-of-band update
+whenever claude_queue_kpis.html polls, so new/finished/deleted jobs and page
+counts stay in sync with the KPI tiles from a single request.
+Expects `jobs`/`page_obj`, `selected_project`, `selected_status` and
+`active_statuses` in context.
+{% endcomment %}
+<div id="claude-queue-table" hx-swap-oob="true">
+    <div class="card">
+        <div class="card-body p-0">
+            <div class="table-responsive">
+                <table class="table table-hover mb-0">
+                    <thead>
+                        <tr>
+                            <th>#</th>
+                            <th>Item</th>
+                            <th>Project</th>
+                            <th>Status</th>
+                            <th>Current step</th>
+                            <th>PR</th>
+                            <th>Turns / Cost</th>
+                            <th>Created</th>
+                            <th>Actions</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for job in jobs %}
+                        {% include 'partials/claude_queue_job_row.html' with disable_row_polling=True %}
+                        {% empty %}
+                        <tr>
+                            <td colspan="9" class="text-center text-muted py-4">No queue jobs found.</td>
+                        </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+
+            <!-- Pagination Controls -->
+            {% if page_obj.has_other_pages %}
+            <nav aria-label="Page navigation" class="mt-3 pb-3 px-3">
+                <ul class="pagination justify-content-center">
+                    {% if page_obj.has_previous %}
+                    <li class="page-item">
+                        <a class="page-link" href="?page=1{% if selected_project %}&project={{ selected_project }}{% endif %}{% if selected_status %}&status={{ selected_status }}{% endif %}">First</a>
+                    </li>
+                    <li class="page-item">
+                        <a class="page-link" href="?page={{ page_obj.previous_page_number }}{% if selected_project %}&project={{ selected_project }}{% endif %}{% if selected_status %}&status={{ selected_status }}{% endif %}">Previous</a>
+                    </li>
+                    {% endif %}
+
+                    <li class="page-item active">
+                        <span class="page-link">
+                            Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}
+                        </span>
+                    </li>
+
+                    {% if page_obj.has_next %}
+                    <li class="page-item">
+                        <a class="page-link" href="?page={{ page_obj.next_page_number }}{% if selected_project %}&project={{ selected_project }}{% endif %}{% if selected_status %}&status={{ selected_status }}{% endif %}">Next</a>
+                    </li>
+                    <li class="page-item">
+                        <a class="page-link" href="?page={{ page_obj.paginator.num_pages }}{% if selected_project %}&project={{ selected_project }}{% endif %}{% if selected_status %}&status={{ selected_status }}{% endif %}">Last</a>
+                    </li>
+                    {% endif %}
+                </ul>
+                <div class="text-center text-muted">
+                    <small>Showing {{ page_obj.start_index }} to {{ page_obj.end_index }} of {{ page_obj.paginator.count }} jobs</small>
+                </div>
+            </nav>
+            {% endif %}
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
Automated draft PR opened by the Claude queue worker for Agira item #1047.

Model: Sonnet
Job: #228

---

## Zusammenfassung

Die Listenansicht unter `/claude-queue/` aktualisiert sich jetzt von selbst per HTMX: neue Jobs erscheinen, erledigte/gelöschte verschwinden, und die Dashboard-Kacheln oben laufen mit — ohne manuellen Reload. Damit zieht die Listenansicht mit dem bereits bestehenden Live-Update-Mechanismus im DetailView gleich.

## Änderungen

- `templates/partials/claude_queue_kpis.html` (neu): die vier Mini-Dashboard-Kacheln, jetzt als eigener HTMX-Poll-Container (`hx-trigger="every 5s"`, `hx-swap="outerHTML"`), URL inkl. aktueller Query-Params.
- `templates/partials/claude_queue_table.html` (neu): Job-Tabelle + Pagination, als Out-of-Band-Swap-Ziel (`hx-swap-oob="true"`) ohne eigenes Polling.
- `templates/partials/claude_queue_list.html`: dient nur noch als kombiniertes Fragment für die HTMX-Poll-Antwort (Kacheln + Tabelle in einer Response).
- `templates/claude_queue_jobs.html`: bindet die beiden neuen Partials an ihren ursprünglichen Stellen ein (Kacheln vor dem Chart, Tabelle nach der Filterleiste); Chart und Filterleiste bleiben unverändert außerhalb des Poll-Zyklus.
- `templates/partials/claude_queue_job_row.html`: neuer Parameter `disable_row_polling`, mit dem die Zeile ihr eigenes `hx-get`/`hx-trigger` weglässt, wenn sie in der selbst-pollenden Liste eingebettet ist. Der eigenständige Zeilen-Endpoint (`claude-queue-job-row`) bleibt unverändert nutzbar.
- `core/views.py`: `claude_queue_jobs()` liefert bei `HX-Request` nur das kombinierte Fragment (`claude_queue_list.html`) statt der vollen Seite.
- `core/test_claude_queue_views.py`: neue Tests für Polling-Attribute auf Kacheln/Tabelle, das schlanke HTMX-Fragment, das Fehlen von Doppel-Polling auf Zeilenebene und die Erhaltung aktiver Filter in der Poll-URL.

## Warum / Entscheidungen

- **Ein Kachel-Container pollt, die Tabelle hängt sich per Out-of-Band-Swap an** – nicht ein einziger Container um Kacheln *und* Tabelle *und* Chart/Filterleiste, weil ein bestehender Test (`test_dashboard_chart_canvas_is_placed_below_kpi_cards`) die Kacheln zwingend vor dem Chart erwartet, während die Tabelle weiterhin nach der Filterleiste stehen soll. Ein einziges DOM-Fragment hätte diese Reihenfolge nicht abbilden können, ohne entweder den Test zu brechen oder das Layout sichtbar zu verändern. Mit zwei physisch getrennten, aber durch OOB-Swap in einer Antwort zusammengefassten Elementen bleibt das Layout erhalten und es gibt trotzdem nur einen Netzwerk-Request pro Poll.
- **Chart und Filterleiste bleiben außerhalb des Poll-Zyklus** – nicht die komplette Seite inklusive Chart neu rendern, weil Chart.js nur einmal beim `DOMContentLoaded` initialisiert wird; ein wiederholtes Ersetzen des Canvas würde ohne zusätzliche Re-Init-Logik zu einem leeren Chart nach dem ersten Poll führen. Die Filterleiste bleibt ebenfalls unangetastet, damit eine gerade geöffnete Dropdown-Auswahl nicht alle 5s unter dem Nutzer weggeswappt wird.
- **Zeilen-Polling wird nur unterdrückt, nicht der Endpoint entfernt** – nicht `claude-queue-job-row` löschen, weil er ein eigenständiger, getesteter Endpoint ist; stattdessen bekommt die Zeile über einen neuen Include-Parameter (`disable_row_polling`) explizit mitgeteilt, dass sie in einem bereits pollenden Kontext sitzt, wodurch das doppelte Polling entfällt, ohne den Endpoint selbst anzufassen.
- **Filter/Scope über `request.GET.urlencode` in die Poll-URL** – nicht einzelne Parameter hart verdrahten, weil so jede aktuell aktive Kombination (Projekt, Status, Seite) automatisch in der Polling-URL landet und bei jedem Refresh konsistent bleibt, ohne dass die Poll-Logik von den konkreten Filterfeldern wissen muss.
- **Intervall 5s statt eines eigenen Werts** – konsistent zum bestehenden Zeilen-Polling, keine neue Taktung eingeführt.
- **Kein automatisches Aussetzen des Pollings bei fehlenden aktiven Jobs** – bewusst nicht umgesetzt (im Ticket als optional markiert), weil neue Jobs jederzeit unabhängig vom Status bestehender Jobs eintreffen können; ein Aussetzen des Pollings anhand des aktuellen Job-Status würde genau den Fall verpassen, den das Ticket eigentlich lösen soll (neu eingereihte Jobs sichtbar machen).

## Test-Hinweise

- `python manage.py test core.test_claude_queue_views` – alle 57 Tests (52 bestehende + 5 neue) grün.
- Manuell: `/claude-queue/` öffnen, in einem zweiten Fenster/Terminal einen neuen `ClaudeQueueJob` anlegen bzw. einen bestehenden auf `done`/`failed` setzen oder löschen – Liste und Kacheln aktualisieren sich innerhalb von 5s ohne Reload, Filter (Projekt/Status/Seite) bleiben dabei erhalten.
- Browser-Devtools/Network prüfen: pro Poll-Zyklus nur ein Request an `/claude-queue/` (kein zusätzlicher Request pro Zeile mehr).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only HTMX/template refactor on an authenticated list view with no changes to job processing or auth; risk is mainly extra polling traffic every 5s on that page.
> 
> **Overview**
> The `/claude-queue/` list now **self-updates every 5s** via HTMX so new, finished, or deleted jobs and the top KPI tiles stay in sync without a full page reload.
> 
> **KPI tiles** (`claude_queue_kpis.html`) are the poll driver: they `hx-get` the list URL (with current query params) and swap themselves. The **jobs table** is updated in the same response through **out-of-band** swap (`claude_queue_table.html`), so one request refreshes both while the chart and filter form stay outside the poll cycle (Chart.js init and open filters are not wiped).
> 
> `claude_queue_jobs` returns the combined partial `claude_queue_list.html` when `HX-Request` is set; the full page still includes the KPI and table partials in their original layout positions.
> 
> List rows no longer poll individually: `claude_queue_job_row.html` accepts `disable_row_polling` when embedded in the list table, avoiding duplicate requests; the standalone row endpoint behavior is unchanged.
> 
> Tests cover polling attributes, slim HTMX responses, filter preservation in poll URLs, and absence of per-row polling on the list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71d59ee2d6d6029aaeeb3c48b1e0cc9435645e29. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->