### PR TITLE
Reiter Github im Issue

### DIFF
--- a/core/test_followup_github_issues.py
+++ b/core/test_followup_github_issues.py
@@ -310,17 +310,23 @@ class FollowupGitHubIssueTestCase(TestCase):
             state='closed',
             html_url='https://github.com/testowner/testrepo/issues/1',
         )
-        
+
+        # The follow-up button in the tab is gated behind a per-user PAT.
+        self.user.github_pat = 'test_pat_123'
+        self.user.save()
+
         # Load GitHub tab
         url = reverse('item-github-tab', args=[item.id])
         response = self.client.get(url)
-        
+
         self.assertEqual(response.status_code, 200)
         content = response.content.decode()
-        
-        # Should show follow-up button instead of regular create button
+
+        # Should show follow-up button instead of regular create button. The button
+        # opens the #followupIssueModal, which now lives on the item detail page
+        # (item_detail.html) so the action menu can reuse it without opening the tab.
         self.assertIn('Create Follow-up GitHub Issue', content)
-        self.assertIn('followupIssueModal', content)
+        self.assertIn('data-bs-target="#followupIssueModal"', content)
     
     def test_github_tab_shows_regular_button_when_no_issue_exists(self):
         """Test that GitHub tab shows regular button when item has no issues."""

--- a/core/test_item_detail.py
+++ b/core/test_item_detail.py
@@ -1151,3 +1151,86 @@ class ItemDetailClaudeCostAggregationTest(TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertIsNone(response.context['claude_total_cost'])
+
+
+class ItemGithubOverviewTest(TestCase):
+    """First-level GitHub overview and the 'Create Follow-up Issue' action menu entry."""
+
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username='ghuser', email='gh@example.com', password='testpass',
+            name='GH User', role='Agent',
+        )
+        self.project = Project.objects.create(
+            name='GH Project', github_owner='owner', github_repo='repo',
+        )
+        self.item_type = ItemType.objects.create(key='bug', name='Bug', is_active=True)
+        self.item = Item.objects.create(
+            project=self.project, title='GH Item', type=self.item_type,
+            status=ItemStatus.WORKING,
+        )
+        self.client = Client()
+        self.client.login(username='ghuser', password='testpass')
+
+    def _url(self):
+        return reverse('item-detail', args=[self.item.id])
+
+    def test_no_overview_when_no_mappings(self):
+        """Without linked artefacts the compact overview renders no card."""
+        response = self.client.get(self._url())
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, 'id="github-overview"')
+        self.assertEqual(list(response.context['external_mappings']), [])
+        # No mappings -> follow-up action disabled
+        self.assertFalse(response.context['has_closed_github_issue'])
+
+    def test_overview_shows_issue_and_pr_with_link_and_state(self):
+        """Overview lists both issues and PRs with number, link and state marker."""
+        ExternalIssueMapping.objects.create(
+            item=self.item, github_id=1, number=11, kind=ExternalIssueKind.ISSUE,
+            state='open', html_url='https://github.com/owner/repo/issues/11',
+        )
+        ExternalIssueMapping.objects.create(
+            item=self.item, github_id=2, number=22, kind=ExternalIssueKind.PR,
+            state='merged', html_url='https://github.com/owner/repo/pull/22',
+        )
+        response = self.client.get(self._url())
+        content = response.content.decode()
+        self.assertIn('id="github-overview"', content)
+        self.assertIn('https://github.com/owner/repo/issues/11', content)
+        self.assertIn('https://github.com/owner/repo/pull/22', content)
+        self.assertIn('Issue #11', content)
+        self.assertIn('PR #22', content)
+        self.assertIn('open', content)
+        self.assertIn('merged', content)
+
+    def test_followup_disabled_when_only_open_issue(self):
+        """Open issue only -> follow-up action disabled."""
+        ExternalIssueMapping.objects.create(
+            item=self.item, github_id=1, number=11, kind=ExternalIssueKind.ISSUE,
+            state='open', html_url='https://github.com/owner/repo/issues/11',
+        )
+        response = self.client.get(self._url())
+        self.assertFalse(response.context['has_closed_github_issue'])
+
+    def test_followup_disabled_when_only_pr(self):
+        """A PR alone never activates the follow-up action, even if closed/merged."""
+        ExternalIssueMapping.objects.create(
+            item=self.item, github_id=2, number=22, kind=ExternalIssueKind.PR,
+            state='merged', html_url='https://github.com/owner/repo/pull/22',
+        )
+        response = self.client.get(self._url())
+        self.assertFalse(response.context['has_closed_github_issue'])
+
+    def test_followup_enabled_when_closed_issue_exists(self):
+        """At least one closed issue -> follow-up action active; modal available globally."""
+        ExternalIssueMapping.objects.create(
+            item=self.item, github_id=1, number=11, kind=ExternalIssueKind.ISSUE,
+            state='closed', html_url='https://github.com/owner/repo/issues/11',
+        )
+        response = self.client.get(self._url())
+        content = response.content.decode()
+        self.assertTrue(response.context['has_closed_github_issue'])
+        # Follow-up modal is present on the detail page even without opening the GitHub tab
+        self.assertIn('id="followupIssueModal"', content)
+        self.assertIn('Create Follow-up Issue', content)

--- a/core/views.py
+++ b/core/views.py
@@ -1074,8 +1074,20 @@ def item_detail(request, item_id):
         total=models.Sum('total_cost_usd')
     )['total']
 
+    # GitHub artefacts surfaced on the first level of the detail (outside the
+    # GitHub tab). Same queryset/ordering the GitHub tab uses – single source of
+    # truth, no parallel data preparation. `has_closed_github_issue` gates the
+    # "Create Follow-up Issue" action: active only when at least one linked
+    # GitHub *Issue* is closed (PRs alone never activate it).
+    external_mappings = item.external_mappings.all().order_by('-last_synced_at')
+    has_closed_github_issue = item.external_mappings.filter(
+        kind=ExternalIssueKind.ISSUE, state='closed'
+    ).exists()
+
     context = {
         'item': item,
+        'external_mappings': external_mappings,
+        'has_closed_github_issue': has_closed_github_issue,
         'followers': followers,
         'users': users,
         'agents': agents,

--- a/templates/item_detail.html
+++ b/templates/item_detail.html
@@ -251,6 +251,15 @@
                         <i class="bi bi-github me-2"></i>An GitHub übergeben
                     </button>
                 </li>
+                {# Same follow-up flow as the button in the GitHub tab (shared #followupIssueModal). #}
+                {# Active only when at least one linked GitHub Issue is closed; PRs alone never activate it. #}
+                <li>
+                    <button type="button"
+                            class="dropdown-item{% if not has_closed_github_issue %} disabled{% endif %}"
+                            {% if has_closed_github_issue %}data-bs-toggle="modal" data-bs-target="#followupIssueModal"{% else %}disabled aria-disabled="true"{% endif %}>
+                        <i class="bi bi-github me-2"></i>Create Follow-up Issue
+                    </button>
+                </li>
                 <li>
                     <button type="button" class="dropdown-item" data-bs-toggle="modal" data-bs-target="#assignResponsibleModal">
                         <i class="bi bi-person-plus me-2"></i>Assign
@@ -290,6 +299,9 @@
     <strong>Achtung: Incoming-Projekt!</strong> Dieses Item befindet sich im Projekt "Incoming" und muss in das richtige Projekt verschoben werden, bevor es bearbeitet werden kann.
 </div>
 {% endif %}
+
+<!-- First-level GitHub overview: linked issues/PRs visible without opening the GitHub tab -->
+{% include 'partials/item_github_overview.html' %}
 
 <!-- Tab Navigation -->
 <ul class="nav nav-tabs mb-4" id="itemTabs" role="tablist">
@@ -2434,6 +2446,74 @@
                 <div class="modal-footer">
                     <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
                     <button type="submit" class="btn btn-primary">Assign</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+
+{# Follow-up GitHub Issue Modal. #}
+{# Lives here (always loaded) instead of in the lazily loaded GitHub tab so the #}
+{# "Create Follow-up Issue" action-menu entry works even when the GitHub tab was #}
+{# never opened. The GitHub tab's follow-up button targets this same modal. #}
+{# Uses the shared handleGitHubIssueCreation handler and item-create-github-issue #}
+{# endpoint – no parallel flow. #}
+<div class="modal fade" id="followupIssueModal" tabindex="-1" aria-labelledby="followupIssueModalLabel" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="followupIssueModalLabel">Create Follow-up GitHub Issue</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <form id="followupIssueForm" hx-post="{% url 'item-create-github-issue' item.id %}" hx-swap="none" hx-on::after-request="handleGitHubIssueCreation(event)">
+                {% csrf_token %}
+                <div class="modal-body">
+                    <div class="alert alert-info">
+                        <small>
+                            <strong>Note:</strong> This will create a new GitHub issue and update the item description with your notes and a list of all related issues and PRs.
+                        </small>
+                    </div>
+                    <div class="mb-3">
+                        <label for="followupNotes" class="form-label">Notes for Follow-up Work <span class="text-danger">*</span></label>
+                        <textarea
+                            class="form-control"
+                            id="followupNotes"
+                            name="notes"
+                            rows="5"
+                            required
+                            placeholder="Describe what additional work is needed and why a follow-up issue is necessary..."></textarea>
+                        <div class="form-text">
+                            These notes will be appended to the item description with the current date and time.
+                        </div>
+                    </div>
+                    <div class="mb-3">
+                        <div class="form-check">
+                            <input
+                                class="form-check-input"
+                                type="checkbox"
+                                id="sendMinimalDescription"
+                                name="send_minimal_description"
+                                value="true">
+                            <label class="form-check-label" for="sendMinimalDescription">
+                                <strong>Send minimal description to GitHub</strong>
+                            </label>
+                            <div class="form-text">
+                                If checked, only a reference to the original issues/PRs and your notes will be sent to GitHub.
+                                If unchecked, the complete item description will be sent.
+                                <br>
+                                <small class="text-muted">Note: The item description in Agira will not be changed, only what is sent to GitHub.</small>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                    <button type="submit" class="btn btn-success">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" fill="currentColor" class="me-1" viewBox="0 0 16 16">
+                            <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.012 8.012 0 0 0 16 8c0-4.42-3.58-8-8-8z"/>
+                        </svg>
+                        Create Follow-up Issue
+                    </button>
                 </div>
             </form>
         </div>

--- a/templates/partials/item_github_overview.html
+++ b/templates/partials/item_github_overview.html
@@ -1,0 +1,24 @@
+{# Compact, first-level overview of the GitHub artefacts linked to an item. #}
+{# Fed by the same `external_mappings` queryset the GitHub tab uses (see #}
+{# core.views.item_detail) – no parallel data preparation. Rendered outside the #}
+{# GitHub tab so the references are visible without opening the tab. #}
+{% if external_mappings %}
+<div class="card mb-3" id="github-overview">
+    <div class="card-body py-2">
+        <div class="d-flex flex-wrap align-items-center gap-2">
+            <span class="text-muted me-1 d-inline-flex align-items-center">
+                <i class="bi bi-github me-1"></i>GitHub:
+            </span>
+            {% for mapping in external_mappings %}
+            <a href="{{ mapping.html_url }}" target="_blank" rel="noopener noreferrer"
+               class="badge rounded-pill text-decoration-none d-inline-flex align-items-center gap-1
+                      {% if mapping.state == 'open' %}bg-success{% elif mapping.state == 'merged' %}bg-primary{% else %}bg-secondary{% endif %}"
+               title="{{ mapping.get_kind_display }} #{{ mapping.number }} – {{ mapping.state }}">
+                <span>{% if mapping.kind == 'PR' %}PR{% else %}Issue{% endif %} #{{ mapping.number }}</span>
+                <span class="opacity-75">· {{ mapping.state }}</span>
+            </a>
+            {% endfor %}
+        </div>
+    </div>
+</div>
+{% endif %}

--- a/templates/partials/item_github_tab.html
+++ b/templates/partials/item_github_tab.html
@@ -172,69 +172,7 @@
     </div>
 </div>
 
-<!-- Follow-up Issue Modal -->
-<div class="modal fade" id="followupIssueModal" tabindex="-1" aria-labelledby="followupIssueModalLabel" aria-hidden="true">
-    <div class="modal-dialog">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h5 class="modal-title" id="followupIssueModalLabel">Create Follow-up GitHub Issue</h5>
-                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-            </div>
-            <form id="followupIssueForm" hx-post="{% url 'item-create-github-issue' item.id %}" hx-swap="none" hx-on::after-request="handleGitHubIssueCreation(event)">
-                {% csrf_token %}
-                <div class="modal-body">
-                    <div class="alert alert-info">
-                        <small>
-                            <strong>Note:</strong> This will create a new GitHub issue and update the item description with your notes and a list of all related issues and PRs.
-                        </small>
-                    </div>
-                    <div class="mb-3">
-                        <label for="followupNotes" class="form-label">Notes for Follow-up Work <span class="text-danger">*</span></label>
-                        <textarea 
-                            class="form-control" 
-                            id="followupNotes" 
-                            name="notes" 
-                            rows="5" 
-                            required
-                            placeholder="Describe what additional work is needed and why a follow-up issue is necessary..."></textarea>
-                        <div class="form-text">
-                            These notes will be appended to the item description with the current date and time.
-                        </div>
-                    </div>
-                    <div class="mb-3">
-                        <div class="form-check">
-                            <input 
-                                class="form-check-input" 
-                                type="checkbox" 
-                                id="sendMinimalDescription" 
-                                name="send_minimal_description"
-                                value="true">
-                            <label class="form-check-label" for="sendMinimalDescription">
-                                <strong>Send minimal description to GitHub</strong>
-                            </label>
-                            <div class="form-text">
-                                If checked, only a reference to the original issues/PRs and your notes will be sent to GitHub. 
-                                If unchecked, the complete item description will be sent.
-                                <br>
-                                <small class="text-muted">Note: The item description in Agira will not be changed, only what is sent to GitHub.</small>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <div class="modal-footer">
-                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
-                    <button type="submit" class="btn btn-success">
-                        <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" fill="currentColor" class="me-1" viewBox="0 0 16 16">
-                            <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.012 8.012 0 0 0 16 8c0-4.42-3.58-8-8-8z"/>
-                        </svg>
-                        Create Follow-up Issue
-                    </button>
-                </div>
-            </form>
-        </div>
-    </div>
-</div>
-
-{# GitHub issue creation JS handlers (handleGitHubIssueCreation, removeModalBackdrop) #}
-{# live in item_detail.html so they are available regardless of whether this tab #}
-{# has been lazily loaded – e.g. when triggered from the item action menu. #}
+{# The Follow-up Issue Modal (#followupIssueModal) and the GitHub issue creation #}
+{# JS handlers (handleGitHubIssueCreation, removeModalBackdrop) live in #}
+{# item_detail.html so they are available regardless of whether this tab has been #}
+{# lazily loaded – e.g. when triggered from the item action menu. #}


### PR DESCRIPTION
Automated draft PR opened by the Claude queue worker for Agira item #1075.

Model: Opus
Job: #266

---

## Zusammenfassung

Verknüpfte GitHub-Artefakte sind im Item-Detail jetzt auf der ersten Ebene sichtbar – ohne den GitHub-Reiter zu öffnen. Zusätzlich ist die bestehende Aktion **"Create Follow-up Issue"** nun auch im Action-Menü verfügbar und nutzt denselben Followup-Flow wie der Button im GitHub-Reiter.

## Änderungen

- **Kompakte GitHub-Übersicht auf erster Ebene** (`templates/partials/item_github_overview.html`): Neue, kompakte Leiste direkt über der Tab-Navigation, dadurch beim Öffnen des Item-Details sofort sichtbar. Zeigt pro Eintrag Typ (`Issue`/`PR`), GitHub-Nummer, einen klickbaren Link (`html_url`) und einen Status-Marker (`open` = grün, `merged` = blau, sonst grau). Wird nur gerendert, wenn Verknüpfungen existieren.
- **View** (`core/views.py`, `item_detail`): Liefert `external_mappings` (identische Query/Sortierung wie der GitHub-Reiter) sowie `has_closed_github_issue` in den Kontext.
- **Action-Menü** (`templates/item_detail.html`): Neuer Eintrag "Create Follow-up Issue" unter "An GitHub übergeben". Aktiv nur bei mindestens einem geschlossenen GitHub-Issue, sonst `disabled`.
- **Followup-Modal global** (`templates/item_detail.html` / `templates/partials/item_github_tab.html`): Das `#followupIssueModal` wurde aus dem lazy geladenen GitHub-Reiter an eine global geladene Stelle im Item-Detail verschoben. Der Followup-Button im GitHub-Reiter bleibt erhalten und targetet dasselbe Modal.
- **Tests** (`core/test_item_detail.py`, `core/test_followup_github_issues.py`): Neue Testklasse für Übersicht und Aktivierungsregel; Anpassung eines bestehenden Tab-Tests an die neue Modal-Position.

## Warum / Entscheidungen

- **Übersicht über der Tab-Navigation, nicht im Overview-Tab** – damit sie unabhängig vom aktiven Reiter sofort sichtbar ist. Nicht im Overview-Tab, weil sie sonst beim Wechsel auf einen anderen Reiter verschwinden würde.
- **Wiederverwendung von `external_mappings`** – Single Source of Truth. Nicht eine zweite Query/Serialisierung, weil das zu paralleler, driftender Datenaufbereitung führen würde.
- **Status-Marker direkt aus dem Modellfeld `state`** – `merged` wird separat dargestellt, weil das bestehende Modell diesen Zustand bereits unterscheidet (der PR-Webhook speichert `state='merged'`). Nicht eine neue Ableitungs-/Synchronisationslogik, weil der Zustand bereits persistiert vorliegt.
- **Modal nach `item_detail.html` verschoben statt dupliziert** – analog zu #723. Nicht ein zweites Modal/zweiter Endpoint im Action-Menü, weil die Aktion sonst zwei parallele Client-Flows hätte; so funktioniert der Einstieg auch ohne vorher geöffneten GitHub-Reiter.
- **Aktivierung über `has_closed_github_issue` (Issue + `state='closed'`)** – PRs allein aktivieren nicht. Nicht Gating über bloße Existenz eines Issues (wie der Button im Reiter), weil die geforderte Regel ausdrücklich ein *geschlossenes* Issue verlangt.
- **Followup-Button im GitHub-Reiter bewusst belassen** – gemäß Aufgabe „vorerst zusätzlich". Nicht entfernt, weil das über den Scope dieses Schritts hinausginge.

## Test-Hinweise

- `python manage.py test core.test_item_detail.ItemGithubOverviewTest` deckt ab: keine Übersicht ohne Mappings; Übersicht mit Issue + PR inkl. Link/State; Followup deaktiviert bei nur offenem Issue; Followup deaktiviert bei nur PR; Followup aktiv bei geschlossenem Issue (Modal global vorhanden).
- Manuell im Item-Detail: Item mit offenem Issue → Übersicht sichtbar, Followup im Action-Menü deaktiviert. Item mit geschlossenem Issue → Followup aktiv, Aufruf über Action-Menü ohne vorher geöffneten GitHub-Reiter funktioniert (Modal + Handler vorhanden).
- Vorbestehende, umgebungsbedingte Fehlschläge in den GitHub-Testsuiten (fehlender per-User-PAT) bestehen unverändert fort und wurden durch diese Änderung weder verursacht noch behoben.