### PR TITLE
Suggested Model: Opus 4.8 und Opus 5 unterscheiden + Fable 5 aufnehmen

### DIFF
--- a/core/management/commands/run_claude_worker.py
+++ b/core/management/commands/run_claude_worker.py
@@ -73,6 +73,7 @@ from core.models import (
     ClaudeQueueJobAuthMode,
     ClaudeQueueJobStatus,
     ItemStatus,
+    claude_cli_model_id,
 )
 
 logger = logging.getLogger(__name__)
@@ -936,12 +937,17 @@ class Command(BaseCommand):
         return result
 
     def _build_claude_args(self, job):
-        """Assemble the headless Claude Code command line."""
-        model = job.model or job.item.suggested_model or 'sonnet'
+        """Assemble the headless Claude Code command line.
+
+        The job's model is a stored slug (``opus-5``), not something the CLI
+        understands — it is translated to a concrete ``--model`` identifier
+        here (#1082).
+        """
+        model = job.model or job.item.suggested_model
         return [
             settings.CLAUDE_CLI_BIN,
             '-p', self._build_prompt(job.item),
-            '--model', model,
+            '--model', claude_cli_model_id(model),
             '--output-format', 'stream-json',
             '--verbose',
             '--dangerously-skip-permissions',

--- a/core/migrations/0075_split_suggested_model_opus_generations.py
+++ b/core/migrations/0075_split_suggested_model_opus_generations.py
@@ -1,0 +1,77 @@
+"""Split the generic "Opus" model choice into Opus 4.8 / Opus 5, add Fable 5 (#1082).
+
+Existing rows carry the generic ``opus`` slug, which the worker used to pass to
+the CLI as the floating ``opus`` alias. That alias resolved to Opus 4.8 in
+practice, so mapping the old value onto ``opus-4-8`` preserves what those items
+were actually running.
+"""
+
+from django.db import migrations, models
+
+_LEGACY_OPUS = 'opus'
+_OPUS_4_8 = 'opus-4-8'
+
+_TARGETS = (
+    ('Item', 'suggested_model'),
+    ('ClaudeQueueJob', 'model'),
+)
+
+
+def opus_to_opus_4_8(apps, schema_editor):
+    for model_name, field in _TARGETS:
+        model = apps.get_model('core', model_name)
+        model.objects.filter(**{field: _LEGACY_OPUS}).update(**{field: _OPUS_4_8})
+
+
+def opus_4_8_to_opus(apps, schema_editor):
+    """Fold both new Opus generations (and Fable) back onto the generic slug.
+
+    Reversing is lossy — the old field had no way to express the distinction —
+    so everything above Sonnet collapses to ``opus``, mirroring the pre-#1082
+    state where any Opus-class job ran on the floating alias.
+    """
+    for model_name, field in _TARGETS:
+        model = apps.get_model('core', model_name)
+        model.objects.filter(
+            **{f'{field}__in': [_OPUS_4_8, 'opus-5', 'fable-5']}
+        ).update(**{field: _LEGACY_OPUS})
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('core', '0074_claudequeuejob_allow_api_key_fallback_and_more'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='claudequeuejob',
+            name='model',
+            field=models.CharField(
+                choices=[
+                    ('sonnet', 'Sonnet'),
+                    ('opus-4-8', 'Opus 4.8'),
+                    ('opus-5', 'Opus 5'),
+                    ('fable-5', 'Fable 5'),
+                ],
+                default='sonnet',
+                max_length=20,
+            ),
+        ),
+        migrations.AlterField(
+            model_name='item',
+            name='suggested_model',
+            field=models.CharField(
+                choices=[
+                    ('sonnet', 'Sonnet'),
+                    ('opus-4-8', 'Opus 4.8'),
+                    ('opus-5', 'Opus 5'),
+                    ('fable-5', 'Fable 5'),
+                ],
+                default='sonnet',
+                help_text='AI-suggested Claude model for automated processing. A suggestion, not a gate — overridable in the UI.',
+                max_length=20,
+            ),
+        ),
+        migrations.RunPython(opus_to_opus_4_8, opus_4_8_to_opus),
+    ]

--- a/core/models.py
+++ b/core/models.py
@@ -619,12 +619,46 @@ class ChangePolicyRole(models.Model):
 
 
 class ClaudeQueueJobModel(models.TextChoices):
-    """Claude models available for automated item processing.
+    """Claude models available for automated item processing (#1082).
 
-    Fable is intentionally excluded from the automatism.
+    The Opus generations are listed separately so a job can be steered at a
+    specific one: Opus 4.8 and Opus 5 differ in cost and capability, and the
+    epic review pass (#1076/#1079) has to run on a different model than the
+    code author. Fable 5 rounds the list out at the top end.
+
+    The stored value is a stable slug, not a CLI identifier — see
+    ``CLAUDE_CLI_MODEL_IDS`` for the translation to ``claude --model``.
     """
     SONNET = 'sonnet', _('Sonnet')
-    OPUS = 'opus', _('Opus')
+    OPUS_4_8 = 'opus-4-8', _('Opus 4.8')
+    OPUS_5 = 'opus-5', _('Opus 5')
+    FABLE_5 = 'fable-5', _('Fable 5')
+
+
+# Display slug -> identifier handed to `claude --model`.
+#
+# Sonnet stays on the CLI's floating alias (that is the pre-#1082 behaviour and
+# keeps the cheap default tracking the current Sonnet); the Opus/Fable entries
+# are pinned to exact model IDs, because pinning is the whole point of the
+# split — a floating `opus` alias is what made 4.8 and 5 indistinguishable.
+CLAUDE_CLI_MODEL_IDS = {
+    ClaudeQueueJobModel.SONNET: 'sonnet',
+    ClaudeQueueJobModel.OPUS_4_8: 'claude-opus-4-8',
+    ClaudeQueueJobModel.OPUS_5: 'claude-opus-5',
+    ClaudeQueueJobModel.FABLE_5: 'claude-fable-5',
+}
+
+
+def claude_cli_model_id(value) -> str:
+    """Translate a stored ``ClaudeQueueJobModel`` slug into a CLI ``--model``.
+
+    Unknown or empty values fall back to Sonnet rather than being passed
+    through: a stale slug would otherwise reach the CLI verbatim and fail the
+    run, and the cheap default is the safe outcome for a suggestion field.
+    """
+    return CLAUDE_CLI_MODEL_IDS.get(
+        value, CLAUDE_CLI_MODEL_IDS[ClaudeQueueJobModel.SONNET]
+    )
 
 
 class ClaudeQueueJobAuthMode(models.TextChoices):

--- a/core/services/claude_queue/enqueue.py
+++ b/core/services/claude_queue/enqueue.py
@@ -20,16 +20,14 @@ from core.services.activity import ActivityService
 from core.services.claude_queue.hint import ensure_git_workflow_hint
 from core.services.workflow.item_workflow_guard import ItemWorkflowGuard
 
-# TODO(#834): once the model-selection agent lands, read `item.suggested_model`
-# here instead of always defaulting to sonnet.
 DEFAULT_CLAUDE_MODEL = ClaudeQueueJobModel.SONNET
 
 
 def _resolve_model(item) -> str:
     """Return the Claude model to run this item with.
 
-    Degrades gracefully to DEFAULT_CLAUDE_MODEL until #834 adds
-    `suggested_model` to Item.
+    The item's `suggested_model` wins; DEFAULT_CLAUDE_MODEL is the fallback for
+    items that carry no suggestion at all.
     """
     return getattr(item, 'suggested_model', None) or DEFAULT_CLAUDE_MODEL
 

--- a/core/services/claude_queue/model_classifier.py
+++ b/core/services/claude_queue/model_classifier.py
@@ -39,6 +39,18 @@ FILE_PATH_PATTERN = re.compile(r'\b[\w./-]+\.[A-Za-z]{1,5}\b')
 MIN_WORDS_FOR_CONFIDENT_SONNET = 10
 MIN_FILE_MENTIONS_FOR_OPUS = 3
 
+# The classifier only distinguishes "cheap default" from "needs an Opus-class
+# model" — picking *which* Opus generation is a human call, made in the UI
+# (#1082). Its coarse verdict therefore lands on Opus 4.8, the cheaper of the
+# two; the Haiku agent's vocabulary is unchanged and its bare 'opus' is mapped
+# onto the same value.
+AUTO_DETECT_OPUS = ClaudeQueueJobModel.OPUS_4_8
+
+_HAIKU_VALUE_ALIASES = {
+    'sonnet': ClaudeQueueJobModel.SONNET,
+    'opus': AUTO_DETECT_OPUS,
+}
+
 
 def _text_for(item) -> str:
     """Concatenate the item's textual fields for keyword/heuristic scans."""
@@ -52,19 +64,19 @@ def _contains_any(text: str, keywords) -> bool:
 def classify_by_heuristics(item) -> Optional[str]:
     """Cheap, deterministic first pass.
 
-    Returns 'opus' or 'sonnet' when confident, None when the signals are
-    inconclusive and a Haiku call is warranted.
+    Returns AUTO_DETECT_OPUS or 'sonnet' when confident, None when the signals
+    are inconclusive and a Haiku call is warranted.
     """
     text = _text_for(item).lower()
 
     if _contains_any(text, MIGRATION_KEYWORDS):
-        return ClaudeQueueJobModel.OPUS
+        return AUTO_DETECT_OPUS
     if _contains_any(text, SECURITY_KEYWORDS):
-        return ClaudeQueueJobModel.OPUS
+        return AUTO_DETECT_OPUS
     if _contains_any(text, LARGE_SCOPE_KEYWORDS):
-        return ClaudeQueueJobModel.OPUS
+        return AUTO_DETECT_OPUS
     if len(FILE_PATH_PATTERN.findall(text)) >= MIN_FILE_MENTIONS_FOR_OPUS:
-        return ClaudeQueueJobModel.OPUS
+        return AUTO_DETECT_OPUS
 
     if len((item.description or '').split()) >= MIN_WORDS_FOR_CONFIDENT_SONNET:
         return ClaudeQueueJobModel.SONNET
@@ -82,7 +94,10 @@ class ModelClassifierService:
         self.agent_service = agent_service or AgentService()
 
     def classify(self, item) -> str:
-        """Return the suggested Claude model ('sonnet' or 'opus') for item.
+        """Return the suggested Claude model for item.
+
+        The result is one of ``ClaudeQueueJobModel.SONNET`` /
+        ``AUTO_DETECT_OPUS``; the remaining choices are manual-only (#1082).
 
         Never raises: any failure in the Haiku fallback degrades to the
         safe default (sonnet) rather than silently defaulting to opus.
@@ -105,8 +120,8 @@ class ModelClassifierService:
             return None
 
         value = response.strip().lower()
-        if value in (ClaudeQueueJobModel.SONNET, ClaudeQueueJobModel.OPUS):
-            return value
+        if value in _HAIKU_VALUE_ALIASES:
+            return _HAIKU_VALUE_ALIASES[value]
 
         logger.warning(f"Haiku model classification returned unexpected value {value!r}, defaulting to sonnet")
         return None

--- a/core/services/claude_queue/test_model_classifier.py
+++ b/core/services/claude_queue/test_model_classifier.py
@@ -23,21 +23,21 @@ class ClassifyByHeuristicsTestCase(TestCase):
 
     def test_migration_keyword_triggers_opus(self):
         item = self._item(description='This needs a database migration to add a column.')
-        self.assertEqual(classify_by_heuristics(item), ClaudeQueueJobModel.OPUS)
+        self.assertEqual(classify_by_heuristics(item), ClaudeQueueJobModel.OPUS_4_8)
 
     def test_security_keyword_triggers_opus(self):
         item = self._item(description='Fix an authentication bypass vulnerability in login.')
-        self.assertEqual(classify_by_heuristics(item), ClaudeQueueJobModel.OPUS)
+        self.assertEqual(classify_by_heuristics(item), ClaudeQueueJobModel.OPUS_4_8)
 
     def test_large_scope_keyword_triggers_opus(self):
         item = self._item(description='Refactor the billing architecture across the codebase.')
-        self.assertEqual(classify_by_heuristics(item), ClaudeQueueJobModel.OPUS)
+        self.assertEqual(classify_by_heuristics(item), ClaudeQueueJobModel.OPUS_4_8)
 
     def test_many_file_mentions_trigger_opus(self):
         item = self._item(
             description='Update views.py, models.py and templates/item_form.html consistently.'
         )
-        self.assertEqual(classify_by_heuristics(item), ClaudeQueueJobModel.OPUS)
+        self.assertEqual(classify_by_heuristics(item), ClaudeQueueJobModel.OPUS_4_8)
 
     def test_clear_scoped_description_returns_sonnet(self):
         item = self._item(
@@ -71,7 +71,7 @@ class ModelClassifierServiceTestCase(TestCase):
 
         result = service.classify(item)
 
-        self.assertEqual(result, ClaudeQueueJobModel.OPUS)
+        self.assertEqual(result, ClaudeQueueJobModel.OPUS_4_8)
         agent_service.execute_agent.assert_not_called()
 
     def test_ambiguous_heuristic_falls_back_to_haiku_opus(self):
@@ -82,7 +82,7 @@ class ModelClassifierServiceTestCase(TestCase):
 
         result = service.classify(item)
 
-        self.assertEqual(result, ClaudeQueueJobModel.OPUS)
+        self.assertEqual(result, ClaudeQueueJobModel.OPUS_4_8)
         agent_service.execute_agent.assert_called_once()
         self.assertEqual(
             agent_service.execute_agent.call_args.kwargs['filename'],

--- a/core/services/claude_queue/test_model_selection.py
+++ b/core/services/claude_queue/test_model_selection.py
@@ -1,0 +1,84 @@
+"""Display slug -> `claude --model` identifier plumbing (#1082).
+
+Covers the two halves of the promise made by the Suggested-Model field: every
+selectable choice maps to a concrete CLI identifier, and that identifier is
+what the worker actually hands to Claude Code.
+"""
+
+from django.test import TestCase
+
+from core.management.commands.run_claude_worker import Command
+from core.models import (
+    CLAUDE_CLI_MODEL_IDS,
+    ClaudeQueueJob,
+    ClaudeQueueJobModel,
+    Item,
+    ItemType,
+    Project,
+    claude_cli_model_id,
+)
+
+
+class ClaudeCliModelIdTest(TestCase):
+    """The slug -> CLI identifier mapping."""
+
+    def test_every_choice_has_a_cli_identifier(self):
+        self.assertEqual(
+            set(CLAUDE_CLI_MODEL_IDS), set(ClaudeQueueJobModel.values),
+        )
+
+    def test_opus_generations_map_to_distinct_pinned_ids(self):
+        self.assertEqual(
+            claude_cli_model_id(ClaudeQueueJobModel.OPUS_4_8), 'claude-opus-4-8',
+        )
+        self.assertEqual(
+            claude_cli_model_id(ClaudeQueueJobModel.OPUS_5), 'claude-opus-5',
+        )
+
+    def test_fable_5_maps_to_its_model_id(self):
+        self.assertEqual(
+            claude_cli_model_id(ClaudeQueueJobModel.FABLE_5), 'claude-fable-5',
+        )
+
+    def test_sonnet_keeps_the_floating_cli_alias(self):
+        self.assertEqual(claude_cli_model_id(ClaudeQueueJobModel.SONNET), 'sonnet')
+
+    def test_unknown_slug_degrades_to_sonnet(self):
+        """A stale slug must not reach the CLI verbatim and break the run."""
+        self.assertEqual(claude_cli_model_id('opus'), 'sonnet')
+        self.assertEqual(claude_cli_model_id(''), 'sonnet')
+        self.assertEqual(claude_cli_model_id(None), 'sonnet')
+
+
+class BuildClaudeArgsModelTest(TestCase):
+    """The worker passes the resolved identifier, not the stored slug."""
+
+    def setUp(self):
+        self.project = Project.objects.create(name='Test Project')
+        self.item_type = ItemType.objects.create(key='task', name='Task')
+        self.item = Item.objects.create(
+            title='Some task', description='Do the thing.',
+            project=self.project, type=self.item_type,
+            suggested_model=ClaudeQueueJobModel.SONNET,
+        )
+
+    def _model_arg(self, job):
+        args = Command()._build_claude_args(job)
+        return args[args.index('--model') + 1]
+
+    def test_job_model_is_translated(self):
+        job = ClaudeQueueJob.objects.create(
+            item=self.item, project=self.project,
+            model=ClaudeQueueJobModel.OPUS_5,
+        )
+        self.assertEqual(self._model_arg(job), 'claude-opus-5')
+
+    def test_falls_back_to_the_items_suggestion(self):
+        job = ClaudeQueueJob.objects.create(
+            item=self.item, project=self.project, model='',
+        )
+        self.item.suggested_model = ClaudeQueueJobModel.FABLE_5
+        self.item.save()
+        job.refresh_from_db()
+
+        self.assertEqual(self._model_arg(job), 'claude-fable-5')

--- a/core/services/item_field_update.py
+++ b/core/services/item_field_update.py
@@ -157,8 +157,9 @@ def _resolve_release(_item: Item, raw: str) -> Optional[Release]:
 def _resolve_suggested_model(_item: Item, raw: str) -> str:
     """Resolve the manually overridable Claude-queue model suggestion (#1072).
 
-    Only the existing field choices (sonnet/opus) are accepted; there is no
-    inline "Auto-detect", so no classifier logic runs on this path.
+    Only the existing field choices (Sonnet / Opus 4.8 / Opus 5 / Fable 5) are
+    accepted; there is no inline "Auto-detect", so no classifier logic runs on
+    this path.
     """
     value = (raw or "").strip()
     if value not in ClaudeQueueJobModel.values:

--- a/core/test_item_detail.py
+++ b/core/test_item_detail.py
@@ -1102,7 +1102,7 @@ class ItemDetailClaudeCostAggregationTest(TestCase):
         )
         ClaudeQueueJob.objects.create(
             item=self.item, project=self.project,
-            model=ClaudeQueueJobModel.OPUS,
+            model=ClaudeQueueJobModel.OPUS_4_8,
             total_cost_usd=Decimal('2.500000'), num_turns=10,
         )
 

--- a/core/test_item_field_update.py
+++ b/core/test_item_field_update.py
@@ -169,14 +169,33 @@ class RequesterOrganisationSideEffectTest(GenericFieldUpdateTestBase):
 class SuggestedModelFieldTest(GenericFieldUpdateTestBase):
     """Inline HTMX editing of the manually overridable suggested_model (#1072)."""
 
-    def test_suggested_model_updates_to_opus(self):
-        response = self.client.post(self.url(), {'field': 'suggested_model', 'value': 'opus'})
+    def test_suggested_model_updates_to_opus_4_8(self):
+        response = self.client.post(self.url(), {'field': 'suggested_model', 'value': 'opus-4-8'})
         self.assertEqual(response.status_code, 200)
         self.item.refresh_from_db()
-        self.assertEqual(self.item.suggested_model, 'opus')
+        self.assertEqual(self.item.suggested_model, 'opus-4-8')
+
+    def test_suggested_model_updates_to_opus_5(self):
+        response = self.client.post(self.url(), {'field': 'suggested_model', 'value': 'opus-5'})
+        self.assertEqual(response.status_code, 200)
+        self.item.refresh_from_db()
+        self.assertEqual(self.item.suggested_model, 'opus-5')
+
+    def test_suggested_model_updates_to_fable_5(self):
+        response = self.client.post(self.url(), {'field': 'suggested_model', 'value': 'fable-5'})
+        self.assertEqual(response.status_code, 200)
+        self.item.refresh_from_db()
+        self.assertEqual(self.item.suggested_model, 'fable-5')
+
+    def test_legacy_opus_value_rejected(self):
+        """The pre-#1082 generic slug is gone; it must not slip through."""
+        response = self.client.post(self.url(), {'field': 'suggested_model', 'value': 'opus'})
+        self.assertEqual(response.status_code, 400)
+        self.item.refresh_from_db()
+        self.assertNotEqual(self.item.suggested_model, 'opus')
 
     def test_response_fragment_reports_success(self):
-        response = self.client.post(self.url(), {'field': 'suggested_model', 'value': 'opus'})
+        response = self.client.post(self.url(), {'field': 'suggested_model', 'value': 'opus-5'})
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, 'Gespeichert')
 

--- a/core/test_item_suggested_model.py
+++ b/core/test_item_suggested_model.py
@@ -35,7 +35,7 @@ class ItemSuggestedModelViewTest(TestCase):
 
         self.assertEqual(response.status_code, 200)
         item = Item.objects.get(id=response.json()['item_id'])
-        self.assertEqual(item.suggested_model, 'opus')
+        self.assertEqual(item.suggested_model, 'opus-4-8')
 
     def test_create_classifies_well_scoped_item_as_sonnet(self):
         response = self.client.post(reverse('item-create'), {
@@ -55,17 +55,17 @@ class ItemSuggestedModelViewTest(TestCase):
             'type': self.item_type.id,
             'title': 'Rename export button',
             'description': 'Change the label on the export button from "Export" to "Download CSV".',
-            'suggested_model': 'opus',
+            'suggested_model': 'opus-5',
         })
 
         self.assertEqual(response.status_code, 200)
         item = Item.objects.get(id=response.json()['item_id'])
-        self.assertEqual(item.suggested_model, 'opus')
+        self.assertEqual(item.suggested_model, 'opus-5')
 
     def test_update_without_suggested_model_field_leaves_it_unchanged(self):
         item = Item.objects.create(
             title='Existing item', description='Some description.',
-            project=self.project, type=self.item_type, suggested_model='opus',
+            project=self.project, type=self.item_type, suggested_model='opus-5',
         )
 
         response = self.client.post(reverse('item-update', args=[item.id]), {
@@ -74,7 +74,7 @@ class ItemSuggestedModelViewTest(TestCase):
 
         self.assertEqual(response.status_code, 200)
         item.refresh_from_db()
-        self.assertEqual(item.suggested_model, 'opus')
+        self.assertEqual(item.suggested_model, 'opus-5')
 
     def test_update_with_explicit_override_changes_it(self):
         item = Item.objects.create(
@@ -84,12 +84,12 @@ class ItemSuggestedModelViewTest(TestCase):
 
         response = self.client.post(reverse('item-update', args=[item.id]), {
             'title': item.title,
-            'suggested_model': 'opus',
+            'suggested_model': 'fable-5',
         })
 
         self.assertEqual(response.status_code, 200)
         item.refresh_from_db()
-        self.assertEqual(item.suggested_model, 'opus')
+        self.assertEqual(item.suggested_model, 'fable-5')
 
     def test_update_with_auto_detect_reclassifies(self):
         item = Item.objects.create(
@@ -105,4 +105,4 @@ class ItemSuggestedModelViewTest(TestCase):
 
         self.assertEqual(response.status_code, 200)
         item.refresh_from_db()
-        self.assertEqual(item.suggested_model, 'opus')
+        self.assertEqual(item.suggested_model, 'opus-4-8')

--- a/core/views.py
+++ b/core/views.py
@@ -4374,12 +4374,12 @@ def _resolve_suggested_model(item, request):
     Resolve Item.suggested_model (#834) from an explicit UI override or
     the hybrid classifier.
 
-    An explicit 'sonnet'/'opus' value in POST['suggested_model'] is a
+    Any valid ClaudeQueueJobModel value in POST['suggested_model'] is a
     manual override and is used as-is. Any other value (missing, or
     empty for "Auto-detect") triggers (re-)classification.
     """
     override = request.POST.get('suggested_model', '').strip()
-    if override in (ClaudeQueueJobModel.SONNET, ClaudeQueueJobModel.OPUS):
+    if override in ClaudeQueueJobModel.values:
         return override
     return ModelClassifierService().classify(item)
 
@@ -4599,6 +4599,7 @@ def item_create(request):
             'default_project': default_project,
             'nodes': nodes,
             'blueprints': blueprints,
+            'suggested_model_choices': ClaudeQueueJobModel.choices,
         }
         return render(request, 'item_form.html', context)
     
@@ -4796,6 +4797,7 @@ def item_edit(request, item_id):
             'releases': releases,
             'parent_items': parent_items,
             'nodes': nodes,
+            'suggested_model_choices': ClaudeQueueJobModel.choices,
         }
         return render(request, 'item_form.html', context)
     

--- a/templates/item_form.html
+++ b/templates/item_form.html
@@ -294,8 +294,9 @@
                     <label for="suggested_model" class="form-label">Suggested Model</label>
                     <select class="form-select" id="suggested_model" name="suggested_model" form="itemForm">
                         <option value="" {% if not item %}selected{% endif %}>Auto-detect</option>
-                        <option value="sonnet" {% if item and item.suggested_model == 'sonnet' %}selected{% endif %}>Sonnet</option>
-                        <option value="opus" {% if item and item.suggested_model == 'opus' %}selected{% endif %}>Opus</option>
+                        {% for value, display in suggested_model_choices %}
+                        <option value="{{ value }}" {% if item and item.suggested_model == value %}selected{% endif %}>{{ display }}</option>
+                        {% endfor %}
                     </select>
                     <small class="form-text text-muted">Used by the Claude queue (#833). A suggestion, not a gate — pick "Auto-detect" to let the classifier decide.</small>
                 </div>


### PR DESCRIPTION
Automated draft PR opened by the Claude queue worker for Agira item #1082.

Model: Opus
Job: #273

---

## Zusammenfassung

Das Feld **Suggested Model** unterscheidet jetzt die Opus-Generationen und kennt Fable 5. Statt eines generischen „Opus" stehen **Sonnet**, **Opus 4.8**, **Opus 5** und **Fable 5** als getrennte Optionen zur Wahl. Der gespeicherte Wert wird beim Job-Start in einen konkreten Modell-Identifier übersetzt und als `--model` an die Claude-Code-Invocation übergeben — bisher reichte der Worker den Wert unübersetzt durch, sodass „Opus" als floating CLI-Alias landete und 4.8 von 5 nicht zu trennen war. Bestehende Items werden per Migration nachvollziehbar auf Opus 4.8 gehoben.

## Änderungen

- `ClaudeQueueJobModel` um `OPUS_4_8` (`opus-4-8`), `OPUS_5` (`opus-5`) und `FABLE_5` (`fable-5`) erweitert; der bisherige Sammelwert `OPUS` (`opus`) entfällt.
- Neues Mapping `CLAUDE_CLI_MODEL_IDS` plus Helper `claude_cli_model_id()` in `core/models.py`: Anzeige-Slug → CLI-Identifier (`claude-opus-4-8`, `claude-opus-5`, `claude-fable-5`); Sonnet bleibt auf dem Alias `sonnet`. Unbekannte oder leere Werte fallen auf Sonnet zurück, statt ungeprüft an die CLI zu gehen.
- `run_claude_worker._build_claude_args()` übersetzt den Job-Wert über diesen Helper, bevor er als `--model` gesetzt wird.
- Migration `0075_split_suggested_model_opus_generations`: neue Choices für `Item.suggested_model` und `ClaudeQueueJob.model` plus Datenmigration `opus` → `opus-4-8`; die Rückrichtung faltet alle Opus/Fable-Werte wieder auf `opus`.
- `ModelClassifierService`: der Auto-Detect-Pfad liefert `AUTO_DETECT_OPUS` (= Opus 4.8); die Antwort des Haiku-Agents wird über eine Alias-Tabelle abgebildet, sein bisheriges `opus` landet unverändert auf demselben Wert.
- `_resolve_suggested_model()` in `core/views.py` prüft gegen `ClaudeQueueJobModel.values` statt gegen ein hartes Sonnet/Opus-Tupel — neue Choices sind damit automatisch als manuelles Override zulässig.
- `templates/item_form.html` rendert die Optionen aus `suggested_model_choices` (wie die Detailansicht bereits) statt aus einer hartkodierten Liste; beide `item_form`-Kontexte in `core/views.py` liefern die Choices.
- Veralteter `TODO(#834)`-Kommentar in `enqueue.py` entfernt — `item.suggested_model` wird dort längst gelesen.
- Tests: neues Modul `test_model_selection.py` (vollständige Slug→CLI-Abdeckung, getrennte Identifier je Opus-Generation, Fallback bei Alt-Slug, `--model`-Argument des Workers inkl. Rückfall auf die Item-Empfehlung); bestehende Suggested-Model- und Inline-Edit-Tests auf die neuen Werte gezogen und um Opus 5, Fable 5 sowie die Ablehnung des Alt-Werts `opus` ergänzt.

## Warum / Entscheidungen

- **Stabile Slugs im Feld, Übersetzung an einer Stelle** — nicht die CLI-Identifier direkt als Choice-Werte speichern, weil ein Identifier-Wechsel (neue Opus-Generation, Umbenennung) sonst jede Zeile in der Datenbank anfassen müsste; die Slugs sind das UI-Vokabular, das Mapping ist die austauschbare Schicht.
- **Opus/Fable auf exakte Modell-IDs gepinnt, Sonnet auf dem Alias** — nicht durchgängig Aliase, weil ein floating `opus` genau die Ununterscheidbarkeit ist, die dieses Item behebt; Sonnet bleibt auf `sonnet`, weil das der bisherige Stand ist und die günstige Vorauswahl bewusst der jeweils aktuellen Sonnet-Version folgen soll.
- **Bestand auf Opus 4.8** — nicht auf Opus 5, weil der bisherige Alias faktisch auf 4.8 auflöste; die Migration bildet also den tatsächlich gelaufenen Stand ab und ändert für Bestands-Items nichts am Verhalten.
- **Liste hart in `TextChoices`** — nicht aus den AI-Providern oder einer Settings-Konfiguration gespeist, weil das Feld `choices` trägt und jede Änderung ohnehin eine Migration erfordert; eine zur Laufzeit variable Liste würde `choices` und DB auseinanderlaufen lassen, ohne den Migrationsaufwand zu sparen. Neue Modelle sind ein Eintrag in der Enum plus einer im Mapping.
- **Auto-Detect bleibt grob (Sonnet vs. Opus 4.8)** — nicht den Klassifikator um eine Wahl zwischen 4.8, 5 und Fable erweitert, weil ihm die Kostenabwägung fehlt, die diese Wahl ausmacht; das Feld ist ausdrücklich Vorschlag und im UI überschreibbar. Das Prompt-Vokabular des Haiku-Agents bleibt dadurch unverändert (kein Cache-Bruch), sein `opus` wird gemappt.
- **Keine Haiku-Klasse aufgenommen** — nicht als weitere Option ergänzt, weil sie im Scope nicht gefordert ist und Haiku hier bereits als interner Klassifikator dient, nicht als ausführendes Modell für Coding-Jobs. Sonnet deckt das günstige Ende ab.
- **Unbekannter Slug fällt auf Sonnet zurück** — nicht durchreichen und nicht hart fehlschlagen: ein Alt- oder Tippfehler-Wert würde die CLI-Invocation sonst zerreißen, und der günstige Default ist bei einem Vorschlagsfeld das harmlosere Ergebnis.

## Test-Hinweise

- `python manage.py test core.services.claude_queue core.test_item_suggested_model core.test_item_field_update` — 68 Tests, grün.
- `python manage.py makemigrations --check --dry-run` meldet keine offenen Modelländerungen.
- Migration wurde vorwärts und rückwärts gegen Bestandsdaten geprüft: ein Item und ein Job mit `opus` landen auf `opus-4-8`, die Rückmigration stellt `opus` wieder her.
- Rendering des Anlage-/Bearbeiten-Formulars geprüft: das Suggested-Model-Feld liefert `Auto-detect`, `Sonnet`, `Opus 4.8`, `Opus 5`, `Fable 5`.
- Manuell nachzuziehen: einen Job mit „Opus 5" bzw. „Fable 5" starten und im Worker-Log verifizieren, dass `--model claude-opus-5` bzw. `--model claude-fable-5` an der CLI ankommt.
- In `core.test_item_detail` schlagen drei Tests fehl (`ItemAutoPopulateTest` × 2, `test_item_edit_view_loads`); diese Fehler bestehen unverändert auch auf dem Basis-Commit und sind nicht Teil dieser Änderung.