### PR TITLE
Agira Issue mit Github PR verbinden über MCP

### DIFF
--- a/agira_mcp/client.py
+++ b/agira_mcp/client.py
@@ -85,3 +85,7 @@ class AgiraClient:
     def update_item(self, item_id: int, payload: dict, *, user_token: str | None) -> dict:
         return self._request("PATCH", f"items/{item_id}",
                              json=payload, user_token=user_token)
+
+    def link_github_pr(self, item_id: int, payload: dict, *, user_token: str | None) -> dict:
+        return self._request("POST", f"items/{item_id}/github-pr",
+                             json=payload, user_token=user_token)

--- a/agira_mcp/server.py
+++ b/agira_mcp/server.py
@@ -205,6 +205,7 @@ def update_item(
     title: str | None = None,
     description: str | None = None,
     solution_description: str | None = None,
+    pr_description: str | None = None,
     status: str | None = None,
     intern: bool | None = None,
     parent_id: int | None = None,
@@ -212,6 +213,13 @@ def update_item(
 ) -> dict:
     """
     Update fields of an existing item (partial update). Only set what changes.
+    Fails with a clear error if ``item_id`` does not refer to an existing item.
+
+    ``solution_description`` sets the item's "Solution" field.
+
+    ``pr_description`` sets the item's "PR-Description" field (normally the
+    final GitHub pull request body, captured automatically on merge — set it
+    explicitly here to record or correct it directly).
 
     ``parent_id`` sets or changes the item's parent (e.g. an Epic). Leave it
     unset to leave the current parent unchanged. To remove an existing parent
@@ -225,6 +233,7 @@ def update_item(
             "title": title,
             "description": description,
             "solution_description": solution_description,
+            "pr_description": pr_description,
             "status": status,
             "intern": intern,
         }.items()
@@ -235,6 +244,37 @@ def update_item(
     elif parent_id is not None:
         payload["parent_id"] = parent_id
     return _client().update_item(item_id, payload, user_token=_user_token())
+
+
+@mcp.tool()
+def link_github_pr(item_id: int, pr_number: int) -> dict:
+    """
+    Link a GitHub pull request to an Agira item via an ExternalIssueMapping
+    (kind="PR"). This is the write path used to record which PR resolves an
+    item; use it once a PR has been opened for the item's work.
+
+    Only ``pr_number`` (the GitHub PR number, e.g. 42 for ".../pull/42") is
+    needed — the owner/repo come from the item's project configuration, and
+    the rest of the PR reference (GitHub id, state, html_url) is resolved
+    from the GitHub API automatically, same as the existing "Link GitHub
+    Issue/PR" UI action.
+
+    Idempotent: calling this again for the same item/PR updates the existing
+    mapping in place (matched by GitHub id, then by item+PR number) instead
+    of creating a duplicate.
+
+    Returns a dict with:
+      - ``item_id``: the affected item
+      - ``created``: True if a new mapping was created, False if an existing
+        one was updated
+      - ``mapping``: the resolved mapping — ``id``, ``kind``, ``number``,
+        ``github_id``, ``state``, ``html_url``
+
+    Fails with a clear error if ``item_id`` does not exist, ``pr_number`` is
+    missing/invalid, the item's project has no GitHub repo configured, or the
+    PR number cannot be resolved on GitHub.
+    """
+    return _client().link_github_pr(item_id, {"pr_number": pr_number}, user_token=_user_token())
 
 
 # --------------------------------------------------------------------------

--- a/core/services/github/service.py
+++ b/core/services/github/service.py
@@ -810,7 +810,12 @@ class GitHubService(IntegrationBase):
             f"{action.capitalize()} mapping for item {item.id}: "
             f"{kind} #{number} (GitHub ID {github_id})"
         )
-        
+
+        # Transient (non-model) attribute so callers that need to distinguish
+        # create vs. update — without changing this method's long-established
+        # return type — can read it off the returned instance.
+        mapping.was_created = (action == 'created')
+
         return mapping
     
     def import_closed_issues_for_project(

--- a/core/test_customgpt_api.py
+++ b/core/test_customgpt_api.py
@@ -16,8 +16,10 @@ from django.contrib.auth import get_user_model
 
 from core.models import (
     Organisation, UserOrganisation, Project, ProjectStatus,
-    ItemType, Item, ItemStatus, UserRole
+    ItemType, Item, ItemStatus, UserRole,
+    ExternalIssueMapping, ExternalIssueKind, GitHubConfiguration,
 )
+from core.services.integrations.errors import IntegrationPermanentError
 from core.services.rag.models import RAGContextObject
 from core.services.rag.extended_service import ExtendedRAGContext
 
@@ -284,6 +286,50 @@ class CustomGPTItemsAPITest(TestCase):
         self.assertEqual(data['title'], 'Updated Item')
         self.assertEqual(data['status'], ItemStatus.TESTING)
     
+    def test_update_item_sets_solution_description(self):
+        """Test PATCH .../items/{id} writes the 'Solution' field."""
+        response = self.client.patch(
+            f'/api/customgpt/items/{self.open_item.id}',
+            data=json.dumps({'solution_description': 'Restarted the worker.'}),
+            content_type='application/json',
+            **self.headers
+        )
+        self.assertEqual(response.status_code, 200)
+
+        data = json.loads(response.content)
+        self.assertEqual(data['solution_description'], 'Restarted the worker.')
+
+        self.open_item.refresh_from_db()
+        self.assertEqual(self.open_item.solution_description, 'Restarted the worker.')
+
+    def test_update_item_sets_pr_description(self):
+        """Test PATCH .../items/{id} writes the 'PR-Description' field."""
+        response = self.client.patch(
+            f'/api/customgpt/items/{self.open_item.id}',
+            data=json.dumps({'pr_description': '## Summary\n\nFixed the bug.'}),
+            content_type='application/json',
+            **self.headers
+        )
+        self.assertEqual(response.status_code, 200)
+
+        data = json.loads(response.content)
+        self.assertEqual(data['pr_description'], '## Summary\n\nFixed the bug.')
+
+        self.open_item.refresh_from_db()
+        self.assertEqual(self.open_item.pr_description, '## Summary\n\nFixed the bug.')
+
+    def test_update_item_not_found(self):
+        """Test PATCH .../items/{id} with an invalid item id fails cleanly."""
+        response = self.client.patch(
+            '/api/customgpt/items/99999',
+            data=json.dumps({'solution_description': 'x'}),
+            content_type='application/json',
+            **self.headers
+        )
+        self.assertEqual(response.status_code, 404)
+        data = json.loads(response.content)
+        self.assertIn('error', data)
+
     def test_update_item_patch(self):
         """Test PATCH /api/customgpt/items/{id}."""
         update_data = {
@@ -700,3 +746,169 @@ class MCPResponsibleTests(TestCase):
         self.assertEqual(response.status_code, 201)
         data = json.loads(response.content)
         self.assertIsNone(data['responsible_id'])
+
+
+class CustomGPTItemLinkGitHubPRAPITest(TestCase):
+    """Test POST /api/customgpt/items/{id}/github-pr (PR -> ExternalIssueMapping linking)."""
+
+    def setUp(self):
+        os.environ['CUSTOMGPT_API_SECRET'] = 'test-secret-123'
+        self.client = Client()
+        self.headers = {'HTTP_X_API_SECRET': 'test-secret-123'}
+
+        self.config = GitHubConfiguration.load()
+        self.config.enable_github = True
+        self.config.github_token = 'test_token_123'
+        self.config.github_api_base_url = 'https://api.github.com'
+        self.config.save()
+
+        self.project = Project.objects.create(
+            name='Test Project',
+            github_owner='testowner',
+            github_repo='testrepo',
+        )
+        self.item_type = ItemType.objects.create(key='bug', name='Bug')
+        self.item = Item.objects.create(
+            project=self.project,
+            type=self.item_type,
+            title='Item with a PR',
+            status=ItemStatus.WORKING,
+        )
+
+    def tearDown(self):
+        if 'CUSTOMGPT_API_SECRET' in os.environ:
+            del os.environ['CUSTOMGPT_API_SECRET']
+
+    def _link(self, item_id, pr_number):
+        return self.client.post(
+            f'/api/customgpt/items/{item_id}/github-pr',
+            data=json.dumps({'pr_number': pr_number}),
+            content_type='application/json',
+            **self.headers,
+        )
+
+    @patch('core.services.github.client.GitHubClient.get_pr')
+    def test_link_creates_new_mapping(self, mock_get_pr):
+        mock_get_pr.return_value = {
+            'id': 55501,
+            'number': 42,
+            'state': 'open',
+            'html_url': 'https://github.com/testowner/testrepo/pull/42',
+        }
+
+        response = self._link(self.item.id, 42)
+        self.assertEqual(response.status_code, 201)
+
+        data = json.loads(response.content)
+        self.assertEqual(data['item_id'], self.item.id)
+        self.assertTrue(data['created'])
+        self.assertEqual(data['mapping']['number'], 42)
+        self.assertEqual(data['mapping']['github_id'], 55501)
+        self.assertEqual(data['mapping']['kind'], ExternalIssueKind.PR)
+        self.assertEqual(data['mapping']['state'], 'open')
+
+        self.assertEqual(ExternalIssueMapping.objects.count(), 1)
+        mapping = ExternalIssueMapping.objects.get()
+        self.assertEqual(mapping.item_id, self.item.id)
+        self.assertEqual(mapping.github_id, 55501)
+
+    @patch('core.services.github.client.GitHubClient.get_pr')
+    def test_link_same_pr_twice_is_idempotent(self, mock_get_pr):
+        mock_get_pr.return_value = {
+            'id': 55502,
+            'number': 43,
+            'state': 'open',
+            'html_url': 'https://github.com/testowner/testrepo/pull/43',
+        }
+
+        first = self._link(self.item.id, 43)
+        second = self._link(self.item.id, 43)
+
+        self.assertEqual(first.status_code, 201)
+        self.assertEqual(second.status_code, 200)
+        self.assertFalse(json.loads(second.content)['created'])
+
+        # No duplicate rows for the same item/PR.
+        self.assertEqual(ExternalIssueMapping.objects.count(), 1)
+        self.assertEqual(
+            json.loads(first.content)['mapping']['id'],
+            json.loads(second.content)['mapping']['id'],
+        )
+
+    @patch('core.services.github.client.GitHubClient.get_pr')
+    def test_link_updates_existing_mapping_deterministically(self, mock_get_pr):
+        existing = ExternalIssueMapping.objects.create(
+            item=self.item,
+            github_id=55503,
+            number=44,
+            kind=ExternalIssueKind.PR,
+            state='open',
+            html_url='https://github.com/testowner/testrepo/pull/44',
+        )
+
+        mock_get_pr.return_value = {
+            'id': 55503,
+            'number': 44,
+            'state': 'closed',
+            'merged_at': '2026-08-01T10:00:00Z',
+            'html_url': 'https://github.com/testowner/testrepo/pull/44',
+        }
+
+        response = self._link(self.item.id, 44)
+        self.assertEqual(response.status_code, 200)
+
+        data = json.loads(response.content)
+        self.assertFalse(data['created'])
+        self.assertEqual(data['mapping']['id'], existing.id)
+        self.assertEqual(data['mapping']['state'], 'merged')
+
+        # The same row was updated in place, not a second one created.
+        self.assertEqual(ExternalIssueMapping.objects.count(), 1)
+        existing.refresh_from_db()
+        self.assertEqual(existing.state, 'merged')
+
+    def test_link_item_not_found(self):
+        response = self._link(999999, 1)
+        self.assertEqual(response.status_code, 404)
+        self.assertIn('error', json.loads(response.content))
+
+    def test_link_missing_pr_number(self):
+        response = self.client.post(
+            f'/api/customgpt/items/{self.item.id}/github-pr',
+            data=json.dumps({}),
+            content_type='application/json',
+            **self.headers,
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('error', json.loads(response.content))
+        self.assertEqual(ExternalIssueMapping.objects.count(), 0)
+
+    def test_link_invalid_pr_number(self):
+        response = self._link(self.item.id, 'not-a-number')
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('error', json.loads(response.content))
+
+    @patch('core.services.github.client.GitHubClient.get_pr')
+    def test_link_unresolvable_pr_returns_clean_error(self, mock_get_pr):
+        mock_get_pr.side_effect = IntegrationPermanentError(
+            "Client error (HTTP 404): Not Found"
+        )
+
+        response = self._link(self.item.id, 9999)
+        self.assertEqual(response.status_code, 400)
+        data = json.loads(response.content)
+        self.assertIn('error', data)
+        self.assertIn('9999', data['error'])
+        self.assertEqual(ExternalIssueMapping.objects.count(), 0)
+
+    def test_link_project_without_github_repo_configured(self):
+        project = Project.objects.create(name='No GitHub Project')
+        item = Item.objects.create(
+            project=project,
+            type=self.item_type,
+            title='Unconfigured item',
+        )
+
+        response = self._link(item.id, 1)
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('error', json.loads(response.content))

--- a/core/urls_api.py
+++ b/core/urls_api.py
@@ -17,5 +17,6 @@ urlpatterns = [
     path('items', views_api.api_items_list, name='api-items-list'),
     path('items/<int:item_id>', views_api.api_item_detail_handler, name='api-item-detail'),
     path('items/<int:item_id>/context', views_api.api_item_context, name='api-item-context'),
+    path('items/<int:item_id>/github-pr', views_api.api_item_link_github_pr, name='api-item-link-github-pr'),
     path('projects/<int:project_id>/items', views_api.api_project_create_item, name='api-project-create-item'),
 ]

--- a/core/views_api.py
+++ b/core/views_api.py
@@ -75,6 +75,7 @@ def serialize_item(item):
         'description': item.description,
         'user_input': item.user_input,
         'solution_description': item.solution_description,
+        'pr_description': item.pr_description,
         'status': item.status,
         'project_id': item.project_id,
         'type_id': item.type_id,
@@ -375,6 +376,8 @@ def api_item_update_put(request, item_id):
             item.user_input = data['user_input']
         if 'solution_description' in data:
             item.solution_description = data['solution_description']
+        if 'pr_description' in data:
+            item.pr_description = data['pr_description']
         if 'status' in data:
             item.status = data['status']
         if 'intern' in data:
@@ -438,6 +441,100 @@ def api_item_update_patch(request, item_id):
     """
     # For now, PATCH and PUT behave the same way (partial update)
     return api_item_update_put(request, item_id)
+
+
+@csrf_exempt
+@require_http_methods(['POST'])
+def api_item_link_github_pr(request, item_id):
+    """
+    POST /api/customgpt/items/{item_id}/github-pr
+
+    Link a GitHub pull request to an item via ``ExternalIssueMapping``.
+
+    Only the PR number has to be supplied — owner/repo are resolved from the
+    item's project (``GitHubService._get_repo_info``) and the rest of the PR
+    reference (GitHub id, state, html_url) is resolved from the GitHub API,
+    exactly like the existing "Link GitHub Issue/PR" UI action. Reuses
+    ``GitHubService.upsert_mapping_from_github`` so the same
+    create-or-update-in-place semantics (matched by GitHub id, then by
+    item+kind+number) apply here — repeated calls for the same PR are
+    idempotent and update the existing mapping instead of duplicating it.
+
+    Request Body:
+        {"pr_number": <int>}   # required, the GitHub PR number (not the Agira id)
+
+    Returns:
+        200: Existing mapping was updated.
+             {"item_id", "mapping": {...}, "created": false}
+        201: A new mapping was created.
+             {"item_id", "mapping": {...}, "created": true}
+        400: Missing/invalid pr_number, GitHub not configured/disabled for the
+             item's project, or the PR could not be resolved on GitHub.
+        404: Item not found.
+    """
+    from core.services.github.service import GitHubService
+    from core.services.integrations.base import (
+        IntegrationDisabled,
+        IntegrationError,
+        IntegrationNotConfigured,
+    )
+
+    try:
+        item = Item.objects.get(id=item_id)
+    except Item.DoesNotExist:
+        return JsonResponse({'error': 'Item not found'}, status=404)
+
+    try:
+        data = json.loads(request.body)
+    except json.JSONDecodeError:
+        return JsonResponse({'error': 'Invalid JSON payload'}, status=400)
+
+    pr_number = data.get('pr_number')
+    if pr_number is None or (isinstance(pr_number, str) and not pr_number.strip()):
+        return JsonResponse({'error': 'pr_number is required'}, status=400)
+    try:
+        pr_number = int(pr_number)
+    except (TypeError, ValueError):
+        return JsonResponse({'error': 'pr_number must be a valid integer'}, status=400)
+
+    try:
+        mapping = GitHubService().upsert_mapping_from_github(
+            item=item,
+            number=pr_number,
+            kind='pr',
+        )
+    except ValueError as e:
+        # e.g. the item's project has no github_owner/github_repo configured
+        return JsonResponse({'error': str(e)}, status=400)
+    except (IntegrationDisabled, IntegrationNotConfigured) as e:
+        return JsonResponse({'error': str(e) or 'GitHub integration is not available'}, status=400)
+    except IntegrationError as e:
+        # Covers "PR not found on GitHub" (permanent 4xx) as well as auth/
+        # rate-limit/temporary upstream failures — all are the caller's problem
+        # to fix or retry, not a 500 on our side.
+        return JsonResponse(
+            {'error': f'Could not resolve GitHub PR #{pr_number}: {e}'}, status=400
+        )
+    except Exception as e:
+        logger.error(f"Error linking GitHub PR #{pr_number} to item {item_id}: {e}", exc_info=True)
+        return JsonResponse({'error': 'Internal server error'}, status=500)
+
+    created = getattr(mapping, 'was_created', False)
+    return JsonResponse(
+        {
+            'item_id': item.id,
+            'mapping': {
+                'id': mapping.id,
+                'kind': mapping.kind,
+                'number': mapping.number,
+                'github_id': mapping.github_id,
+                'state': mapping.state,
+                'html_url': mapping.html_url,
+            },
+            'created': created,
+        },
+        status=201 if created else 200,
+    )
 
 
 @csrf_exempt


### PR DESCRIPTION
Automated draft PR opened by the Claude queue worker for Agira item #1071.

Model: Sonnet
Job: #262

---

## Zusammenfassung

- Neues MCP-Tool `link_github_pr` verknüpft einen GitHub-PR mit einem Agira-Issue über `ExternalIssueMapping` — idempotent und ohne Duplikate.
- Das bestehende MCP-Tool `update_item` kann jetzt zusätzlich zu `Solution` (`solution_description`, war bereits vorhanden) auch `PR-Description` (`pr_description`) schreiben.
- Beide Fähigkeiten nutzen ausschließlich vorhandene Projektlogik (`GitHubService.upsert_mapping_from_github`, PATCH-Item-Endpoint) — keine neue parallele Mapping- oder Update-Logik.

## Änderungen

- `core/services/github/service.py`: `upsert_mapping_from_github` markiert die zurückgegebene Mapping-Instanz zusätzlich mit dem transienten (nicht persistierten) Attribut `was_created`, damit Aufrufer create/update ohne neue Lookup-Logik unterscheiden können. Rückgabetyp und alle vier bestehenden Call-Sites (Demo, Sync-Worker, interner Aufruf) bleiben unverändert.
- `core/views_api.py`:
  - Neuer Endpoint `POST /api/customgpt/items/{item_id}/github-pr` (`api_item_link_github_pr`). Erwartet `{"pr_number": <int>}`, ruft `GitHubService.upsert_mapping_from_github(item, number=pr_number, kind='pr')` auf (gleiche Owner/Repo- und PR-Auflösung wie die bestehende UI-Aktion "Link GitHub Issue/PR"). Antwort: `{"item_id", "mapping": {id, kind, number, github_id, state, html_url}, "created"}`, Status 201 bei Neuanlage, 200 bei Update. Fehlerfälle: 404 (Issue nicht gefunden), 400 (PR-Nummer fehlt/ungültig, GitHub nicht konfiguriert/deaktiviert, PR nicht auflösbar).
  - `serialize_item` und `api_item_update_put` (PUT/PATCH auf `/items/{id}`) unterstützen jetzt zusätzlich `pr_description`.
- `core/urls_api.py`: Route `items/<int:item_id>/github-pr` registriert.
- `agira_mcp/client.py`: `link_github_pr(...)` als dünner Wrapper um den neuen Endpoint.
- `agira_mcp/server.py`:
  - Neues Tool `link_github_pr(item_id, pr_number)` mit eindeutiger Docstring (nur PR-Nummer nötig, Rest wird serverseitig aufgelöst; idempotent; Rückgabeform).
  - `update_item` um Parameter `pr_description` erweitert, Docstring stellt klar, welches Feld `solution_description` bzw. `pr_description` jeweils setzt ("Solution" / "PR-Description").
- `core/test_customgpt_api.py`: neue Tests für Mapping-Erstellung, idempotenten Zweitaufruf, deterministisches Update einer bestehenden Zuordnung, fehlendes Issue, fehlende/ungültige/nicht auflösbare PR-Nummer, fehlende GitHub-Projektkonfiguration, sowie für das Schreiben von `solution_description` und `pr_description` über das Update-Tool inkl. Fehlerfall bei ungültiger Issue-ID.

## Warum / Entscheidungen

- Wiederverwendung von `GitHubService.upsert_mapping_from_github` statt der Logik aus der UI-View `item_link_github`, weil letztere bei bereits existierendem Mapping mit einem harten 400-Fehler abbricht statt zu aktualisieren — nicht kompatibel mit der geforderten Idempotenz. `upsert_mapping_from_github` implementiert bereits genau das geforderte Verhalten (Lookup zuerst über `github_id`, dann über `item+kind+number`, deterministisches Update statt Duplikat) und wird bereits an vier Stellen im Projekt produktiv genutzt.
- Nicht Rückgabetyp von `upsert_mapping_from_github` auf ein `(mapping, created)`-Tupel umgestellt, weil das alle vier bestehenden Call-Sites hätte anfassen müssen; stattdessen ein transientes `was_created`-Attribut auf der zurückgegebenen Instanz, das nur der neue Endpoint liest — minimal-invasiv, keine Verhaltensänderung für bestehenden Code.
- Kein separates MCP-Sonderwerkzeug für `Solution`/`PR-Description`, weil mit `update_item` bereits ein allgemeiner Issue-Update-Mechanismus existiert (und `solution_description` dort bereits unterstützt wurde); `pr_description` wurde als weiterer Parameter in genau diesen Pfad integriert statt einen parallelen Endpoint zu schaffen.
- PR-Referenz bewusst nur als reine PR-Nummer (`pr_number`) modelliert, nicht als volle GitHub-URL oder Owner/Repo/Nummer-Tripel, weil laut bestehender Projektkonvention (UI-Formular, `upsert_mapping_from_github`) die Nummer ausreicht und Owner/Repo serverseitig aus der Projektkonfiguration aufgelöst werden — ein zusätzliches Eingabeformat hätte lediglich Mehrdeutigkeit für den Agenten geschaffen.
- Fehler aus der GitHub-Auflösung (nicht konfiguriert, deaktiviert, PR nicht gefunden, Auth-/Rate-Limit-/temporäre Fehler) werden alle als strukturierte 400-Antworten zurückgegeben statt als 500, weil es sich fachlich um Eingabe- bzw. Konfigurationsprobleme des Aufrufers handelt, nicht um interne Serverfehler — ein Agent kann daraus eine klare Handlungsanweisung ableiten.

## Test-Hinweise

- `python manage.py test core.test_customgpt_api core.services.github.test_github core.test_github_pr_webhook --keepdb`
- Alle 96 relevanten Tests grün; die einzige verbleibende Fehlermeldung (`test_get_item_context`, fehlendes `alpha`-Feld) ist vorbestehend und unabhängig von dieser Änderung (reproduzierbar auch auf dem unveränderten Branch, hängt an fehlender Weaviate/AI-Modell-Konfiguration in dieser Umgebung).
- Neue Tests decken ab: Mapping-Neuanlage, idempotenter Zweitaufruf ohne Duplikat, deterministisches Update eines bestehenden Mappings (State-Wechsel `open` → `merged`), Issue nicht gefunden, `pr_number` fehlt, `pr_number` ungültig, PR auf GitHub nicht auflösbar (404), Projekt ohne GitHub-Repo-Konfiguration, sowie Schreiben von `solution_description` und `pr_description` über den Update-Endpoint inkl. Fehlerfall bei ungültiger Issue-ID.