### PR TITLE
Move Button "Create Github Issue" to Action Menü of Item

### DIFF
--- a/core/test_github_issue_creation.py
+++ b/core/test_github_issue_creation.py
@@ -655,24 +655,40 @@ class GitHubIssueCreationViewTestCase(TestCase):
         self.assertEqual(mapping.github_id, 12345)
         self.assertEqual(mapping.number, 42)
     
-    def test_view_rejects_inbox_item(self):
-        """Test that view rejects Inbox items."""
+    @patch('core.services.github.client.GitHubClient.create_issue')
+    def test_view_creates_issue_for_inbox_item(self, mock_create_issue):
+        """Test that GitHub issue creation is status-independent (e.g. Inbox items are allowed)."""
         from django.test import Client
-        
+
+        # Create Copilot user for local assignment
+        self._create_copilot_user()
+
         item = Item.objects.create(
             project=self.project,
             title='Inbox Item',
             type=self.item_type,
             status=ItemStatus.INBOX,
         )
-        
+
+        mock_create_issue.return_value = {
+            'id': 54321,
+            'number': 7,
+            'state': 'open',
+            'html_url': 'https://github.com/testowner/testrepo/issues/7',
+            'title': 'Inbox Item',
+            'assignees': [],
+        }
+
         client = Client()
         client.force_login(self.user)
         response = client.post(f'/items/{item.id}/create-github-issue/')
-        
-        # Check that request was rejected
-        self.assertEqual(response.status_code, 400)
-        self.assertIn('status', response.content.decode().lower())
-        
-        # Check that no mapping was created
-        self.assertEqual(ExternalIssueMapping.objects.filter(item=item).count(), 0)
+
+        # Status is no longer a blocking guard - issue should be created
+        self.assertEqual(response.status_code, 200)
+        mock_create_issue.assert_called_once()
+
+        # Check that mapping was created
+        mapping = ExternalIssueMapping.objects.filter(item=item).first()
+        self.assertIsNotNone(mapping)
+        self.assertEqual(mapping.github_id, 54321)
+        self.assertEqual(mapping.number, 7)

--- a/core/views.py
+++ b/core/views.py
@@ -1807,14 +1807,9 @@ def item_create_github_issue(request, item_id):
                 status=400
             )
 
-        # Check if item has valid status
-        if not github_service.can_create_issue_for_item(item):
-            return HttpResponse(
-                f"Cannot create GitHub issue for item with status '{item.status}'. "
-                f"Item must have status 'Backlog', 'Working', or 'Testing'.",
-                status=400
-            )
-        
+        # Note: GitHub issue creation is intentionally status-independent.
+        # The action must always be available regardless of the item's status.
+
         # Check if this is a follow-up issue (item already has issues)
         existing_issues = item.external_mappings.filter(kind='Issue').exists()
         

--- a/templates/item_detail.html
+++ b/templates/item_detail.html
@@ -241,6 +241,16 @@
                 </li>
                 {% endif %}
                 {% endif %}
+                {# Status-independent: always available, same flow as the "Create GitHub Issue" button in the GitHub tab #}
+                <li>
+                    <button type="button" class="dropdown-item"
+                            hx-post="{% url 'item-create-github-issue' item.id %}"
+                            hx-target="#github"
+                            hx-swap="none"
+                            hx-on::after-request="handleGitHubIssueCreation(event)">
+                        <i class="bi bi-github me-2"></i>An GitHub übergeben
+                    </button>
+                </li>
                 <li>
                     <button type="button" class="dropdown-item" data-bs-toggle="modal" data-bs-target="#assignResponsibleModal">
                         <i class="bi bi-person-plus me-2"></i>Assign
@@ -1550,6 +1560,97 @@
                 showToast('error', 'Ein Fehler ist beim Übergeben an Claude aufgetreten.');
             });
         }
+    }
+
+    // GitHub issue creation handler.
+    // Shared single source of truth for the "Create GitHub Issue" button in the
+    // GitHub tab (partials/item_github_tab.html) and the "An GitHub übergeben"
+    // action-menu entry. Defined here (always loaded) so it is available even when
+    // the GitHub tab has not been lazily loaded yet.
+    function handleGitHubIssueCreation(event) {
+        const xhr = event.detail.xhr;
+
+        // Check if request was successful
+        if (event.detail.successful) {
+            try {
+                // Try to parse response as JSON
+                const response = JSON.parse(xhr.responseText);
+
+                // Check if this is a JSON response with mail_preview
+                if (response.success && response.mail_preview) {
+                    // Close the followup modal if it's open
+                    const followupModal = bootstrap.Modal.getInstance(document.getElementById('followupIssueModal'));
+                    if (followupModal) {
+                        followupModal.hide();
+                        document.getElementById('followupIssueForm').reset();
+                    }
+
+                    // Update the GitHub tab with the new HTML
+                    if (response.github_tab_html) {
+                        document.getElementById('github').innerHTML = response.github_tab_html;
+                    }
+
+                    // Ensure modal backdrop is removed
+                    removeModalBackdrop();
+
+                    // Show mail confirmation modal (reuse existing mail modal from item_form.html)
+                    if (typeof showMailConfirmationModal === 'function') {
+                        showMailConfirmationModal(response.mail_preview, response.item_id);
+                    } else {
+                        console.error('showMailConfirmationModal function not found');
+                        // Fallback: show a toast notification
+                        showToast('success', 'GitHub issue created successfully. Mail preview not available.');
+                    }
+                    return;
+                }
+            } catch (e) {
+                // Not JSON, might be HTML response - handle as regular HTMX response
+            }
+
+            // Handle regular HTML response (no mail preview)
+            // Close the followup modal if it's open
+            const followupModal = bootstrap.Modal.getInstance(document.getElementById('followupIssueModal'));
+            if (followupModal) {
+                followupModal.hide();
+                document.getElementById('followupIssueForm').reset();
+            }
+
+            // Update the GitHub tab with the response
+            document.getElementById('github').innerHTML = xhr.responseText;
+
+            // Ensure modal backdrop is removed
+            removeModalBackdrop();
+
+            // Show success toast
+            if (typeof showToast === 'function') {
+                showToast('success', 'GitHub issue created successfully');
+            }
+        } else {
+            // Handle errors
+            if (typeof showToast === 'function') {
+                const errorMsg = xhr.responseText || 'Failed to create GitHub issue';
+                showToast('error', errorMsg);
+            }
+        }
+    }
+
+    // Helper function to remove modal backdrop
+    function removeModalBackdrop() {
+        // Remove any lingering modal backdrops
+        const backdrops = document.querySelectorAll('.modal-backdrop');
+        backdrops.forEach(backdrop => backdrop.remove());
+
+        // Remove modal-open class from body
+        document.body.classList.remove('modal-open');
+
+        // Reset body padding/overflow that Bootstrap may have set
+        document.body.style.overflow = '';
+        document.body.style.paddingRight = '';
+    }
+
+    // Keep the old function for compatibility (redirect to new handler)
+    function handleFollowupIssueResponse(event) {
+        handleGitHubIssueCreation(event);
     }
 
     // Assign responsible action

--- a/templates/partials/item_github_tab.html
+++ b/templates/partials/item_github_tab.html
@@ -15,17 +15,12 @@
                 <p class="mb-3">
                     <small class="text-muted">
                         Create a new GitHub issue for this item.
-                        {% if can_create_issue %}
-                            <span class="text-success">✓ Status is valid ({{ item.status }})</span>
-                        {% else %}
-                            <span class="text-danger">✗ Status must be Backlog, Working, or Testing (current: {{ item.status }})</span>
-                        {% endif %}
                         {% if not user_has_github_pat %}
                             <br><span class="text-danger">✗ GitHub Personal Access Token not configured</span>
                         {% endif %}
                     </small>
                 </p>
-                {% if can_create_issue and user_has_github_pat %}
+                {% if user_has_github_pat %}
                     {% if has_existing_issue %}
                         <!-- Follow-up issue creation - requires notes -->
                         <div class="alert alert-info mb-3">
@@ -61,12 +56,8 @@
                 {% else %}
                     <div class="alert alert-warning mb-0">
                         <small>
-                            {% if not can_create_issue %}
-                                Cannot create GitHub issue. Item status must be Backlog, Working, or Testing.
-                            {% elif not user_has_github_pat %}
-                                Cannot create GitHub issue. You need to configure your GitHub Personal Access Token in
-                                <a href="{% url 'user-settings' %}" class="alert-link">User Settings</a>.
-                            {% endif %}
+                            Cannot create GitHub issue. You need to configure your GitHub Personal Access Token in
+                            <a href="{% url 'user-settings' %}" class="alert-link">User Settings</a>.
                         </small>
                     </div>
                 {% endif %}
@@ -244,90 +235,6 @@
     </div>
 </div>
 
-<script>
-function handleGitHubIssueCreation(event) {
-    const xhr = event.detail.xhr;
-    
-    // Check if request was successful
-    if (event.detail.successful) {
-        try {
-            // Try to parse response as JSON
-            const response = JSON.parse(xhr.responseText);
-            
-            // Check if this is a JSON response with mail_preview
-            if (response.success && response.mail_preview) {
-                // Close the followup modal if it's open
-                const followupModal = bootstrap.Modal.getInstance(document.getElementById('followupIssueModal'));
-                if (followupModal) {
-                    followupModal.hide();
-                    document.getElementById('followupIssueForm').reset();
-                }
-                
-                // Update the GitHub tab with the new HTML
-                if (response.github_tab_html) {
-                    document.getElementById('github').innerHTML = response.github_tab_html;
-                }
-                
-                // Ensure modal backdrop is removed
-                removeModalBackdrop();
-                
-                // Show mail confirmation modal (reuse existing mail modal from item_form.html)
-                if (typeof showMailConfirmationModal === 'function') {
-                    showMailConfirmationModal(response.mail_preview, response.item_id);
-                } else {
-                    console.error('showMailConfirmationModal function not found');
-                    // Fallback: show a toast notification
-                    showToast('success', 'GitHub issue created successfully. Mail preview not available.');
-                }
-                return;
-            }
-        } catch (e) {
-            // Not JSON, might be HTML response - handle as regular HTMX response
-        }
-        
-        // Handle regular HTML response (no mail preview)
-        // Close the followup modal if it's open
-        const followupModal = bootstrap.Modal.getInstance(document.getElementById('followupIssueModal'));
-        if (followupModal) {
-            followupModal.hide();
-            document.getElementById('followupIssueForm').reset();
-        }
-        
-        // Update the GitHub tab with the response
-        document.getElementById('github').innerHTML = xhr.responseText;
-        
-        // Ensure modal backdrop is removed
-        removeModalBackdrop();
-        
-        // Show success toast
-        if (typeof showToast === 'function') {
-            showToast('success', 'GitHub issue created successfully');
-        }
-    } else {
-        // Handle errors
-        if (typeof showToast === 'function') {
-            const errorMsg = xhr.responseText || 'Failed to create GitHub issue';
-            showToast('error', errorMsg);
-        }
-    }
-}
-
-// Helper function to remove modal backdrop
-function removeModalBackdrop() {
-    // Remove any lingering modal backdrops
-    const backdrops = document.querySelectorAll('.modal-backdrop');
-    backdrops.forEach(backdrop => backdrop.remove());
-    
-    // Remove modal-open class from body
-    document.body.classList.remove('modal-open');
-    
-    // Reset body padding/overflow that Bootstrap may have set
-    document.body.style.overflow = '';
-    document.body.style.paddingRight = '';
-}
-
-// Keep the old function for compatibility (redirect to new handler)
-function handleFollowupIssueResponse(event) {
-    handleGitHubIssueCreation(event);
-}
-</script>
+{# GitHub issue creation JS handlers (handleGitHubIssueCreation, removeModalBackdrop) #}
+{# live in item_detail.html so they are available regardless of whether this tab #}
+{# has been lazily loaded – e.g. when triggered from the item action menu. #}


### PR DESCRIPTION
Automated draft PR opened by the Claude queue worker for Agira item #1073.

Model: Opus
Job: #264

---

## Zusammenfassung

Die bestehende Funktion zum Erstellen eines GitHub-Issues ist jetzt zusätzlich als Aktion **„An GitHub übergeben“** im Action-Menü des Item-Details verfügbar – direkt unter **„An Claude übergeben“**. Die Aktion führt exakt denselben Flow aus wie der bisherige Button **„Create GitHub Issue“** im Reiter „GitHub“ und nutzt denselben Endpoint/Handler (kein Parallelcode). Zusätzlich ist die GitHub-Übergabe ab sofort **statusunabhängig** und nicht mehr an den Item-Status gekoppelt.

## Änderungen

- **`templates/item_detail.html`**: Neuer Menü-Eintrag „An GitHub übergeben“ direkt unter „An Claude übergeben“. Er postet per HTMX auf den bestehenden Endpoint `item-create-github-issue` und verarbeitet die Antwort über den gemeinsamen Handler `handleGitHubIssueCreation` (identisch zum GitHub-Reiter-Button). Der Eintrag ist immer sichtbar und statusunabhängig.
- **`templates/item_detail.html`**: Die JS-Handler `handleGitHubIssueCreation`, `removeModalBackdrop` und `handleFollowupIssueResponse` wurden aus dem lazy geladenen Partial hierher (immer geladen) verschoben, damit die Menü-Aktion auch funktioniert, wenn der GitHub-Reiter noch nie geöffnet wurde.
- **`templates/partials/item_github_tab.html`**: Das statusabhängige UI-Gating entfernt – der „Create GitHub Issue“-Button hängt nur noch vom vorhandenen GitHub-PAT ab, nicht mehr vom Item-Status. Das duplizierte `<script>` wurde entfernt (nun einzige Definition in `item_detail.html`).
- **`core/views.py`**: Der serverseitige Status-Guard (`can_create_issue_for_item`) in `item_create_github_issue` wurde entfernt, sodass die Erstellung statusunabhängig möglich ist. Die übrigen Prüfungen (GitHub aktiviert, PAT vorhanden) bleiben unverändert.
- **`core/test_github_issue_creation.py`**: Der Test `test_view_rejects_inbox_item` (der das alte Guard-Verhalten prüfte) wurde durch `test_view_creates_issue_for_inbox_item` ersetzt, der das neue statusunabhängige Verhalten abbildet.

## Warum / Entscheidungen

- **Single Source of Truth statt Parallelimplementierung**: Die Menü-Aktion zeigt auf denselben Endpoint (`item-create-github-issue`) und denselben Response-Handler wie der bestehende Button – so bleiben API-Aufrufe, Mappings, Folgeprozesse (Mail-Trigger) und Fehlerbehandlung unverändert. Nicht eine eigene Client-/Server-Logik für das Menü, weil das die geforderte Konsistenz beider Einstiegspunkte gefährdet hätte.
- **JS-Handler in `item_detail.html` verschoben statt dupliziert**: Der Handler lag bisher im lazy geladenen GitHub-Tab-Partial und wäre bei einem Menü-Klick ohne vorher geöffneten Reiter nicht definiert. Nicht den Handler im Partial belassen und im Menü duplizieren, weil das doppelte Business-Glue-Logik und Divergenzrisiko erzeugt hätte. Das Partial wird stets innerhalb von `item_detail.html` gerendert, daher ist die Funktion immer verfügbar.
- **Status-Guard komplett entfernt statt umgangen**: Der blockierende Guard wurde serverseitig und im UI beider Einstiegspunkte entfernt, damit die Aktion überall konsistent immer verfügbar ist. Nicht nur clientseitig ausblenden, weil der Server sonst weiterhin mit 400 blockiert hätte.
- **`can_create_issue_for_item` bewusst nicht gelöscht**: Die Service-Methode wird weiterhin an anderer Stelle (`core/admin.py`) genutzt; nur die blockierende Verwendung für diese UI-Übergabe wurde entfernt. Nicht die Methode global auf „immer True“ ändern, weil das Verhalten außerhalb des Scopes verändert hätte.
- **Rolle unverändert gelassen**: Der Eintrag ist statusunabhängig und immer sichtbar, entsprechend der Sichtbarkeit des GitHub-Reiters für alle Nutzer. Nicht an die Agent-Rolle gekoppelt wie „An Claude übergeben“, weil die Anforderung „immer verfügbar“ lautet.

## Test-Hinweise

- Item-Detail öffnen → Action-Menü aufklappen: Eintrag **„An GitHub übergeben“** erscheint direkt unter **„An Claude übergeben“**.
- Klick auf **„An GitHub übergeben“** erstellt das GitHub-Issue mit demselben Flow wie der Button im GitHub-Reiter (Issue-Erstellung, ggf. Status→Working, Mail-Preview-Modal, Toast, Aktualisierung des GitHub-Reiters).
- Aktion mit einem Item testen, dessen Status bisher blockiert hätte (z. B. `Inbox`/`Closed`): Ausführung ist nun möglich, kein Status-Fehler mehr.
- Bestehender Button „Create GitHub Issue“ im Reiter „GitHub“ funktioniert weiterhin und verhält sich konsistent.
- Automatisiert: `python manage.py test core.test_github_issue_creation` – der neue Test `test_view_creates_issue_for_inbox_item` deckt die Statusunabhängigkeit ab. Hinweis: In dieser Umgebung schlagen einige GitHub-View-Tests bereits vor der Änderung fehl, weil der Test-User kein persönliches GitHub-PAT konfiguriert hat (`has_github_pat()` → 400); dies ist vorbestehend und unabhängig von dieser Änderung.