### PR TITLE
Mobile Ansicht / Smartphone Menü einklappen

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -358,6 +358,21 @@
                 localStorage.setItem('sidebarCollapsed', isCollapsed);
             });
 
+            // Mobile: collapse the sidebar automatically after tapping a navigation link.
+            // Reuses the existing "collapsed" toggle mechanism instead of custom logic.
+            // Only fires on the mobile breakpoint (matches the CSS max-width: 768px rule),
+            // so the desktop behaviour stays untouched.
+            const mobileNavQuery = window.matchMedia('(max-width: 768px)');
+            sidebar.querySelectorAll('.sidebar-link').forEach(function(link) {
+                link.addEventListener('click', function() {
+                    if (mobileNavQuery.matches && !sidebar.classList.contains('collapsed')) {
+                        sidebar.classList.add('collapsed');
+                        mainContent.classList.add('sidebar-collapsed');
+                        localStorage.setItem('sidebarCollapsed', 'true');
+                    }
+                });
+            });
+
             // Right sidebar (Recents & Pinned) toggle
             const rightSidebar = document.getElementById('rightSidebar');
             const rightSidebarToggle = document.getElementById('rightSidebarToggle');


### PR DESCRIPTION
Automated draft PR opened by the Claude queue worker for Agira item #1074.

Model: Opus
Job: #265

---

## Zusammenfassung

Auf Smartphones blieb die geöffnete Seiten-Navigation (Sidebar) nach dem Antippen eines Navigationslinks sichtbar und musste manuell geschlossen werden. Jetzt schließt sich das Menü auf mobilen Breakpoints automatisch, sobald ein regulärer Navigationslink ausgewählt wird. Der Link wird dabei ganz normal weiter ausgeführt.

## Änderungen

- `templates/base.html`: Im bestehenden Sidebar-Init-Script einen Klick-Handler für alle `.sidebar-link`-Einträge ergänzt. Auf dem mobilen Breakpoint (`max-width: 768px`) wird beim Klick die vorhandene `collapsed`-Logik ausgelöst (Sidebar wird per `translateX(-100%)` ausgeblendet) und der Zustand wie beim manuellen Toggle in `localStorage` persistiert, damit die Navigation auch nach dem Laden der Zielseite geschlossen bleibt.

## Warum / Entscheidungen

- Wiederverwendung des bestehenden `collapsed`-Toggle-Mechanismus statt paralleler Custom-Schließlogik, wie in den Anforderungen gefordert. Der Handler spiegelt exakt das Verhalten des vorhandenen Sidebar-Toggle-Buttons wider (gleiche Klassen, gleicher `localStorage`-Key).
- Erkennung des mobilen Modus über `window.matchMedia('(max-width: 768px)')`, passend zum bereits im CSS definierten Breakpoint. Dadurch bleibt das Desktop-Verhalten unverändert, weil der Handler dort schlicht nicht greift.
- Vor dem Schließen wird geprüft, ob die Sidebar noch nicht `collapsed` ist. So entstehen keine doppelten Toggle-/Flicker-Effekte.
- Nur `.sidebar-link`-Einträge angebunden, nicht die `.sidebar-section-header` (Bootstrap-Collapse-Umschalter für Unterbereiche). Damit klappt ein Antippen der Sektionsüberschrift weiterhin nur die Untergruppe auf/zu, ohne die gesamte Navigation zu schließen.
- Nicht als reines Load-Time-Default gelöst (mobil immer geschlossen starten), weil das den Default-Zustand des Menüs verändert hätte; die Aufgabe verlangt ausschließlich das Schließen nach Auswahl eines Eintrags.
- Kein Bootstrap-Offcanvas/Navbar-Collapse eingeführt, weil die Navigation projektweit eine eigene `sidebar`-Implementierung mit `collapsed`-Klasse ist; ein Umbau auf Bootstrap-Komponenten wäre eine Neugestaltung und außerhalb des Aufgabenumfangs.

## Test-Hinweise

- Mobilen Viewport (≤ 768px) öffnen, Menü über den Toggle-Button öffnen, einen internen Navigationslink (z. B. Dashboard, Projects, Kanban) antippen: Zielseite lädt und das Menü ist geschlossen.
- Mehrere unterschiedliche Einträge inkl. Untereinträge (Items → Kanban/Inbox/Backlog) prüfen: Verhalten ist konsistent.
- Antippen einer Sektionsüberschrift (z. B. „Items", „AI/KI") klappt weiterhin nur die Untergruppe auf/zu, ohne die Sidebar zu schließen.
- Desktop-Viewport (> 768px) prüfen: Toggle-Verhalten und Icon-Collapse unverändert, kein automatisches Schließen beim Klick auf Links.