### PR TITLE
Suggested Model ist nur im Edit View des Issues Verfügbar

### DIFF
--- a/core/services/item_field_update.py
+++ b/core/services/item_field_update.py
@@ -29,6 +29,7 @@ from django.core.exceptions import ValidationError
 from django.db.models import Model
 
 from core.models import (
+    ClaudeQueueJobModel,
     Item,
     ItemStatus,
     ItemType,
@@ -153,6 +154,25 @@ def _resolve_release(_item: Item, raw: str) -> Optional[Release]:
     return _resolve_fk(Release, raw, nullable=True, label="Release")
 
 
+def _resolve_suggested_model(_item: Item, raw: str) -> str:
+    """Resolve the manually overridable Claude-queue model suggestion (#1072).
+
+    Only the existing field choices (sonnet/opus) are accepted; there is no
+    inline "Auto-detect", so no classifier logic runs on this path.
+    """
+    value = (raw or "").strip()
+    if value not in ClaudeQueueJobModel.values:
+        raise FieldUpdateError("Ungültiges Modell.")
+    return value
+
+
+_SUGGESTED_MODEL_LABELS = dict(ClaudeQueueJobModel.choices)
+
+
+def _suggested_model_display(value: Any) -> str:
+    return _SUGGESTED_MODEL_LABELS.get(value, value) if value else "None"
+
+
 def _user_display(user: Optional[User]) -> str:
     return user.name if user else "None"
 
@@ -193,6 +213,10 @@ FIELD_SPECS: dict[str, FieldSpec] = {
     "solution_release": FieldSpec(
         "solution_release", "fk", _resolve_release,
         display=lambda v: v.version if v else "None", label="Release",
+    ),
+    "suggested_model": FieldSpec(
+        "suggested_model", "text", _resolve_suggested_model,
+        display=_suggested_model_display, label="Suggested Model",
     ),
 }
 

--- a/core/test_item_detail.py
+++ b/core/test_item_detail.py
@@ -222,6 +222,17 @@ def example():
         self.assertIn('releases', response.context)
         self.assertIn(self.release, response.context['releases'])
     
+    def test_item_detail_shows_suggested_model_inline_edit(self):
+        """suggested_model is visible in the normal detail view and inline-editable (#1072)."""
+        url = reverse('item-detail', args=[self.item.id])
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('suggested_model_choices', response.context)
+        self.assertContains(response, 'Suggested Model:')
+        self.assertContains(response, '"field": "suggested_model"')
+        self.assertContains(response, 'field-feedback-suggested_model')
+
     def test_item_detail_shows_incoming_warning_for_incoming_project(self):
         """Test that incoming warning is shown for items in Incoming project."""
         # Create Incoming project

--- a/core/test_item_field_update.py
+++ b/core/test_item_field_update.py
@@ -166,6 +166,33 @@ class RequesterOrganisationSideEffectTest(GenericFieldUpdateTestBase):
         self.assertEqual(self.item.organisation, self.org_b)
 
 
+class SuggestedModelFieldTest(GenericFieldUpdateTestBase):
+    """Inline HTMX editing of the manually overridable suggested_model (#1072)."""
+
+    def test_suggested_model_updates_to_opus(self):
+        response = self.client.post(self.url(), {'field': 'suggested_model', 'value': 'opus'})
+        self.assertEqual(response.status_code, 200)
+        self.item.refresh_from_db()
+        self.assertEqual(self.item.suggested_model, 'opus')
+
+    def test_response_fragment_reports_success(self):
+        response = self.client.post(self.url(), {'field': 'suggested_model', 'value': 'opus'})
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'Gespeichert')
+
+    def test_invalid_value_rejected(self):
+        self.item.suggested_model = 'sonnet'
+        self.item.save()
+        response = self.client.post(self.url(), {'field': 'suggested_model', 'value': 'fable'})
+        self.assertEqual(response.status_code, 400)
+        self.item.refresh_from_db()
+        self.assertEqual(self.item.suggested_model, 'sonnet')
+
+    def test_empty_value_rejected(self):
+        response = self.client.post(self.url(), {'field': 'suggested_model', 'value': ''})
+        self.assertEqual(response.status_code, 400)
+
+
 class ActivityLoggingTest(GenericFieldUpdateTestBase):
     def test_change_creates_activity(self):
         before = Activity.objects.count()
@@ -186,5 +213,6 @@ class FieldSpecRegistryTest(TestCase):
 
     def test_expected_fields_present(self):
         for name in ['title', 'short_description', 'intern', 'type', 'organisation',
-                     'requester', 'assigned_to', 'responsible', 'parent', 'solution_release']:
+                     'requester', 'assigned_to', 'responsible', 'parent', 'solution_release',
+                     'suggested_model']:
             self.assertIn(name, FIELD_SPECS)

--- a/core/views.py
+++ b/core/views.py
@@ -1087,6 +1087,7 @@ def item_detail(request, item_id):
         'item_types': item_types,
         'active_tab': active_tab,
         'available_statuses': ItemStatus.choices,
+        'suggested_model_choices': ClaudeQueueJobModel.choices,
         'claude_queue_jobs': claude_queue_jobs,
         'claude_total_cost': claude_total_cost,
     }

--- a/templates/item_detail.html
+++ b/templates/item_detail.html
@@ -830,6 +830,21 @@
                             <div id="field-feedback-type" class="mt-1"></div>
                         </div>
                         <div class="mb-3">
+                            <strong>Suggested Model:</strong>
+                            <select class="form-select form-select-sm mt-1"
+                                    name="value"
+                                    hx-post="{% url 'item-update-field' item.id %}"
+                                    hx-vals='{"field": "suggested_model"}'
+                                    hx-trigger="change"
+                                    hx-target="#field-feedback-suggested_model"
+                                    hx-swap="innerHTML">
+                                {% for value, display in suggested_model_choices %}
+                                <option value="{{ value }}" {% if item.suggested_model == value %}selected{% endif %}>{{ display }}</option>
+                                {% endfor %}
+                            </select>
+                            <div id="field-feedback-suggested_model" class="mt-1"></div>
+                        </div>
+                        <div class="mb-3">
                             <strong>Parent Item:</strong>
                             <div class="mt-2 d-flex gap-2" id="parent-field-container">
                                 <select 


### PR DESCRIPTION
Automated draft PR opened by the Claude queue worker for Agira item #1072.

Model: Opus
Job: #263

---

## Zusammenfassung

`suggested_model` war bisher nur im Edit-View (`item_form.html`) eines Issues verfügbar. Dieses PR zeigt das Feld auch im normalen Issue-Detailview an und macht es dort — wie die anderen Sidebar-Felder (Organisation, Requester, Typ, …) — per HTMX inline editierbar. Das Feld nutzt dieselbe Datenquelle und dieselben Auswahloptionen wie der Edit-View; es wird keine neue Fachlogik eingeführt.

## Änderungen

- **`core/services/item_field_update.py`**: `suggested_model` in die Whitelist `FIELD_SPECS` des generischen Inline-Edit-Services (#996) aufgenommen. Neuer Resolver `_resolve_suggested_model`, der nur die bestehenden Feldoptionen (`ClaudeQueueJobModel.values` → `sonnet`/`opus`) akzeptiert und ungültige Werte mit `FieldUpdateError` abweist. Anzeige im Activity-Log über das Choices-Label.
- **`core/views.py`**: `item_detail` reicht `suggested_model_choices` (= `ClaudeQueueJobModel.choices`) in den Template-Kontext, damit die Optionen aus derselben Quelle stammen wie im Edit-View.
- **`templates/item_detail.html`**: Neues Feld „Suggested Model" in der Karte „Additional Information" (nach „Type"), umgesetzt als `<select>` mit dem bestehenden HTMX-Muster (`hx-post` auf `item-update-field`, `hx-vals={"field": "suggested_model"}`, Feedback-Container `#field-feedback-suggested_model`).
- **`core/test_item_field_update.py`**: Tests für erfolgreiches Update auf `opus`, gerendertes Erfolgs-Fragment, Ablehnung ungültiger/leerer Werte sowie Aufnahme in die Whitelist-Registry.
- **`core/test_item_detail.py`**: Test für Sichtbarkeit des Feldes und der HTMX-Verdrahtung im normalen Detailview.

## Warum / Entscheidungen

- **Bestehendes generisches Inline-Edit-Muster wiederverwendet, nicht neuer Sonder-Endpoint**, weil `item-update-field` (#996) bereits Whitelist, Validierung, Activity-Logging und das Feedback-Fragment für alle Sidebar-Felder kapselt — so bleibt `suggested_model` konsistent zu den anderen Feldern.
- **Optionen aus `ClaudeQueueJobModel.choices` in den Kontext gereicht, nicht im Template hartkodiert**, damit View- und Edit-Modus dieselbe Datenquelle nutzen und die Auswahlwerte exakt den definierten Feldoptionen entsprechen.
- **Kein inline „Auto-detect" angeboten, nur `sonnet`/`opus`**, weil die Akzeptanzkriterien exakt die bestehenden Feldoptionen fordern und „Auto-detect" den Klassifizierer auslösen würde — das wäre neue Fachlogik im Inline-Pfad. Der Klassifizierer bleibt ausschließlich dem Edit-/Create-Flow (`_resolve_suggested_model` in `views.py`) vorbehalten und unverändert funktionsfähig.
- **Platzierung nach „Type" in der Karte „Additional Information"**, weil sich das Feld strukturell in die vorhandenen inline-editierbaren Sidebar-Felder einfügt.

## Test-Hinweise

- `python manage.py test core.test_item_field_update core.test_item_detail` — alle Tests grün.
- Manuell: Issue-Detailview öffnen → „Suggested Model" in der Karte „Additional Information" auf einen anderen Wert stellen → „Gespeichert" erscheint ohne Page-Reload; nach Reload bleibt der Wert erhalten. Ungültige Werte werden weiterhin abgewiesen; der Edit-View für `suggested_model` bleibt unverändert nutzbar.